### PR TITLE
Add initial Data preparing for SSR support

### DIFF
--- a/packages/db-collections/src/index.ts
+++ b/packages/db-collections/src/index.ts
@@ -2,6 +2,7 @@ export {
   ElectricCollection,
   createElectricCollection,
   type ElectricCollectionConfig,
+  type ElectricInitialData,
 } from "./electric"
 export {
   QueryCollection,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -118,6 +118,11 @@ export interface CollectionConfig<T extends object = Record<string, unknown>> {
   id: string
   sync: SyncConfig<T>
   schema?: StandardSchema<T>
+  /**
+   * Initial data for server-side rendering
+   * Allows hydration from server-loaded data
+   */
+  initialData?: Array<T>
 }
 
 export type ChangesPayload<T extends object = Record<string, unknown>> = Array<


### PR DESCRIPTION
Hey guys I had a stab at implementing initial data as a first step for SSR support. I can do hydration provider etc similar to tanstack query in a separate pull request.