### PR TITLE
Add onInsert/onUpdate/onDelete handlers to collections

### DIFF
--- a/.changeset/light-hands-love.md
+++ b/.changeset/light-hands-love.md
@@ -1,0 +1,26 @@
+---
+"@tanstack/db-collections": patch
+"@tanstack/db-example-react-todo": patch
+"@tanstack/db": patch
+---
+
+This change introduces a more streamlined and intuitive API for handling mutations by allowing `onInsert`, `onUpdate`, and `onDelete` handlers to be defined directly on the collection configuration.
+
+When `collection.insert()`, `.update()`, or `.delete()` are called outside of an explicit transaction (i.e., not within `useOptimisticMutation`), the library now automatically creates a single-operation transaction and invokes the corresponding handler to persist the change.
+
+Key changes:
+
+- **`@tanstack/db`**: The `Collection` class now supports `onInsert`, `onUpdate`, and `onDelete` in its configuration. Direct calls to mutation methods will throw an error if the corresponding handler is not defined.
+- **`@tanstack/db-collections`**:
+  - `queryCollectionOptions` now accepts the new handlers and will automatically `refetch` the collection's query after a handler successfully completes. This behavior can be disabled if the handler returns `{ refetch: false }`.
+  - `electricCollectionOptions` also accepts the new handlers. These handlers are now required to return an object with a transaction ID (`{ txid: string }`). The collection then automatically waits for this `txid` to be synced back before resolving the mutation, ensuring consistency.
+- **Breaking Change**: Calling `collection.insert()`, `.update()`, or `.delete()` without being inside a `useOptimisticMutation` callback and without a corresponding persistence handler (`onInsert`, etc.) configured on the collection will now throw an error.
+
+This new pattern simplifies the most common use cases, making the code more declarative. The `useOptimisticMutation` hook remains available for more complex scenarios, such as transactions involving multiple mutations across different collections.
+
+---
+
+The documentation and the React Todo example application have been significantly refactored to adopt the new direct persistence handler pattern as the primary way to perform mutations.
+
+- The `README.md` and `docs/overview.md` files have been updated to de-emphasize `useOptimisticMutation` for simple writes. They now showcase the much simpler API of calling `collection.insert()` directly and defining persistence logic in the collection's configuration.
+- The React Todo example (`examples/react/todo/src/App.tsx`) has been completely overhauled. All instances of `useOptimisticMutation` have been removed and replaced with the new `onInsert`, `onUpdate`, and `onDelete` handlers, resulting in cleaner and more concise code.

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,19 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .DS_Store
+
+# Added by Task Master AI
+dev-debug.log
+# Environment variables
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+# OS specific
+# Task files
+tasks.json
+tasks/ 

--- a/README.md
+++ b/README.md
@@ -72,31 +72,29 @@ const Todos = () => {
 }
 ```
 
-Apply transactional writes with local optimistic state:
+Apply mutations with local optimistic state:
 
 ```tsx
-import { useOptimisticMutation } from "@tanstack/react-db"
+// Define collection with persistence handlers
+const todoCollection = createCollection({
+  id: "todos",
+  // ... other config
+  onInsert: async ({ transaction }) => {
+    const modified = transaction.mutations[0].modified
+    await api.todos.create(modified)
+  },
+})
 
+// Then use collection operators in your components
 const AddTodo = () => {
-  const addTodo = useOptimisticMutation({
-    mutationFn: async ({ transaction }) => {
-      const { collection, modified: newTodo } = transaction.mutations[0]!
-
-      await api.todos.create(newTodo)
-      await collection.refetch()
-    },
-  })
-
   return (
     <Button
       onClick={() =>
-        addTodo.mutate(() =>
-          todoCollection.insert({
-            id: uuid(),
-            text: "🔥 Make app faster",
-            completed: false,
-          })
-        )
+        todoCollection.insert({
+          id: uuid(),
+          text: "🔥 Make app faster",
+          completed: false,
+        })
       }
     />
   )

--- a/examples/react/todo/src/App.tsx
+++ b/examples/react/todo/src/App.tsx
@@ -134,7 +134,7 @@ const createTodoCollection = (type: CollectionType) => {
   } else {
     let newCollection: Collection
     if (type === CollectionType.Electric) {
-      newCollection = createCollection(
+      newCollection = createCollection<UpdateTodo>(
         electricCollectionOptions({
           id: `todos`,
           shapeOptions: {
@@ -176,7 +176,7 @@ const createTodoCollection = (type: CollectionType) => {
 
             return { txid: String(txids[0]) }
           },
-        }).collectionOptions
+        }).options
       )
     } else {
       // Query collection using our API helper
@@ -228,7 +228,7 @@ const createTodoCollection = (type: CollectionType) => {
 
             return { txid: String(txids[0]) }
           },
-        }).collectionOptions
+        }).options
       )
     }
     collectionsCache.set(`todo`, newCollection)
@@ -279,7 +279,7 @@ const createConfigCollection = (type: CollectionType) => {
 
             return { txid: String(txids[0]) }
           },
-        }).collectionOptions
+        }).options
       )
     } else {
       // Query collection using our API helper
@@ -323,7 +323,7 @@ const createConfigCollection = (type: CollectionType) => {
 
             return { txid: String(txids[0]) }
           },
-        }).collectionOptions
+        }).options
       )
     }
     collectionsCache.set(`config`, newCollection)

--- a/examples/react/todo/src/App.tsx
+++ b/examples/react/todo/src/App.tsx
@@ -152,6 +152,7 @@ const createTodoCollection = (type: CollectionType) => {
           onInsert: async ({ transaction }) => {
             const modified = transaction.mutations[0].modified
             const response = await api.todos.create(modified)
+
             return { txid: String(response.txid) }
           },
           onUpdate: async ({ transaction }) => {
@@ -159,22 +160,24 @@ const createTodoCollection = (type: CollectionType) => {
               transaction.mutations.map(async (mutation) => {
                 const { original, changes } = mutation
                 const response = await api.todos.update(original.id, changes)
+
                 return { txid: String(response.txid) }
               })
             )
 
-            return { txid: String(txids[0]) }
+            return { txid: String(txids[0].txid) }
           },
           onDelete: async ({ transaction }) => {
             const txids = await Promise.all(
               transaction.mutations.map(async (mutation) => {
-                const { original, changes } = mutation
+                const { original } = mutation
                 const response = await api.todos.delete(original.id)
+
                 return { txid: String(response.txid) }
               })
             )
 
-            return { txid: String(txids[0]) }
+            return { txid: String(txids[0].txid) }
           },
         }).options
       )
