### PR TITLE
fix: comparator calls toString on undefined values in order-by

### DIFF
--- a/packages/db/src/query/order-by.ts
+++ b/packages/db/src/query/order-by.ts
@@ -179,8 +179,8 @@ export function processOrderBy(
       // All elements are equal up to the minimum length
       return a.length - b.length
     }
-    // if a and b are both null/undefined, return 0
-    if (a == null && b == null) {
+    // if a or b are null/undefined, return 0
+    if (a == null || b == null) {
       return 0
     }
     // Fallback to string comparison for all other cases


### PR DESCRIPTION
When testing for [#112](https://github.com/TanStack/db/issues/112) locally, I noticed that when adding items in the todo example, you get `Cannot call toString on undefined.` during mutation. I believe this is just caused by the last bit of logic in the comparator function in `order-by`.