### PR TITLE
feat: select callback

### DIFF
--- a/.changeset/full-steaks-wait.md
+++ b/.changeset/full-steaks-wait.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+the live query select clause can now be a callback function that receives each row as a context object returning a new object with the selected fields. This also allows the for the callback to make more expressive changes to the returned data.

--- a/packages/db/src/query/query-builder.ts
+++ b/packages/db/src/query/query-builder.ts
@@ -198,8 +198,9 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
   /**
    * Specify what columns to select.
    * Overwrites any previous select clause.
+   * Also supports callback functions that receive the row context and return selected data.
    *
-   * @param selects The columns to select
+   * @param selects The columns to select (can include callbacks)
    * @returns A new QueryBuilder with the select clause set
    */
   select<TSelects extends Array<Select<TContext>>>(

--- a/packages/db/src/query/schema.ts
+++ b/packages/db/src/query/schema.ts
@@ -191,6 +191,11 @@ export type Select<TContext extends Context = Context> =
         | AggregateFunctionCall<TContext>
     }
   | WildcardReferenceString<TContext>
+  | SelectCallback<TContext>
+
+export type SelectCallback<TContext extends Context = Context> = (
+  context: TContext extends { schema: infer S } ? S : any
+) => any
 
 export type As<TContext extends Context = Context> = string
 

--- a/packages/db/tests/query/query-builder/select.test.ts
+++ b/packages/db/tests/query/query-builder/select.test.ts
@@ -39,8 +39,8 @@ describe(`QueryBuilder.select`, () => {
 
     const builtQuery = query._query
     expect(builtQuery.select).toHaveLength(2)
-    expect(builtQuery.select[0]).toBe(`@id`)
-    expect(builtQuery.select[1]).toHaveProperty(`employee_name`, `@name`)
+    expect(builtQuery.select![0]).toBe(`@id`)
+    expect(builtQuery.select![1]).toHaveProperty(`employee_name`, `@name`)
   })
 
   it(`handles function calls`, () => {
@@ -52,7 +52,7 @@ describe(`QueryBuilder.select`, () => {
 
     const builtQuery = query._query
     expect(builtQuery.select).toHaveLength(2)
-    expect(builtQuery.select[1]).toHaveProperty(`upper_name`)
+    expect(builtQuery.select![1]).toHaveProperty(`upper_name`)
   })
 
   it(`overrides previous select calls`, () => {
@@ -84,5 +84,60 @@ describe(`QueryBuilder.select`, () => {
     // that the query is constructed correctly, which implies the types work
     const builtQuery = query._query
     expect(builtQuery.select).toEqual([`@id`, `@name`])
+  })
+
+  it(`supports callback functions`, () => {
+    const callback = ({ employees }: any) => ({
+      fullInfo: `${employees.name} (ID: ${employees.id})`,
+      salaryLevel: employees.salary > 50000 ? `high` : `low`,
+    })
+
+    const query = queryBuilder<TestSchema>().from(`employees`).select(callback)
+
+    const builtQuery = query._query
+    expect(builtQuery.select).toHaveLength(1)
+    expect(builtQuery.select).toBeDefined()
+    expect(typeof builtQuery.select![0]).toBe(`function`)
+    expect(builtQuery.select![0]).toBe(callback)
+  })
+
+  it(`combines callback with traditional selects`, () => {
+    const callback = ({ employees }: any) => ({
+      computed: employees.salary * 1.1,
+    })
+
+    const query = queryBuilder<TestSchema>()
+      .from(`employees`)
+      .select(`@id`, `@name`, callback, { department_name: `@employees.name` })
+
+    const builtQuery = query._query
+    expect(builtQuery.select).toHaveLength(4)
+    expect(builtQuery.select).toBeDefined()
+    expect(builtQuery.select![0]).toBe(`@id`)
+    expect(builtQuery.select![1]).toBe(`@name`)
+    expect(typeof builtQuery.select![2]).toBe(`function`)
+    expect(builtQuery.select![3]).toHaveProperty(`department_name`)
+  })
+
+  it(`supports multiple callback functions`, () => {
+    const callback1 = ({ employees }: any) => ({
+      displayName: employees.name.toUpperCase(),
+    })
+    const callback2 = ({ employees }: any) => ({
+      isActive: employees.active,
+      experience: new Date().getFullYear() - 2020,
+    })
+
+    const query = queryBuilder<TestSchema>()
+      .from(`employees`)
+      .select(callback1, callback2)
+
+    const builtQuery = query._query
+    expect(builtQuery.select).toHaveLength(2)
+    expect(builtQuery.select).toBeDefined()
+    expect(typeof builtQuery.select![0]).toBe(`function`)
+    expect(typeof builtQuery.select![1]).toBe(`function`)
+    expect(builtQuery.select![0]).toBe(callback1)
+    expect(builtQuery.select![1]).toBe(callback2)
   })
 })


### PR DESCRIPTION
this add the option for select to take a callback function for generating the final row objects. It reseves an object as the context of the row, namespaced with each input collection - essentially what a multiple input (i.e. query with joins) query would return.

```ts
useLiveQuery((query) =>
  query
      .from({ collection })
      .select(({ collection }) => ({
        displayName: `${collection.name} (Age: ${collection.age})`,
        status: collection.isActive ? `Active` : `Inactive`,
        ageGroup:
          collection.age < 30
            ? `Young`
            : collection.age < 40
              ? `Middle`
              : `Senior`,
        emailDomain: collection.email.split(`@`)[1],
      })
)
```

Internally it is also possible to provide both the original references and new callbacks - we should leverage this undocumented until we have a new syntax replacing the original:

https://github.com/TanStack/db/blob/06c224cc0654d4c07d674d543d4278a228061ece/packages/db/tests/query/query-builder/select.test.ts#L104-L112