### PR TITLE
feat: orderBy in the query builder

### DIFF
--- a/packages/optimistic/package.json
+++ b/packages/optimistic/package.json
@@ -3,7 +3,7 @@
   "description": "Core optimistic updates library",
   "version": "0.0.3",
   "dependencies": {
-    "@electric-sql/d2ts": "^0.1.4",
+    "@electric-sql/d2ts": "^0.1.5",
     "@standard-schema/spec": "^1.0.0",
     "@tanstack/store": "^0.7.0"
   },

--- a/packages/optimistic/src/collection.ts
+++ b/packages/optimistic/src/collection.ts
@@ -263,8 +263,8 @@ export class Collection<T extends object = Record<string, unknown>> {
     this.derivedArray = new Derived({
       fn: ({ currDepVals: [stateMap] }) => {
         const array = Array.from(stateMap.values())
-        if (this.config.sortFn) {
-          array.sort(this.config.sortFn)
+        if (config.sortFn) {
+          array.sort(config.sortFn)
         }
         return array
       },

--- a/packages/optimistic/src/collection.ts
+++ b/packages/optimistic/src/collection.ts
@@ -262,7 +262,11 @@ export class Collection<T extends object = Record<string, unknown>> {
     // Create a derived array from the map to avoid recalculating it
     this.derivedArray = new Derived({
       fn: ({ currDepVals: [stateMap] }) => {
-        return Array.from(stateMap.values())
+        const array = Array.from(stateMap.values())
+        if (this.config.sortFn) {
+          array.sort(this.config.sortFn)
+        }
+        return array
       },
       deps: [this.derivedState],
     })

--- a/packages/optimistic/src/query/compiled-query.ts
+++ b/packages/optimistic/src/query/compiled-query.ts
@@ -29,6 +29,7 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
   constructor(queryBuilder: QueryBuilder<Context<Schema>>) {
     const query = queryBuilder._query
     const collections = query.collections
+    const hasOrderBy = !!query.orderBy
 
     if (!collections) {
       throw new Error(`No collections provided`)
@@ -103,6 +104,13 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
       sync: {
         sync,
       },
+      sortFn: hasOrderBy
+        ? (a, b) => {
+            const aIndex = (a as { _orderByIndex: number })[`_orderByIndex`]
+            const bIndex = (b as { _orderByIndex: number })[`_orderByIndex`]
+            return aIndex - bIndex
+          }
+        : undefined,
     })
   }
 

--- a/packages/optimistic/src/query/order-by.ts
+++ b/packages/optimistic/src/query/order-by.ts
@@ -137,7 +137,7 @@ export function processOrderBy(
     }
     // if a and b are both booleans, compare them
     if (typeof a === `boolean` && typeof b === `boolean`) {
-      return a ? 1 : -1
+      return a === b ? 0 : a ? 1 : -1
     }
     // if a and b are both dates, compare them
     if (a instanceof Date && b instanceof Date) {
@@ -149,11 +149,34 @@ export function processOrderBy(
     }
     // if a and b are both arrays, compare them element by element
     if (Array.isArray(a) && Array.isArray(b)) {
-      for (let i = 0; i < a.length; i++) {
-        const result = comparator(a[i], b[i])
-        if (result !== 0) return result
+      for (let i = 0; i < Math.min(a.length, b.length); i++) {
+        // Get the values from the array
+        const aVal = a[i]
+        const bVal = b[i]
+
+        // Compare the values
+        let result: number
+
+        if (typeof aVal === `boolean` && typeof bVal === `boolean`) {
+          // Special handling for booleans - false comes before true
+          result = aVal === bVal ? 0 : aVal ? 1 : -1
+        } else if (typeof aVal === `number` && typeof bVal === `number`) {
+          // Numeric comparison
+          result = aVal - bVal
+        } else if (typeof aVal === `string` && typeof bVal === `string`) {
+          // String comparison
+          result = aVal.localeCompare(bVal)
+        } else {
+          // Default comparison using the general comparator
+          result = comparator(aVal, bVal)
+        }
+
+        if (result !== 0) {
+          return result
+        }
       }
-      return 0
+      // All elements are equal up to the minimum length
+      return a.length - b.length
     }
     // if a and b are both null/undefined, return 0
     if ((a === null || a === undefined) && (b === null || b === undefined)) {

--- a/packages/optimistic/src/query/query-builder.ts
+++ b/packages/optimistic/src/query/query-builder.ts
@@ -262,6 +262,12 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
       return select
     })
 
+    // Ensure we have an orderByIndex in the select if we have an orderBy
+    // This is required if select is called after orderBy
+    if (this._query.orderBy) {
+      validatedSelects.push({ _orderByIndex: { ORDER_INDEX: `numeric` } })
+    }
+
     const newBuilder = new BaseQueryBuilder<TContext>(
       (this as BaseQueryBuilder<TContext>).query
     )
@@ -704,7 +710,8 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
     // Set the orderBy clause
     newBuilder.query.orderBy = orderBy
 
-    // And the order index to the select
+    // Ensure we have an orderByIndex in the select if we have an orderBy
+    // This is required if select is called before orderBy
     newBuilder.query.select = [
       ...(newBuilder.query.select ?? []),
       { _orderByIndex: { ORDER_INDEX: `numeric` } },

--- a/packages/optimistic/src/query/query-builder.ts
+++ b/packages/optimistic/src/query/query-builder.ts
@@ -704,6 +704,12 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
     // Set the orderBy clause
     newBuilder.query.orderBy = orderBy
 
+    // And the order index to the select
+    newBuilder.query.select = [
+      ...(newBuilder.query.select ?? []),
+      { _orderByIndex: { ORDER_INDEX: `numeric` } },
+    ]
+
     return newBuilder as QueryBuilder<TContext>
   }
 

--- a/packages/optimistic/src/types.ts
+++ b/packages/optimistic/src/types.ts
@@ -118,6 +118,7 @@ export interface CollectionConfig<T extends object = Record<string, unknown>> {
   id: string
   sync: SyncConfig<T>
   schema?: StandardSchema<T>
+  sortFn?: (a: T, b: T) => number
 }
 
 export type ChangesPayload<T extends object = Record<string, unknown>> = Array<

--- a/packages/optimistic/tests/query/query-builder/key-by.test.ts
+++ b/packages/optimistic/tests/query/query-builder/key-by.test.ts
@@ -97,7 +97,13 @@ describe(`QueryBuilder.keyBy`, () => {
     expect(builtQuery.as).toBe(`e`)
     expect(builtQuery.join).toBeDefined()
     expect(builtQuery.where).toBeDefined()
-    expect(builtQuery.select).toHaveLength(3)
+    expect(builtQuery.select).toHaveLength(4)
+    expect(builtQuery.select).toEqual([
+      `@e.id`,
+      `@e.name`,
+      `@d.name`,
+      { _orderByIndex: { ORDER_INDEX: `numeric` } }, // Added by the orderBy method
+    ])
     expect(builtQuery.orderBy).toBe(`@e.salary`)
     expect(builtQuery.limit).toBe(10)
     expect(builtQuery.offset).toBe(5)

--- a/packages/optimistic/tests/query/query-builder/order-by.test.ts
+++ b/packages/optimistic/tests/query/query-builder/order-by.test.ts
@@ -125,7 +125,12 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
       expect(builtQuery.as).toBe(`e`)
       expect(builtQuery.join).toBeDefined()
       expect(builtQuery.where).toBeDefined()
-      expect(builtQuery.select).toHaveLength(3)
+      expect(builtQuery.select).toEqual([
+        `@e.id`,
+        `@e.name`,
+        `@d.name`,
+        { _orderByIndex: { ORDER_INDEX: `numeric` } }, // Added by the orderBy method
+      ])
     })
   })
 })

--- a/packages/optimistic/tests/query/query-collection.test.ts
+++ b/packages/optimistic/tests/query/query-collection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import mitt from "mitt"
 import { Collection } from "../../src/collection.js"
 import { queryBuilder } from "../../src/query/query-builder.js"
@@ -75,23 +75,18 @@ describe(`Query Collections`, () => {
       sync: {
         sync: ({ begin, write, commit }) => {
           // Listen for sync events
-          // @ts-expect-error don't trust Mitt's typing and this works.
-          emitter.on(`sync`, (changes: Array<PendingMutation<Person>>) => {
+          emitter.on(`sync`, (changes) => {
             begin()
-            changes.forEach((change) => {
+            ;(changes as Array<PendingMutation>).forEach((change) => {
               write({
                 key: change.key,
                 type: change.type,
-                value: change.changes,
+                value: change.changes as Person,
               })
             })
             commit()
           })
         },
-      },
-      mutationFn: async ({ transaction }) => {
-        emitter.emit(`sync`, transaction.mutations)
-        return Promise.resolve()
       },
     })
 
@@ -191,26 +186,18 @@ describe(`Query Collections`, () => {
       id: `person-collection-test`,
       sync: {
         sync: ({ begin, write, commit }) => {
-          // @ts-expect-error Mitt typing doesn't match our usage
-          emitter.on(
-            `sync-person`,
-            (changes: Array<PendingMutation<Person>>) => {
-              begin()
-              changes.forEach((change) => {
-                write({
-                  key: change.key,
-                  type: change.type,
-                  value: change.changes,
-                })
+          emitter.on(`sync-person`, (changes) => {
+            begin()
+            ;(changes as Array<PendingMutation>).forEach((change) => {
+              write({
+                key: change.key,
+                type: change.type,
+                value: change.changes as Person,
               })
-              commit()
-            }
-          )
+            })
+            commit()
+          })
         },
-      },
-      mutationFn: async ({ transaction }) => {
-        emitter.emit(`sync-person`, transaction.mutations)
-        return Promise.resolve()
       },
     })
 
@@ -219,23 +206,18 @@ describe(`Query Collections`, () => {
       id: `issue-collection-test`,
       sync: {
         sync: ({ begin, write, commit }) => {
-          // @ts-expect-error Mitt typing doesn't match our usage
-          emitter.on(`sync-issue`, (changes: Array<PendingMutation<Issue>>) => {
+          emitter.on(`sync-issue`, (changes) => {
             begin()
-            changes.forEach((change) => {
+            ;(changes as Array<PendingMutation>).forEach((change) => {
               write({
                 key: change.key,
                 type: change.type,
-                value: change.changes,
+                value: change.changes as Issue,
               })
             })
             commit()
           })
         },
-      },
-      mutationFn: async ({ transaction }) => {
-        emitter.emit(`sync-issue`, transaction.mutations)
-        return Promise.resolve()
       },
     })
 

--- a/packages/react-optimistic/tests/useLiveQuery.test.tsx
+++ b/packages/react-optimistic/tests/useLiveQuery.test.tsx
@@ -81,14 +81,13 @@ describe(`Query Collections`, () => {
       sync: {
         sync: ({ begin, write, commit }) => {
           // Listen for sync events
-          // @ts-expect-error don't trust Mitt's typing and this works.
-          emitter.on(`sync`, (changes: Array<PendingMutation<Person>>) => {
+          emitter.on(`*`, (_, changes) => {
             begin()
-            changes.forEach((change) => {
+            ;(changes as Array<PendingMutation>).forEach((change) => {
               write({
                 key: change.key,
                 type: change.type,
-                value: change.changes,
+                value: change.changes as Person,
               })
             })
             commit()
@@ -116,6 +115,7 @@ describe(`Query Collections`, () => {
           .where(`@age`, `>`, 30)
           .keyBy(`@id`)
           .select(`@id`, `@name`)
+          .orderBy({ "@id": `asc` })
       )
     })
 
@@ -227,22 +227,17 @@ describe(`Query Collections`, () => {
       id: `person-collection-test`,
       sync: {
         sync: ({ begin, write, commit }) => {
-          // @ts-expect-error Mitt typing doesn't match our usage
-          emitter.on(
-            `sync-person`,
-            // @ts-expect-error Mitt typing doesn't match our usage
-            (changes: Array<PendingMutation<Person>>) => {
-              begin()
-              changes.forEach((change) => {
-                write({
-                  key: change.key,
-                  type: change.type,
-                  value: change.changes,
-                })
+          emitter.on(`sync-person`, (changes) => {
+            begin()
+            ;(changes as Array<PendingMutation>).forEach((change) => {
+              write({
+                key: change.key,
+                type: change.type,
+                value: change.changes as Person,
               })
-              commit()
-            }
-          )
+            })
+            commit()
+          })
         },
       },
     })
@@ -252,23 +247,18 @@ describe(`Query Collections`, () => {
       id: `issue-collection-test`,
       sync: {
         sync: ({ begin, write, commit }) => {
-          // @ts-expect-error Mitt typing doesn't match our usage
-          emitter.on(`sync-issue`, (changes: Array<PendingMutation<Issue>>) => {
+          emitter.on(`sync-issue`, (changes) => {
             begin()
-            changes.forEach((change) => {
+            ;(changes as Array<PendingMutation>).forEach((change) => {
               write({
                 key: change.key,
                 type: change.type,
-                value: change.changes,
+                value: change.changes as Issue,
               })
             })
             commit()
           })
         },
-      },
-      mutationFn: async ({ transaction }) => {
-        emitter.emit(`sync-issue`, transaction.mutations)
-        return Promise.resolve()
       },
     })
 
@@ -405,14 +395,13 @@ describe(`Query Collections`, () => {
       sync: {
         sync: ({ begin, write, commit }) => {
           // Listen for sync events
-          // @ts-expect-error don't trust Mitt's typing and this works.
-          emitter.on(`sync`, (changes: Array<PendingMutation<Person>>) => {
+          emitter.on(`sync`, (changes) => {
             begin()
-            changes.forEach((change) => {
+            ;(changes as Array<PendingMutation>).forEach((change) => {
               write({
                 key: change.key,
                 type: change.type,
-                value: change.changes,
+                value: change.changes as Person,
               })
             })
             commit()
@@ -500,14 +489,13 @@ describe(`Query Collections`, () => {
       id: `stop-query-test`,
       sync: {
         sync: ({ begin, write, commit }) => {
-          // @ts-expect-error Mitt typing doesn't match our usage
-          emitter.on(`sync`, (changes: Array<PendingMutation<Person>>) => {
+          emitter.on(`sync`, (changes) => {
             begin()
-            changes.forEach((change) => {
+            ;(changes as Array<PendingMutation>).forEach((change) => {
               write({
                 key: change.key,
                 type: change.type,
-                value: change.changes,
+                value: change.changes as Person,
               })
             })
             commit()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,8 +222,8 @@ importers:
   packages/optimistic:
     dependencies:
       '@electric-sql/d2ts':
-        specifier: ^0.1.4
-        version: 0.1.4(@electric-sql/client@1.0.0)
+        specifier: ^0.1.5
+        version: 0.1.5(@electric-sql/client@1.0.0)
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
@@ -483,8 +483,8 @@ packages:
   '@electric-sql/client@1.0.0':
     resolution: {integrity: sha512-kGiVbBIlMqc/CeJpWZuLjxNkm0836NWxeMtIWH2w5IUK8pUL13hyxg3ZkR7+FlTGhpKuZRiCP5nPOH9D6wbhPw==}
 
-  '@electric-sql/d2ts@0.1.4':
-    resolution: {integrity: sha512-Dv16cDexD1RzrNvIpZPdLF1xVuoe3+j/UjoO84Y3n939UH4sIEF9o8SCVyIo2ngOKMoVXajb2mBI2Ko7Sss8Tw==}
+  '@electric-sql/d2ts@0.1.5':
+    resolution: {integrity: sha512-Rmhlmp5G7P229Ul1LLxmnTgY51DIFEw4YJeouyZ9Dg+4nGbOvNAFx2tnb+ghGH77Cd4oMjxqB+94+YasPdu9nA==}
     peerDependencies:
       '@electric-sql/client': '>=1.0.0-beta.4'
       better-sqlite3: ^11.7.0
@@ -5124,7 +5124,7 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.36.0
 
-  '@electric-sql/d2ts@0.1.4(@electric-sql/client@1.0.0)':
+  '@electric-sql/d2ts@0.1.5(@electric-sql/client@1.0.0)':
     dependencies:
       fractional-indexing: 3.2.0
     optionalDependencies:


### PR DESCRIPTION
the result collections `.toArray` is ordered by the order by, and there is a `_orderByIndex` prop on each result.

This also updates the D2TS dep to a new version that fixes an issue in compaction that was apparent when doing an order by. This may also fix the issue @KyleAMathews saw with joins, as I think that was the same thing happening.
