### PR TITLE
WIP reactor collection

### DIFF
--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -165,7 +165,7 @@ export class Transaction {
     const hasCalled = new Set()
     for (const mutation of this.mutations) {
       if (!hasCalled.has(mutation.collection.id)) {
-        mutation.collection.transactions.setState((state) => state)
+        mutation.collection.onTransactionStateChange()
         mutation.collection.commitPendingTransactions()
         hasCalled.add(mutation.collection.id)
       }

--- a/packages/db/tests/collection-subscribe-changes.test.ts
+++ b/packages/db/tests/collection-subscribe-changes.test.ts
@@ -532,6 +532,7 @@ describe(`Collection.subscribeChanges`, () => {
     )
 
     // Verify only the 3 new items were emitted, not the existing ones
+    console.log(JSON.stringify(callback.mock.calls, null, 2))
     expect(callback).toHaveBeenCalledTimes(1)
     const batchChanges = callback.mock.calls[0]![0] as ChangesPayload<{
       value: string

--- a/packages/db/tests/collection-subscribe-changes.test.ts
+++ b/packages/db/tests/collection-subscribe-changes.test.ts
@@ -207,7 +207,11 @@ describe(`Collection.subscribeChanges`, () => {
       },
     })
 
-    const mutationFn = async ({ transaction }) => {
+    const mutationFn = async ({
+      transaction,
+    }: {
+      transaction: Transaction
+    }) => {
       emitter.emit(`sync`, transaction.mutations)
       return Promise.resolve()
     }
@@ -220,12 +224,7 @@ describe(`Collection.subscribeChanges`, () => {
 
     // Perform optimistic insert
     const tx = createTransaction({ mutationFn })
-    tx.mutate(() =>
-      collection.insert(
-        { id: 1, value: `optimistic value` },
-        { key: `optimisticItem` }
-      )
-    )
+    tx.mutate(() => collection.insert({ id: 1, value: `optimistic value` }))
 
     // Verify that insert was emitted immediately (optimistically)
     expect(callback).toHaveBeenCalledTimes(1)
@@ -287,7 +286,7 @@ describe(`Collection.subscribeChanges`, () => {
 
     // Perform optimistic delete
     const deleteTx = createTransaction({ mutationFn })
-    deleteTx.mutate(() => collection.delete(item.id))
+    deleteTx.mutate(() => collection.delete(String(item.id)))
 
     // Verify that delete was emitted
     expect(callback).toHaveBeenCalledTimes(1)
@@ -338,7 +337,11 @@ describe(`Collection.subscribeChanges`, () => {
       },
     })
 
-    const mutationFn = async ({ transaction }) => {
+    const mutationFn = async ({
+      transaction,
+    }: {
+      transaction: Transaction
+    }) => {
       emitter.emit(`sync`, transaction.mutations)
       return Promise.resolve()
     }
@@ -503,7 +506,11 @@ describe(`Collection.subscribeChanges`, () => {
         },
       },
     })
-    const mutationFn = async ({ transaction }) => {
+    const mutationFn = async ({
+      transaction,
+    }: {
+      transaction: Transaction
+    }) => {
       emitter.emit(`sync`, transaction.mutations)
       return Promise.resolve()
     }
@@ -532,7 +539,6 @@ describe(`Collection.subscribeChanges`, () => {
     )
 
     // Verify only the 3 new items were emitted, not the existing ones
-    console.log(JSON.stringify(callback.mock.calls, null, 2))
     expect(callback).toHaveBeenCalledTimes(1)
     const batchChanges = callback.mock.calls[0]![0] as ChangesPayload<{
       value: string

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -3,11 +3,7 @@ import mitt from "mitt"
 import { z } from "zod"
 import { Collection, SchemaValidationError } from "../src/collection"
 import { createTransaction } from "../src/transactions"
-import type {
-  ChangeMessage,
-  MutationFn,
-  PendingMutation,
-} from "../src/types"
+import type { ChangeMessage, MutationFn, PendingMutation } from "../src/types"
 
 describe(`Collection`, () => {
   it(`should throw if there's no sync config`, () => {
@@ -217,7 +213,10 @@ describe(`Collection`, () => {
     // Check the optimistic operation is there
     const insertKey = `KEY::${collection.id}/1`
     expect(collection.derivedUpserts.has(insertKey)).toBe(true)
-    expect(collection.derivedUpserts.get(insertKey)).toEqual({ id: 1, value: `bar` })
+    expect(collection.derivedUpserts.get(insertKey)).toEqual({
+      id: 1,
+      value: `bar`,
+    })
 
     // Check persist data (moved outside the persist callback)
     // @ts-expect-error possibly undefined is ok in test
@@ -263,10 +262,12 @@ describe(`Collection`, () => {
     // Test insert with provided key
     const tx2 = createTransaction({ mutationFn })
     tx2.mutate(() => collection.insert({ id: 2, value: `baz` }))
-    expect(collection.state.get(collection.generateObjectKey(2, null))).toEqual({
-      id: 2,
-      value: `baz`,
-    })
+    expect(collection.state.get(collection.generateObjectKey(2, null))).toEqual(
+      {
+        id: 2,
+        value: `baz`,
+      }
+    )
     await tx2.isPersisted.promise
 
     // Test bulk insert
@@ -484,7 +485,10 @@ describe(`Collection`, () => {
     // Check the optimistic operation is there
     const insertKey = `KEY::${collection.id}/1`
     expect(collection.derivedUpserts.has(insertKey)).toBe(true)
-    expect(collection.derivedUpserts.get(insertKey)).toEqual({ id: 1, value: `bar` })
+    expect(collection.derivedUpserts.get(insertKey)).toEqual({
+      id: 1,
+      value: `bar`,
+    })
 
     await tx1.isPersisted.promise
 


### PR DESCRIPTION
This is a **WIP** significant refactor of the `Collection` replacing the Store based derived state with a more fine grade system that will be faster and more efficient.

Rather than computing a full "derived state" on each change, we only compute a derived upserts and deletes, along with emitting insert/update/delete messages on each change. This should result in much less object churn and far less GC.

The `Collection` is now also more `Map` like with many similar methods `keys`, `values`, `entries`, `get(key)` and `has(key)`.

You can subscribe to either changes to the whole collection, or to a single key - perfect for fine grade reactivity.

Queries still "sync" into a collection as their materialised state.

Finally, as there is only loose coupling between the live query system and collections, the latter can be used without a live query if wanted.

Still to do:

- [ ] React hook
- [ ] Vue hook

There is also a note in the code somewhere about changes to the query system for ordered collection, these should have an ordered set of keys so that all the generators (`keys`, `values`, `entries`) fall out of the `keys` generator.

*why not use a D2 pipeline to implement this?** because I think this will be more efficient (far less state is needed if we hand roll it), and keep the two loosely coupled.

More to do...