### PR TITLE
fix(db): correctly filter optimistic ops by collection

### DIFF
--- a/.changeset/smooth-hairs-look.md
+++ b/.changeset/smooth-hairs-look.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fix a bug where optimistic operations could be applied to the wrong collection

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -202,7 +202,6 @@ export class Collection<T extends object = Record<string, unknown>> {
             return transaction.mutations
               .filter((mutation) => mutation.collection === this)
               .map((mutation) => {
-                console.log(`HERE1`)
                 const message: OptimisticChangeMessage<T> = {
                   type: mutation.type,
                   key: mutation.key,

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -199,21 +199,27 @@ export class Collection<T extends object = Record<string, unknown>> {
             const isActive = ![`completed`, `failed`].includes(
               transaction.state
             )
-            return transaction.mutations.map((mutation) => {
-              const message: OptimisticChangeMessage<T> = {
-                type: mutation.type,
-                key: mutation.key,
-                value: mutation.modified as T,
-                isActive,
-              }
-              if (
-                mutation.metadata !== undefined &&
-                mutation.metadata !== null
-              ) {
-                message.metadata = mutation.metadata as Record<string, unknown>
-              }
-              return message
-            })
+            return transaction.mutations
+              .filter((mutation) => mutation.collection === this)
+              .map((mutation) => {
+                console.log(`HERE1`)
+                const message: OptimisticChangeMessage<T> = {
+                  type: mutation.type,
+                  key: mutation.key,
+                  value: mutation.modified as T,
+                  isActive,
+                }
+                if (
+                  mutation.metadata !== undefined &&
+                  mutation.metadata !== null
+                ) {
+                  message.metadata = mutation.metadata as Record<
+                    string,
+                    unknown
+                  >
+                }
+                return message
+              })
           })
           .flat()
 


### PR DESCRIPTION
if you mutated two collections in a single transaction, the optimistic state would bleed into the other collections.