### PR TITLE
collections: add `QueryCollection.refetch()`.

### DIFF
--- a/.changeset/bumpy-wombats-yell.md
+++ b/.changeset/bumpy-wombats-yell.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db-collections": patch
+---
+
+Provide `queryCollection.refetch()` as an alternative to `queryCollection.invalidate()` that actually waits for thr collection to be updated.

--- a/.changeset/bumpy-wombats-yell.md
+++ b/.changeset/bumpy-wombats-yell.md
@@ -2,4 +2,7 @@
 "@tanstack/db-collections": patch
 ---
 
-Provide `queryCollection.refetch()` as an alternative to `queryCollection.invalidate()` that actually waits for thr collection to be updated.
+Replace `queryCollection.invalidate()` with `queryCollection.refetch()`.
+
+This means that we actually wait for the collection to be updated before
+discarding local optimistic state.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const AddTodo = () => {
       const { collection, modified: newTodo } = transaction.mutations[0]!
 
       await api.todos.create(newTodo)
-      await collection.invalidate()
+      await collection.refetch()
     },
   })
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -560,7 +560,7 @@ const Todos = () => {
   })
 
   // Here we define another mutator with its own specific mutationFn.
-  // This knows the api call to make and the collection to invalidate.
+  // This knows the api call to make and the collection to refetch.
   const addList = useOptimisticMutation({
     mutationFn: async ({ transaction }) => {
       const { changes: newList } = transaction.mutations[0]!

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,7 +102,7 @@ Rather than mutating the collection data directly, the collection internally tre
 
 In addition, the local mutations are passed to the async `mutationFn` that's passed in when creating the mutator. This mutationFn is responsible for handling the writes, usually by sending them to a server or a database. TanStack DB waits for the function to resolve before then removing the optimistic state that was applied when the local writes was made.
 
-For example, in the following code, the mutationFn first sends the write to the server using `await api.todos.update(updatedTodo)` and then calls `await collection.invalidate()` to trigger a re-fetch of the collection contents using TanStack Query. When this second await resolves, the collection is up-to-date with the latest changes and the optimistic state is safely discarded.
+For example, in the following code, the mutationFn first sends the write to the server using `await api.todos.update(updatedTodo)` and then calls `await collection.refetch()` to trigger a re-fetch of the collection contents using TanStack Query. When this second await resolves, the collection is up-to-date with the latest changes and the optimistic state is safely discarded.
 
 ```ts
 const updateTodo = useOptimisticMutation({
@@ -110,7 +110,7 @@ const updateTodo = useOptimisticMutation({
     const { collection, modified: updatedTodo } = transaction.mutations[0]!
 
     await api.todos.update(updatedTodo)
-    await collection.invalidate()
+    await collection.refetch()
   },
 })
 ```
@@ -362,7 +362,7 @@ const mutationFn: MutationFn = async ({ transaction }) => {
   // Wait for the transaction to be synced back from the server
   // before discarding the optimistic state.
   const collection: Collection = transaction.mutations[0]!.collection
-  await collection.invalidate()
+  await collection.refetch()
 }
 ```
 
@@ -555,7 +555,7 @@ const Todos = () => {
       // This blocks until the collection is up-to-date.
       // The local app avoids flickering and always converges
       // on the server state as the source of truth.
-      await todoCollection.invalidate()
+      await todoCollection.refetch()
     },
   })
 
@@ -566,7 +566,7 @@ const Todos = () => {
       const { changes: newList } = transaction.mutations[0]!
 
       await api.todoLists.create(newList)
-      await todoListCollection.invalidate()
+      await todoListCollection.refetch()
     },
   })
 

--- a/examples/react/todo/src/App.tsx
+++ b/examples/react/todo/src/App.tsx
@@ -237,7 +237,7 @@ async function collectionSync(
   txid: number
 ) {
   if (type === CollectionType.Query) {
-    await (mutation.collection as QueryCollection<UpdateTodo>).invalidate()
+    await (mutation.collection as QueryCollection<UpdateTodo>).refetch()
   } else {
     await (mutation.collection as ElectricCollection<UpdateTodo>).awaitTxId(
       txid

--- a/packages/db-collections/src/query.ts
+++ b/packages/db-collections/src/query.ts
@@ -233,6 +233,26 @@ export class QueryCollection<
       throw error
     }
   }
+
+  public async refetch(): Promise<void> {
+    console.log(
+      `[QueryCollection] refetch() called for ${String(this.queryConfig.queryKey)}`
+    )
+    try {
+      await this.queryClient.refetchQueries({
+        queryKey: this.queryConfig.queryKey,
+      })
+      console.log(
+        `[QueryCollection] Refetch successful for ${String(this.queryConfig.queryKey)}.`
+      )
+    } catch (error) {
+      console.error(
+        `[QueryCollection] Error during refetch for ${String(this.queryConfig.queryKey)}:`,
+        error
+      )
+      throw error
+    }
+  }
 }
 
 export function createQueryCollection<

--- a/packages/db-collections/src/query.ts
+++ b/packages/db-collections/src/query.ts
@@ -214,26 +214,6 @@ export class QueryCollection<
     this.queryClient = queryClient
   }
 
-  public async invalidate(): Promise<void> {
-    console.log(
-      `[QueryCollection] invalidate() called for ${String(this.queryConfig.queryKey)}`
-    )
-    try {
-      await this.queryClient.invalidateQueries({
-        queryKey: this.queryConfig.queryKey,
-      })
-      console.log(
-        `[QueryCollection] Invalidation successful for ${String(this.queryConfig.queryKey)}.`
-      )
-    } catch (error) {
-      console.error(
-        `[QueryCollection] Error during invalidate for ${String(this.queryConfig.queryKey)}:`,
-        error
-      )
-      throw error
-    }
-  }
-
   public async refetch(): Promise<void> {
     console.log(
       `[QueryCollection] refetch() called for ${String(this.queryConfig.queryKey)}`

--- a/packages/db-collections/tests/query.test.ts
+++ b/packages/db-collections/tests/query.test.ts
@@ -128,18 +128,15 @@ describe(`QueryCollection`, () => {
       // Item 2 removed
     ]
 
-    // Invalidate the query to trigger a refetch in the background.
-    await collection.invalidate()
+    // Refetch the query.
+    await collection.refetch()
 
-    // Wait for the refetch and collection update
-    await vi.waitFor(() => {
-      expect(queryFn).toHaveBeenCalledTimes(2)
-      // Check for update, addition, and removal
-      expect(collection.state.size).toBe(2)
-      expect(collection.state.has(`1`)).toBe(true)
-      expect(collection.state.has(`3`)).toBe(true)
-      expect(collection.state.has(`2`)).toBe(false)
-    })
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    // Check for update, addition, and removal
+    expect(collection.state.size).toBe(2)
+    expect(collection.state.has(`1`)).toBe(true)
+    expect(collection.state.has(`3`)).toBe(true)
+    expect(collection.state.has(`2`)).toBe(false)
 
     // Verify the final state more thoroughly
     expect(collection.state.get(`1`)).toEqual(updatedItem)
@@ -153,7 +150,7 @@ describe(`QueryCollection`, () => {
     // Refetch the query to trigger a refetch.
     await collection.refetch()
 
-    // No need to `vi.waitFor` this time.
+    // Verify expected.
     expect(queryFn).toHaveBeenCalledTimes(3)
     expect(collection.state.size).toBe(3)
     expect(collection.state.get(`4`)).toEqual(item4)
@@ -191,14 +188,12 @@ describe(`QueryCollection`, () => {
       expect(collection.state.get(`1`)).toEqual(initialItem)
     })
 
-    // Trigger an error by invalidating
-    await collection.invalidate()
+    // Trigger an error by refetching
+    await collection.refetch()
 
     // Wait for the error to be logged
-    await vi.waitFor(() => {
-      expect(queryFn).toHaveBeenCalledTimes(2)
-      expect(consoleErrorSpy).toHaveBeenCalled()
-    })
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    expect(consoleErrorSpy).toHaveBeenCalled()
 
     // Verify the error was logged correctly
     const errorCallArgs = consoleErrorSpy.mock.calls.find((call) =>
@@ -291,18 +286,15 @@ describe(`QueryCollection`, () => {
     consoleSpy.mockClear()
 
     // Trigger first refetch - should not cause an update due to shallow equality
-    await collection.invalidate()
+    await collection.refetch()
 
-    // Wait for the refetch to complete
-    await vi.waitFor(() => {
-      expect(queryFn).toHaveBeenCalledTimes(2)
-      // Verify invalidation was logged
-      expect(
-        consoleSpy.mock.calls.some((call) =>
-          call[0].includes(`Invalidation successful for ${String(queryKey)}`)
-        )
-      ).toBe(true)
-    })
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    // Verify refetch was logged
+    expect(
+      consoleSpy.mock.calls.some((call) =>
+        call[0].includes(`Refetch successful for ${String(queryKey)}`)
+      )
+    ).toBe(true)
 
     // Since the data is identical (though a different object reference),
     // the state object reference should remain the same due to shallow equality
@@ -311,18 +303,15 @@ describe(`QueryCollection`, () => {
     consoleSpy.mockClear()
 
     // Trigger second refetch - should cause an update due to actual data change
-    await collection.invalidate()
+    await collection.refetch()
 
-    // Wait for the refetch to complete
-    await vi.waitFor(() => {
-      expect(queryFn).toHaveBeenCalledTimes(3)
-      // Verify invalidation was logged
-      expect(
-        consoleSpy.mock.calls.some((call) =>
-          call[0].includes(`Invalidation successful for ${String(queryKey)}`)
-        )
-      ).toBe(true)
-    })
+    expect(queryFn).toHaveBeenCalledTimes(3)
+    // Verify refetch was logged
+    expect(
+      consoleSpy.mock.calls.some((call) =>
+        call[0].includes(`Refetch successful for ${String(queryKey)}`)
+      )
+    ).toBe(true)
 
     // Now the state should be updated with the new value
     const updatedItem = collection.state.get(`1`)
@@ -384,13 +373,10 @@ describe(`QueryCollection`, () => {
     queryFn.mockResolvedValueOnce(updatedItems)
 
     // Trigger a refetch
-    await collection.invalidate()
+    await collection.refetch()
 
-    // Wait for the refetch to complete
-    await vi.waitFor(() => {
-      expect(queryFn).toHaveBeenCalledTimes(2)
-      expect(collection.state.size).toBe(updatedItems.length)
-    })
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    expect(collection.state.size).toBe(updatedItems.length)
 
     // Verify getId was called at least once for each item
     // It may be called multiple times per item during the diffing process

--- a/packages/db-collections/tests/query.test.ts
+++ b/packages/db-collections/tests/query.test.ts
@@ -128,7 +128,7 @@ describe(`QueryCollection`, () => {
       // Item 2 removed
     ]
 
-    // Invalidate the query to trigger a refetch
+    // Invalidate the query to trigger a refetch in the background.
     await collection.invalidate()
 
     // Wait for the refetch and collection update
@@ -145,6 +145,18 @@ describe(`QueryCollection`, () => {
     expect(collection.state.get(`1`)).toEqual(updatedItem)
     expect(collection.state.get(`3`)).toEqual(newItem)
     expect(collection.state.get(`2`)).toBeUndefined()
+
+    // Now update the data again.
+    const item4 = { id: `4`, name: `Item 4` }
+    currentItems = [...currentItems, item4]
+
+    // Refetch the query to trigger a refetch.
+    await collection.refetch()
+
+    // No need to `vi.waitFor` this time.
+    expect(queryFn).toHaveBeenCalledTimes(3)
+    expect(collection.state.size).toBe(3)
+    expect(collection.state.get(`4`)).toEqual(item4)
   })
 
   it(`should handle query errors gracefully`, async () => {


### PR DESCRIPTION
This adds a new `refetch()` method as an alternative to `invalidate()` and updates the docs and examples to use it.