@@ -203,30 +206,23 @@ const createTodoCollection = (type: CollectionType) => {
           queryClient,
           onInsert: async ({ transaction }) => {
             const modified = transaction.mutations[0].modified
-            const response = await api.todos.create(modified)
-            return { txid: String(response.txid) }
+            return await api.todos.create(modified)
           },
           onUpdate: async ({ transaction }) => {
-            const txids = await Promise.all(
+            return await Promise.all(
               transaction.mutations.map(async (mutation) => {
                 const { original, changes } = mutation
-                const response = await api.todos.update(original.id, changes)
-                return { txid: String(response.txid) }
+                return await api.todos.update(original.id, changes)
               })
             )
-
-            return { txid: txids[0] }
           },
           onDelete: async ({ transaction }) => {
-            const txids = await Promise.all(
+            return await Promise.all(
               transaction.mutations.map(async (mutation) => {
-                const { original, changes } = mutation
+                const { original } = mutation
                 const response = await api.todos.delete(original.id)
-                return { txid: String(response.txid) }
               })
             )
-
-            return { txid: String(txids[0]) }
           },
         }).options
       )

--- a/examples/react/todo/src/App.tsx
+++ b/examples/react/todo/src/App.tsx
@@ -7,7 +7,7 @@ import {
 // import { DevTools } from "./DevTools"
 import { QueryClient } from "@tanstack/query-core"
 import { updateConfigSchema, updateTodoSchema } from "./db/validation"
-import type { Collection, PendingMutation } from "@tanstack/react-db"
+import type { Collection } from "@tanstack/react-db"
 import type { UpdateConfig, UpdateTodo } from "./db/validation"
 import type { FormEvent } from "react"
 
@@ -127,7 +127,6 @@ const queryClient = new QueryClient()
 
 // Cache for collections and their utility functions
 const collectionsCache = new Map()
-const utilityFunctionsCache = new Map()
 // Function to create the appropriate todo collection based on type
 const createTodoCollection = (type: CollectionType) => {
   if (collectionsCache.has(`todo`)) {
@@ -151,7 +150,7 @@ const createTodoCollection = (type: CollectionType) => {
           getId: (item) => item.id,
           schema: updateTodoSchema,
           onInsert: async ({ transaction }) => {
-            const modified = transaction.mutations[0]!.modified
+            const modified = transaction.mutations[0].modified
             const response = await api.todos.create(modified)
             return { txid: String(response.txid) }
           },
@@ -203,7 +202,7 @@ const createTodoCollection = (type: CollectionType) => {
           schema: updateTodoSchema,
           queryClient,
           onInsert: async ({ transaction }) => {
-            const modified = transaction.mutations[0]!.modified
+            const modified = transaction.mutations[0].modified
             const response = await api.todos.create(modified)
             return { txid: String(response.txid) }
           },
@@ -262,7 +261,7 @@ const createConfigCollection = (type: CollectionType) => {
           getId: (item: UpdateConfig) => item.id,
           schema: updateConfigSchema,
           onInsert: async ({ transaction }) => {
-            const modified = transaction.mutations[0]!.modified
+            const modified = transaction.mutations[0].modified
             const response = await api.config.create(modified)
             return { txid: String(response.txid) }
           },
@@ -306,7 +305,7 @@ const createConfigCollection = (type: CollectionType) => {
           schema: updateConfigSchema,
           queryClient,
           onInsert: async ({ transaction }) => {
-            const modified = transaction.mutations[0]!.modified
+            const modified = transaction.mutations[0].modified
             const response = await api.config.create(modified)
             return { txid: String(response.txid) }
           },

--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -4,7 +4,11 @@ import {
   isControlMessage,
 } from "@electric-sql/client"
 import { Store } from "@tanstack/store"
-import type { CollectionConfig, SyncConfig } from "@tanstack/db"
+import type {
+  CollectionConfig,
+  MutationFnParams,
+  SyncConfig,
+} from "@tanstack/db"
 import type {
   ControlMessage,
   Message,
@@ -28,6 +32,30 @@ export interface ElectricCollectionConfig<T extends Row<unknown>> {
   schema?: CollectionConfig<T>[`schema`]
   getId: CollectionConfig<T>[`getId`]
   sync?: CollectionConfig<T>[`sync`]
+
+  /**
+   * Optional asynchronous handler function called before an insert operation
+   * Must return an object containing a txid string
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to an object with txid
+   */
+  onInsert?: (params: MutationFnParams) => Promise<{ txid: string } | undefined>
+
+  /**
+   * Optional asynchronous handler function called before an update operation
+   * Must return an object containing a txid string
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to an object with txid
+   */
+  onUpdate?: (params: MutationFnParams) => Promise<{ txid: string } | undefined>
+
+  /**
+   * Optional asynchronous handler function called before a delete operation
+   * Must return an object containing a txid string
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to an object with txid
+   */
+  onDelete?: (params: MutationFnParams) => Promise<{ txid: string } | undefined>
 }
 
 function isUpToDateMessage<T extends Row<unknown> = Row>(
@@ -57,20 +85,20 @@ export function electricCollectionOptions<T extends Row<unknown>>(
   config: ElectricCollectionConfig<T>
 ): {
   collectionOptions: CollectionConfig<T>
-  awaitTxId: (txId: number, timeout?: number) => Promise<boolean>
+  awaitTxId: (txId: string, timeout?: number) => Promise<boolean>
 } {
-  const seenTxids = new Store<Set<number>>(new Set([Math.random()]))
+  const seenTxids = new Store<Set<string>>(new Set([`${Math.random()}`]))
   const sync = createElectricSync<T>(config.shapeOptions, {
     seenTxids,
   })
 
   /**
    * Wait for a specific transaction ID to be synced
-   * @param txId The transaction ID to wait for
+   * @param txId The transaction ID to wait for as a string
    * @param timeout Optional timeout in milliseconds (defaults to 30000ms)
    * @returns Promise that resolves when the txId is synced
    */
-  const awaitTxId = async (txId: number, timeout = 30000): Promise<boolean> => {
+  const awaitTxId = async (txId: string, timeout = 30000): Promise<boolean> => {
     const hasTxid = seenTxids.state.has(txId)
     if (hasTxid) return true
 
@@ -90,13 +118,65 @@ export function electricCollectionOptions<T extends Row<unknown>>(
     })
   }
 
+  // Create wrapper handlers for direct persistence operations that handle txid awaiting
+  const wrappedOnInsert = config.onInsert
+    ? async (params: MutationFnParams) => {
+        const handlerResult = (await config.onInsert!(params)) ?? {}
+        const txid = (handlerResult as { txid?: string }).txid
+
+        if (!txid) {
+          throw new Error(
+            `Electric collection onInsert handler must return a txid`
+          )
+        }
+
+        await awaitTxId(txid)
+        return handlerResult
+      }
+    : undefined
+
+  const wrappedOnUpdate = config.onUpdate
+    ? async (params: MutationFnParams) => {
+        const handlerResult = await config.onUpdate!(params)
+        const txid = (handlerResult as { txid?: string }).txid
+
+        if (!txid) {
+          throw new Error(
+            `Electric collection onUpdate handler must return a txid`
+          )
+        }
+
+        await awaitTxId(txid)
+        return handlerResult
+      }
+    : undefined
+
+  const wrappedOnDelete = config.onDelete
+    ? async (params: MutationFnParams) => {
+        const handlerResult = await config.onDelete!(params)
+        const txid = (handlerResult as { txid?: string }).txid
+
+        if (!txid) {
+          throw new Error(
+            `Electric collection onDelete handler must return a txid`
+          )
+        }
+
+        await awaitTxId(txid)
+        return handlerResult
+      }
+    : undefined
+
   // Extract standard Collection config properties
-  const { shapeOptions, ...restConfig } = config
+  const { shapeOptions, onInsert, onUpdate, onDelete, ...restConfig } = config
 
   return {
     collectionOptions: {
       ...restConfig,
       sync,
+      onInsert: wrappedOnInsert,
+      onUpdate: wrappedOnUpdate,
+      onDelete: wrappedOnDelete,
     },
     awaitTxId,
   }
@@ -108,7 +188,7 @@ export function electricCollectionOptions<T extends Row<unknown>>(
 function createElectricSync<T extends Row<unknown>>(
   shapeOptions: ShapeStreamOptions,
   options: {
-    seenTxids: Store<Set<number>>
+    seenTxids: Store<Set<string>>
   }
 ): SyncConfig<T> {
   const { seenTxids } = options
@@ -136,7 +216,7 @@ function createElectricSync<T extends Row<unknown>>(
       const { begin, write, commit } = params
       const stream = new ShapeStream(shapeOptions)
       let transactionStarted = false
-      let newTxids = new Set<number>()
+      let newTxids = new Set<string>()
 
       stream.subscribe((messages: Array<Message<Row>>) => {
         let hasUpToDate = false
@@ -144,7 +224,7 @@ function createElectricSync<T extends Row<unknown>>(
         for (const message of messages) {
           // Check for txids in the message and add them to our store
           if (hasTxids(message) && message.headers.txids) {
-            message.headers.txids.forEach((txid) => newTxids.add(txid))
+            message.headers.txids.forEach((txid) => newTxids.add(String(txid)))
           }
 
           // Check if the message contains schema information
@@ -183,7 +263,7 @@ function createElectricSync<T extends Row<unknown>>(
           commit()
           seenTxids.setState((currentTxids) => {
             const clonedSeen = new Set(currentTxids)
-            newTxids.forEach((txid) => clonedSeen.add(txid))
+            newTxids.forEach((txid) => clonedSeen.add(String(txid)))
 
             newTxids = new Set()
             return clonedSeen

--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -84,7 +84,7 @@ function hasTxids<T extends Row<unknown> = Row>(
 export function electricCollectionOptions<T extends Row<unknown>>(
   config: ElectricCollectionConfig<T>
 ): {
-  collectionOptions: CollectionConfig<T>
+  options: CollectionConfig<T>
   awaitTxId: (txId: string, timeout?: number) => Promise<boolean>
 } {
   const seenTxids = new Store<Set<string>>(new Set([`${Math.random()}`]))
@@ -171,7 +171,7 @@ export function electricCollectionOptions<T extends Row<unknown>>(
   const { shapeOptions, onInsert, onUpdate, onDelete, ...restConfig } = config
 
   return {
-    collectionOptions: {
+    options: {
       ...restConfig,
       sync,
       onInsert: wrappedOnInsert,

--- a/packages/db-collections/src/query.ts
+++ b/packages/db-collections/src/query.ts
@@ -5,7 +5,11 @@ import type {
   QueryKey,
   QueryObserverOptions,
 } from "@tanstack/query-core"
-import type { CollectionConfig, SyncConfig } from "@tanstack/db"
+import type {
+  CollectionConfig,
+  MutationFnParams,
+  SyncConfig,
+} from "@tanstack/db"
 
 export interface QueryCollectionConfig<
   TItem extends object,
@@ -52,6 +56,28 @@ export interface QueryCollectionConfig<
   getId: CollectionConfig<TItem>[`getId`]
   schema?: CollectionConfig<TItem>[`schema`]
   sync?: CollectionConfig<TItem>[`sync`]
+
+  // Direct persistence handlers
+  /**
+   * Optional asynchronous handler function called before an insert operation
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to void or { refetch?: boolean } to control refetching
+   */
+  onInsert?: CollectionConfig<TItem>[`onInsert`]
+
+  /**
+   * Optional asynchronous handler function called before an update operation
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to void or { refetch?: boolean } to control refetching
+   */
+  onUpdate?: CollectionConfig<TItem>[`onUpdate`]
+
+  /**
+   * Optional asynchronous handler function called before a delete operation
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to void or { refetch?: boolean } to control refetching
+   */
+  onDelete?: CollectionConfig<TItem>[`onDelete`]
 }
 
 /**
@@ -80,6 +106,9 @@ export function queryCollectionOptions<
     retryDelay,
     staleTime,
     getId,
+    onInsert,
+    onUpdate,
+    onDelete,
     ...baseCollectionConfig
   } = config
 
@@ -243,11 +272,57 @@ export function queryCollectionOptions<
     }
   }
 
+  // Create wrapper handlers for direct persistence operations that handle refetching
+  const wrappedOnInsert = onInsert
+    ? async (params: MutationFnParams) => {
+        const handlerResult = (await onInsert(params)) ?? {}
+        const shouldRefetch =
+          (handlerResult as { refetch?: boolean }).refetch !== false
+
+        if (shouldRefetch) {
+          await refetch()
+        }
+
+        return handlerResult
+      }
+    : undefined
+
+  const wrappedOnUpdate = onUpdate
+    ? async (params: MutationFnParams) => {
+        const handlerResult = (await onUpdate(params)) ?? {}
+        const shouldRefetch =
+          (handlerResult as { refetch?: boolean }).refetch !== false
+
+        if (shouldRefetch) {
+          await refetch()
+        }
+
+        return handlerResult
+      }
+    : undefined
+
+  const wrappedOnDelete = onDelete
+    ? async (params: MutationFnParams) => {
+        const handlerResult = (await onDelete(params)) ?? {}
+        const shouldRefetch =
+          (handlerResult as { refetch?: boolean }).refetch !== false
+
+        if (shouldRefetch) {
+          await refetch()
+        }
+
+        return handlerResult
+      }
+    : undefined
+
   return {
     collectionOptions: {
       ...baseCollectionConfig,
       getId,
       sync: { sync: internalSync },
+      onInsert: wrappedOnInsert,
+      onUpdate: wrappedOnUpdate,
+      onDelete: wrappedOnDelete,
     },
     refetch,
   }

--- a/packages/db-collections/src/query.ts
+++ b/packages/db-collections/src/query.ts
@@ -93,7 +93,7 @@ export function queryCollectionOptions<
 >(
   config: QueryCollectionConfig<TItem, TError, TQueryKey>
 ): {
-  collectionOptions: CollectionConfig<TItem>
+  options: CollectionConfig<TItem>
   refetch: () => Promise<void>
 } {
   const {
@@ -316,7 +316,7 @@ export function queryCollectionOptions<
     : undefined
 
   return {
-    collectionOptions: {
+    options: {
       ...baseCollectionConfig,
       getId,
       sync: { sync: internalSync },

--- a/packages/db-collections/tests/electric.test.ts
+++ b/packages/db-collections/tests/electric.test.ts
@@ -48,9 +48,8 @@ describe(`Electric Integration`, () => {
       getId: (item: Row) => item.id,
     }
 
-    const { collectionOptions, awaitTxId: txIdFn } =
-      electricCollectionOptions(config)
-    collection = new Collection(collectionOptions)
+    const { options, awaitTxId: txIdFn } = electricCollectionOptions(config)
+    collection = new Collection(options)
     awaitTxId = txIdFn
   })
 
@@ -403,12 +402,12 @@ describe(`Electric Integration`, () => {
         onDelete,
       }
 
-      const { collectionOptions } = electricCollectionOptions(config)
+      const { options } = electricCollectionOptions(config)
 
       // Verify that the handlers were passed to the collection options
-      expect(collectionOptions.onInsert).toBeDefined()
-      expect(collectionOptions.onUpdate).toBeDefined()
-      expect(collectionOptions.onDelete).toBeDefined()
+      expect(options.onInsert).toBeDefined()
+      expect(options.onUpdate).toBeDefined()
+      expect(options.onDelete).toBeDefined()
     })
 
     it(`should throw an error if handler doesn't return a txid`, async () => {
@@ -431,10 +430,10 @@ describe(`Electric Integration`, () => {
         onInsert,
       }
 
-      const { collectionOptions } = electricCollectionOptions(config)
+      const { options } = electricCollectionOptions(config)
 
       // Call the wrapped handler and expect it to throw
-      await expect(collectionOptions.onInsert!(mockParams)).rejects.toThrow(
+      await expect(options.onInsert!(mockParams)).rejects.toThrow(
         `Electric collection onInsert handler must return a txid`
       )
     })
@@ -515,8 +514,8 @@ describe(`Electric Integration`, () => {
         onInsert,
       }
 
-      const { collectionOptions } = electricCollectionOptions(config)
-      const testCollection = new Collection(collectionOptions)
+      const { options } = electricCollectionOptions(config)
+      const testCollection = new Collection(options)
 
       // Insert data using the transaction
       const tx = testCollection.insert({

--- a/packages/db-collections/tests/electric.test.ts
+++ b/packages/db-collections/tests/electric.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { Collection, createTransaction } from "@tanstack/db"
 import { electricCollectionOptions } from "../src/electric"
-import type { PendingMutation, Transaction } from "@tanstack/db"
+import type {
+  MutationFnParams,
+  PendingMutation,
+  Transaction,
+} from "@tanstack/db"
 import type { Message, Row } from "@electric-sql/client"
 
 // Mock the ShapeStream module
@@ -20,7 +24,7 @@ vi.mock(`@electric-sql/client`, async () => {
 
 describe(`Electric Integration`, () => {
   let collection: Collection<Row>
-  let awaitTxId: (txId: number, timeout?: number) => Promise<boolean>
+  let awaitTxId: (txId: string, timeout?: number) => Promise<boolean>
   let subscriber: (messages: Array<Message<Row>>) => void
 
   beforeEach(() => {
@@ -189,7 +193,7 @@ describe(`Electric Integration`, () => {
   // Tests for txid tracking functionality
   describe(`txid tracking`, () => {
     it(`should track txids from incoming messages`, async () => {
-      const testTxid = 123
+      const testTxid = `123`
 
       // Send a message with a txid
       subscriber([
@@ -210,9 +214,9 @@ describe(`Electric Integration`, () => {
       await expect(awaitTxId(testTxid)).resolves.toBe(true)
     })
 
-    it(`should handle multiple txids in a single message`, async () => {
-      const txid1 = 1
-      const txid2 = 2
+    it(`should track multiple txids`, async () => {
+      const txid1 = `100`
+      const txid2 = `200`
 
       // Send a message with multiple txids
       subscriber([
@@ -236,7 +240,7 @@ describe(`Electric Integration`, () => {
 
     it(`should reject with timeout when waiting for unknown txid`, async () => {
       // Set a short timeout for the test
-      const unknownTxid = 0
+      const unknownTxid = `0`
       const shortTimeout = 100
 
       // Attempt to await a txid that hasn't been seen with a short timeout
@@ -249,7 +253,7 @@ describe(`Electric Integration`, () => {
     })
 
     it(`should resolve when a txid arrives after awaitTxId is called`, async () => {
-      const laterTxid = 1000
+      const laterTxid = `1000`
 
       // Start waiting for a txid that hasn't arrived yet
       const promise = awaitTxId(laterTxid, 1000)
@@ -286,10 +290,10 @@ describe(`Electric Integration`, () => {
     it(`should simulate the complete flow`, async () => {
       // Create a fake backend store to simulate server-side storage
       const fakeBackend = {
-        data: new Map<string, { txid: number; value: unknown }>(),
+        data: new Map<string, { txid: string; value: unknown }>(),
         // Simulates persisting data to a backend and returning a txid
-        persist: (mutations: Array<PendingMutation>): Promise<number> => {
-          const txid = Date.now()
+        persist: (mutations: Array<PendingMutation>): Promise<string> => {
+          const txid = String(Date.now())
 
           // Store the changes with the txid
           mutations.forEach((mutation) => {
@@ -302,7 +306,7 @@ describe(`Electric Integration`, () => {
           return Promise.resolve(txid)
         },
         // Simulates the server sending sync messages with txids
-        simulateSyncMessage: (txid: number) => {
+        simulateSyncMessage: (txid: string) => {
           // Create messages for each item in the store that has this txid
           const messages: Array<Message<Row>> = []
 
@@ -374,6 +378,175 @@ describe(`Electric Integration`, () => {
       // This is just verifying our test setup worked correctly
       expect(fakeBackend.data.has(`KEY::${collection.id}/1`)).toBe(true)
       expect(collection.state.has(`KEY::${collection.id}/1`)).toBe(true)
+    })
+  })
+
+  // Tests for direct persistence handlers
+  describe(`Direct persistence handlers`, () => {
+    it(`should pass through direct persistence handlers to collection options`, () => {
+      // Create mock handlers
+      const onInsert = vi.fn().mockResolvedValue({ txid: `123` })
+      const onUpdate = vi.fn().mockResolvedValue({ txid: `456` })
+      const onDelete = vi.fn().mockResolvedValue({ txid: `789` })
+
+      const config = {
+        id: `test-handlers`,
+        shapeOptions: {
+          url: `http://test-url`,
+          params: {
+            table: `test_table`,
+          },
+        },
+        getId: (item: Row) => item.id,
+        onInsert,
+        onUpdate,
+        onDelete,
+      }
+
+      const { collectionOptions } = electricCollectionOptions(config)
+
+      // Verify that the handlers were passed to the collection options
+      expect(collectionOptions.onInsert).toBeDefined()
+      expect(collectionOptions.onUpdate).toBeDefined()
+      expect(collectionOptions.onDelete).toBeDefined()
+    })
+
+    it(`should throw an error if handler doesn't return a txid`, async () => {
+      // Create a mock transaction for testing
+      const mockTransaction = { id: `test-transaction` } as Transaction
+      const mockParams: MutationFnParams = { transaction: mockTransaction }
+
+      // Create a handler that doesn't return a txid
+      const onInsert = vi.fn().mockResolvedValue({})
+
+      const config = {
+        id: `test-handlers`,
+        shapeOptions: {
+          url: `http://test-url`,
+          params: {
+            table: `test_table`,
+          },
+        },
+        getId: (item: Row) => item.id,
+        onInsert,
+      }
+
+      const { collectionOptions } = electricCollectionOptions(config)
+
+      // Call the wrapped handler and expect it to throw
+      await expect(collectionOptions.onInsert!(mockParams)).rejects.toThrow(
+        `Electric collection onInsert handler must return a txid`
+      )
+    })
+
+    // We no longer need to test for invalid txid format since we're using strings directly
+
+    it(`should simulate complete flow with direct persistence handlers`, async () => {
+      // Create a fake backend store to simulate server-side storage
+      const fakeBackend = {
+        data: new Map<string, { txid: string; value: unknown }>(),
+        // Simulates persisting data to a backend and returning a txid
+        persist: (mutations: Array<PendingMutation>): Promise<string> => {
+          const txid = String(Date.now())
+
+          // Store the changes with the txid
+          mutations.forEach((mutation) => {
+            const key = mutation.key
+            fakeBackend.data.set(key, { txid, value: mutation.changes })
+          })
+
+          return Promise.resolve(txid)
+        },
+        // Simulates the server sending sync messages with txids
+        simulateSyncMessage: (txid: string) => {
+          // Create messages for each item in the store that has this txid
+          const messages: Array<Message<Row>> = []
+
+          fakeBackend.data.forEach((value, key) => {
+            if (value.txid === txid) {
+              messages.push({
+                key,
+                value: value.value as Row,
+                headers: {
+                  operation: `insert`,
+                  txids: [Number(txid)], // Convert to number as the API expects numbers but our code converts to strings
+                },
+              })
+            }
+          })
+
+          // Add up-to-date message
+          messages.push({
+            headers: { control: `up-to-date` },
+          })
+
+          // Send the messages to the subscriber
+          subscriber(messages)
+        },
+      }
+
+      // Create a mutation function for the transaction
+      const mutationFn = vi.fn(async (params: MutationFnParams) => {
+        const txid = await fakeBackend.persist(params.transaction.mutations)
+
+        // Simulate server sending sync message after a delay
+        setTimeout(() => {
+          fakeBackend.simulateSyncMessage(txid)
+        }, 50)
+
+        return txid
+      })
+
+      // Create direct persistence handler that returns the txid
+      const onInsert = vi.fn(async (params: MutationFnParams) => {
+        return { txid: await mutationFn(params) }
+      })
+
+      // Create a test collection with our direct persistence handler
+      const config = {
+        id: `test-direct-persistence`,
+        shapeOptions: {
+          url: `http://test-url`,
+          params: {
+            table: `test_table`,
+          },
+        },
+        getId: (item: Row) => item.id,
+        onInsert,
+      }
+
+      const { collectionOptions } = electricCollectionOptions(config)
+      const testCollection = new Collection(collectionOptions)
+
+      // Insert data using the transaction
+      const tx = testCollection.insert({
+        id: 1,
+        name: `Direct Persistence User`,
+      })
+
+      // If awaitTxId wasn't called automatically, this wouldn't be true.
+      expect(testCollection.syncedData.state.size).toEqual(0)
+      expect(
+        testCollection.optimisticOperations.state.filter((o) => o.isActive)
+          .length
+      ).toEqual(1)
+
+      // Verify that our onInsert handler was called
+      expect(onInsert).toHaveBeenCalled()
+
+      await tx.isPersisted.promise
+
+      // Verify that the data was added to the collection via the sync process
+      expect(testCollection.state.has(`KEY::${testCollection.id}/1`)).toBe(true)
+      expect(testCollection.state.get(`KEY::${testCollection.id}/1`)).toEqual({
+        id: 1,
+        name: `Direct Persistence User`,
+      })
+      expect(testCollection.syncedData.state.size).toEqual(1)
+      expect(
+        testCollection.optimisticOperations.state.filter((o) => o.isActive)
+          .length
+      ).toEqual(0)
     })
   })
 })

--- a/packages/db-collections/tests/query.test.ts
+++ b/packages/db-collections/tests/query.test.ts
@@ -54,8 +54,8 @@ describe(`QueryCollection`, () => {
       getId,
     }
 
-    const { collectionOptions } = queryCollectionOptions(config)
-    const collection = new Collection(collectionOptions)
+    const { options } = queryCollectionOptions(config)
+    const collection = new Collection(options)
 
     // Wait for the query to complete and collection to update
     await vi.waitFor(
@@ -114,8 +114,8 @@ describe(`QueryCollection`, () => {
       getId,
     }
 
-    const { collectionOptions, refetch } = queryCollectionOptions(config)
-    const collection = new Collection(collectionOptions)
+    const { options, refetch } = queryCollectionOptions(config)
+    const collection = new Collection(options)
 
     // Wait for initial data to load
     await vi.waitFor(() => {
@@ -187,7 +187,7 @@ describe(`QueryCollection`, () => {
       .mockResolvedValueOnce([initialItem])
       .mockRejectedValueOnce(testError)
 
-    const { collectionOptions, refetch } = queryCollectionOptions({
+    const { options, refetch } = queryCollectionOptions({
       id: `test`,
       queryClient,
       queryKey,
@@ -195,7 +195,7 @@ describe(`QueryCollection`, () => {
       getId,
       retry: 0, // Disable retries for this test case
     })
-    const collection = new Collection(collectionOptions)
+    const collection = new Collection(options)
 
     // Wait for initial data to load
     await vi.waitFor(() => {
@@ -237,14 +237,14 @@ describe(`QueryCollection`, () => {
     // Mock queryFn to return invalid data (not an array of objects)
     const queryFn = vi.fn().mockResolvedValue(`not an array` as any)
 
-    const { collectionOptions } = queryCollectionOptions({
+    const { options } = queryCollectionOptions({
       id: `test`,
       queryClient,
       queryKey,
       queryFn,
       getId,
     })
-    const collection = new Collection(collectionOptions)
+    const collection = new Collection(options)
 
     // Wait for the query to execute
     await vi.waitFor(() => {
@@ -285,14 +285,14 @@ describe(`QueryCollection`, () => {
     // Spy on console.log to detect when commits happen
     const consoleSpy = vi.spyOn(console, `log`)
 
-    const { collectionOptions, refetch } = queryCollectionOptions({
+    const { options, refetch } = queryCollectionOptions({
       id: `test`,
       queryClient,
       queryKey,
       queryFn,
       getId,
     })
-    const collection = new Collection(collectionOptions)
+    const collection = new Collection(options)
 
     // Wait for initial data to load
     await vi.waitFor(() => {
@@ -367,14 +367,14 @@ describe(`QueryCollection`, () => {
     // Create a spy for the getId function
     const getIdSpy = vi.fn((item: any) => item.customId)
 
-    const { collectionOptions, refetch } = queryCollectionOptions({
+    const { options, refetch } = queryCollectionOptions({
       id: `test`,
       queryClient,
       queryKey,
       queryFn,
       getId: getIdSpy,
     })
-    const collection = new Collection(collectionOptions)
+    const collection = new Collection(options)
 
     // Wait for initial data to load
     await vi.waitFor(() => {
@@ -456,12 +456,12 @@ describe(`QueryCollection`, () => {
         onDelete,
       }
 
-      const { collectionOptions } = queryCollectionOptions(config)
+      const { options } = queryCollectionOptions(config)
 
       // Verify that the handlers were passed to the collection options
-      expect(collectionOptions.onInsert).toBeDefined()
-      expect(collectionOptions.onUpdate).toBeDefined()
-      expect(collectionOptions.onDelete).toBeDefined()
+      expect(options.onInsert).toBeDefined()
+      expect(options.onUpdate).toBeDefined()
+      expect(options.onDelete).toBeDefined()
     })
 
     it(`should wrap handlers and call the original handler`, async () => {
@@ -489,12 +489,12 @@ describe(`QueryCollection`, () => {
         onDelete,
       }
 
-      const { collectionOptions } = queryCollectionOptions(config)
+      const { options } = queryCollectionOptions(config)
 
       // Call the wrapped handlers
-      await collectionOptions.onInsert!(mockParams)
-      await collectionOptions.onUpdate!(mockParams)
-      await collectionOptions.onDelete!(mockParams)
+      await options.onInsert!(mockParams)
+      await options.onUpdate!(mockParams)
+      await options.onDelete!(mockParams)
 
       // Verify the original handlers were called
       expect(onInsert).toHaveBeenCalledWith(mockParams)
@@ -537,8 +537,7 @@ describe(`QueryCollection`, () => {
       vi.spyOn(queryClient, `refetchQueries`).mockImplementation(refetchSpy)
 
       // Test case 1: Default behavior (undefined return) should trigger refetch
-      const { collectionOptions: optionsDefault } =
-        queryCollectionOptions(configDefault)
+      const { options: optionsDefault } = queryCollectionOptions(configDefault)
       await optionsDefault.onInsert!(mockParams)
 
       // Verify handler was called and refetch was triggered
@@ -549,8 +548,7 @@ describe(`QueryCollection`, () => {
       refetchSpy.mockClear()
 
       // Test case 2: Explicit { refetch: false } should not trigger refetch
-      const { collectionOptions: optionsFalse } =
-        queryCollectionOptions(configFalse)
+      const { options: optionsFalse } = queryCollectionOptions(configFalse)
       await optionsFalse.onInsert!(mockParams)
 
       // Verify handler was called but refetch was NOT triggered

--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -4,6 +4,7 @@ import type {
   PendingMutation,
   TransactionConfig,
   TransactionState,
+  TransactionWithMutations,
 } from "./types"
 
 function generateUUID() {
@@ -181,11 +182,17 @@ export class Transaction {
 
     if (this.mutations.length === 0) {
       this.setState(`completed`)
+
+      return this
     }
 
     // Run mutationFn
     try {
-      await this.mutationFn({ transaction: this })
+      // At this point we know there's at least one mutation
+      // Use type assertion to tell TypeScript about this guarantee
+      const transactionWithMutations =
+        this as unknown as TransactionWithMutations
+      await this.mutationFn({ transaction: transactionWithMutations })
 
       this.setState(`completed`)
       this.touchCollection()

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -27,7 +27,19 @@ export interface PendingMutation<T extends object = Record<string, unknown>> {
  * Configuration options for creating a new transaction
  */
 export type MutationFnParams = {
-  transaction: Transaction
+  transaction: Transaction & {
+    mutations: [PendingMutation<any>, ...Array<PendingMutation<any>>] // Ensure at least one mutation
+  }
+}
+
+/**
+ * Utility type for a Transaction with at least one mutation
+ * This is used internally by the Transaction.commit method
+ */
+export type TransactionWithMutations<
+  T extends object = Record<string, unknown>,
+> = Transaction & {
+  mutations: [PendingMutation<T>, ...Array<PendingMutation<T>>]
 }
 
 export type MutationFn = (params: MutationFnParams) => Promise<any>

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -27,10 +27,10 @@ export interface PendingMutation<T extends object = Record<string, unknown>> {
  * Configuration options for creating a new transaction
  */
 export type MutationFnParams = {
-  transaction: Transaction & {
-    mutations: [PendingMutation<any>, ...Array<PendingMutation<any>>] // Ensure at least one mutation
-  }
+  transaction: Transaction
 }
+
+export type MutationFn = (params: MutationFnParams) => Promise<any>
 
 /**
  * Utility type for a Transaction with at least one mutation
@@ -41,8 +41,6 @@ export type TransactionWithMutations<
 > = Transaction & {
   mutations: [PendingMutation<T>, ...Array<PendingMutation<T>>]
 }
-
-export type MutationFn = (params: MutationFnParams) => Promise<any>
 
 export interface TransactionConfig {
   /** Unique identifier for the transaction */

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -130,6 +130,24 @@ export interface CollectionConfig<T extends object = Record<string, unknown>> {
    * getId: (item) => item.uuid
    */
   getId: (item: T) => any
+  /**
+   * Optional asynchronous handler function called before an insert operation
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to any value
+   */
+  onInsert?: MutationFn
+  /**
+   * Optional asynchronous handler function called before an update operation
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to any value
+   */
+  onUpdate?: MutationFn
+  /**
+   * Optional asynchronous handler function called before a delete operation
+   * @param params Object containing transaction and mutation information
+   * @returns Promise resolving to any value
+   */
+  onDelete?: MutationFn
 }
 
 export type ChangesPayload<T extends object = Record<string, unknown>> = Array<

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -635,7 +635,7 @@ describe(`Collection`, () => {
     expect(typeof collection.config.onDelete).toBe(`function`)
   })
 
-  it.only(`should execute operations outside of explicit transactions using handlers`, async () => {
+  it(`should execute operations outside of explicit transactions using handlers`, async () => {
     // Create handler functions that resolve after a short delay to simulate async operations
     const onInsertMock = vi.fn().mockImplementation(async (tx) => {
       // Wait a bit to simulate an async operation

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -44,19 +44,25 @@ describe(`Collection`, () => {
     // Verify that insert throws an error
     expect(() => {
       collection.insert({ value: `new value` })
-    }).toThrow(`no transaction found when calling collection.insert`)
+    }).toThrow(
+      `Collection.insert called directly (not within an explicit transaction) but no 'onInsert' handler is configured.`
+    )
 
     // Verify that update throws an error
     expect(() => {
       collection.update(`initial`, (draft) => {
         draft.value = `updated value`
       })
-    }).toThrow(`no transaction found when calling collection.update`)
+    }).toThrow(
+      `Collection.update called directly (not within an explicit transaction) but no 'onUpdate' handler is configured.`
+    )
 
     // Verify that delete throws an error
     expect(() => {
       collection.delete(`initial`)
-    }).toThrow(`no transaction found when calling collection.delete`)
+    }).toThrow(
+      `Collection.delete called directly (not within an explicit transaction) but no 'onDelete' handler is configured.`
+    )
   })
 
   it(`should throw an error when trying to update an item's ID`, async () => {
@@ -627,6 +633,120 @@ describe(`Collection`, () => {
     expect(typeof collection.config.onInsert).toBe(`function`)
     expect(typeof collection.config.onUpdate).toBe(`function`)
     expect(typeof collection.config.onDelete).toBe(`function`)
+  })
+
+  it.only(`should execute operations outside of explicit transactions using handlers`, async () => {
+    // Create handler functions that resolve after a short delay to simulate async operations
+    const onInsertMock = vi.fn().mockImplementation(async (tx) => {
+      // Wait a bit to simulate an async operation
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return { success: true, operation: `insert` }
+    })
+
+    const onUpdateMock = vi.fn().mockImplementation(async (tx) => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return { success: true, operation: `update` }
+    })
+
+    const onDeleteMock = vi.fn().mockImplementation(async (tx) => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return { success: true, operation: `delete` }
+    })
+
+    // Create a collection with handler functions
+    const collection = new Collection<{ id: number; value: string }>({
+      id: `direct-operations-test`,
+      getId: (item) => item.id,
+      sync: {
+        sync: ({ begin, write, commit }) => {
+          begin()
+          write({
+            type: `insert`,
+            value: { id: 1, value: `initial value` },
+          })
+          commit()
+        },
+      },
+      // Add the handler functions
+      onInsert: onInsertMock,
+      onUpdate: onUpdateMock,
+      onDelete: onDeleteMock,
+    })
+
+    await collection.stateWhenReady()
+
+    // Test direct insert operation
+    const insertTx = collection.insert({ id: 2, value: `inserted directly` })
+    expect(insertTx).toBeDefined()
+    expect(onInsertMock).toHaveBeenCalledTimes(1)
+
+    // Test direct update operation
+    const updateTx = collection.update(1, (draft) => {
+      draft.value = `updated directly`
+    })
+    expect(updateTx).toBeDefined()
+    expect(onUpdateMock).toHaveBeenCalledTimes(1)
+
+    // Test direct delete operation
+    const deleteTx = collection.delete(1)
+    expect(deleteTx).toBeDefined()
+    expect(onDeleteMock).toHaveBeenCalledTimes(1)
+
+    // Wait for all transactions to complete
+    await Promise.all([
+      insertTx.isPersisted.promise,
+      updateTx.isPersisted.promise,
+      deleteTx.isPersisted.promise,
+    ])
+
+    // Verify the transactions were created with the correct configuration
+    expect(insertTx.autoCommit).toBe(true)
+    expect(updateTx.autoCommit).toBe(true)
+    expect(deleteTx.autoCommit).toBe(true)
+  })
+
+  it(`should throw errors when operations are called outside transactions without handlers`, async () => {
+    // Create a collection without handler functions
+    const collection = new Collection<{ id: number; value: string }>({
+      id: `no-handlers-test`,
+      getId: (item) => item.id,
+      sync: {
+        sync: ({ begin, write, commit }) => {
+          begin()
+          write({
+            type: `insert`,
+            value: { id: 1, value: `initial value` },
+          })
+          commit()
+        },
+      },
+      // No handler functions defined
+    })
+
+    await collection.stateWhenReady()
+
+    // Test insert without handler
+    expect(() => {
+      collection.insert({ id: 2, value: `should fail` })
+    }).toThrow(
+      `Collection.insert called directly (not within an explicit transaction) but no 'onInsert' handler is configured.`
+    )
+
+    // Test update without handler
+    expect(() => {
+      collection.update(1, (draft) => {
+        draft.value = `should fail`
+      })
+    }).toThrow(
+      `Collection.update called directly (not within an explicit transaction) but no 'onUpdate' handler is configured.`
+    )
+
+    // Test delete without handler
+    expect(() => {
+      collection.delete(1)
+    }).toThrow(
+      `Collection.delete called directly (not within an explicit transaction) but no 'onDelete' handler is configured.`
+    )
   })
 })
 


### PR DESCRIPTION
Fix #132 

This change introduces a more streamlined and intuitive API for handling mutations by allowing `onInsert`, `onUpdate`, and `onDelete` handlers to be defined directly on the collection configuration.

When `collection.insert()`, `.update()`, or `.delete()` are called outside of an explicit transaction (i.e., not within `useOptimisticMutation`), the library now automatically creates a single-operation transaction and invokes the corresponding handler to persist the change.

Key changes:

-   **`@tanstack/db`**: The `Collection` class now supports `onInsert`, `onUpdate`, and `onDelete` in its configuration. Direct calls to mutation methods will throw an error if the corresponding handler is not defined.
-   **`@tanstack/db-collections`**:
    -   `queryCollectionOptions` now accepts the new handlers and will automatically `refetch` the collection's query after a handler successfully completes. This behavior can be disabled if the handler returns `{ refetch: false }`.
    -   `electricCollectionOptions` also accepts the new handlers. These handlers are now required to return an object with a transaction ID (`{ txid: string }`). The collection then automatically waits for this `txid` to be synced back before resolving the mutation, ensuring consistency.
-   **Breaking Change**: Calling `collection.insert()`, `.update()`, or `.delete()` without being inside a `useOptimisticMutation` callback and without a corresponding persistence handler (`onInsert`, etc.) configured on the collection will now throw an error.

This new pattern simplifies the most common use cases, making the code more declarative. The `useOptimisticMutation` hook remains available for more complex scenarios, such as transactions involving multiple mutations across different collections.

***

### refactor(docs): Simplify mutation API and update examples

The documentation and the React Todo example application have been significantly refactored to adopt the new direct persistence handler pattern as the primary way to perform mutations.

-   The `README.md` and `docs/overview.md` files have been updated to de-emphasize `useOptimisticMutation` for simple writes. They now showcase the much simpler API of calling `collection.insert()` directly and defining persistence logic in the collection's configuration.
-   The React Todo example (`examples/react/todo/src/App.tsx`) has been completely overhauled. All instances of `useOptimisticMutation` have been removed and replaced with the new `onInsert`, `onUpdate`, and `onDelete` handlers, resulting in cleaner and more concise code.