### PR TITLE
chore: update d2ts version

### DIFF
--- a/.changeset/small-bushes-hide.md
+++ b/.changeset/small-bushes-hide.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+update d2ts to to latest version that improves hashing performance

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "description": "A reactive client store for building super fast apps on sync",
   "version": "0.0.4",
   "dependencies": {
-    "@electric-sql/d2ts": "^0.1.5",
+    "@electric-sql/d2ts": "^0.1.6",
     "@standard-schema/spec": "^1.0.0",
     "@tanstack/store": "^0.7.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
   packages/db:
     dependencies:
       '@electric-sql/d2ts':
-        specifier: ^0.1.5
-        version: 0.1.5(@electric-sql/client@1.0.0)
+        specifier: ^0.1.6
+        version: 0.1.6(@electric-sql/client@1.0.0)
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
@@ -511,8 +511,8 @@ packages:
   '@electric-sql/client@1.0.0':
     resolution: {integrity: sha512-kGiVbBIlMqc/CeJpWZuLjxNkm0836NWxeMtIWH2w5IUK8pUL13hyxg3ZkR7+FlTGhpKuZRiCP5nPOH9D6wbhPw==}
 
-  '@electric-sql/d2ts@0.1.5':
-    resolution: {integrity: sha512-Rmhlmp5G7P229Ul1LLxmnTgY51DIFEw4YJeouyZ9Dg+4nGbOvNAFx2tnb+ghGH77Cd4oMjxqB+94+YasPdu9nA==}
+  '@electric-sql/d2ts@0.1.6':
+    resolution: {integrity: sha512-N2smnYMHGYplWx7WQkWoMYLHSQeGCJp990lYYgLVDBJ8hfBOC4KYYhj5L9FoWd8pH9y4OLnWehhzBtn58mflJg==}
     peerDependencies:
       '@electric-sql/client': '>=1.0.0-beta.4'
       better-sqlite3: ^11.7.0
@@ -1724,6 +1724,9 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/murmurhash-js@1.0.6':
+    resolution: {integrity: sha512-P2RRwRpevEKO0FrK5xNjxBywg0Br24tEv8K2+iWg56PtcCUNGAkaaOWKBQiUpofA8H/gmgdHXrcvSgp2uXCVAQ==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -3603,6 +3606,9 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -5210,9 +5216,11 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.36.0
 
-  '@electric-sql/d2ts@0.1.5(@electric-sql/client@1.0.0)':
+  '@electric-sql/d2ts@0.1.6(@electric-sql/client@1.0.0)':
     dependencies:
+      '@types/murmurhash-js': 1.0.6
       fractional-indexing: 3.2.0
+      murmurhash-js: 1.0.0
     optionalDependencies:
       '@electric-sql/client': 1.0.0
 
@@ -6201,6 +6209,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/mime@1.3.5': {}
+
+  '@types/murmurhash-js@1.0.6': {}
 
   '@types/node@12.20.55': {}
 
@@ -8306,6 +8316,8 @@ snapshots:
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
+
+  murmurhash-js@1.0.0: {}
 
   mz@2.7.0:
     dependencies:


### PR DESCRIPTION
this version includes changes that improve hashing performance: https://github.com/electric-sql/d2ts/pull/53