### PR TITLE
Export `ElectricCollectionUtils` & allow passing generic to `createTransaction` & fix some type issues in tests

### DIFF
--- a/.changeset/solid-sloths-flash.md
+++ b/.changeset/solid-sloths-flash.md
@@ -1,0 +1,9 @@
+---
+"@tanstack/db-example-react-todo": patch
+"@tanstack/db": patch
+"@tanstack/db-collections": patch
+"@tanstack/react-db": patch
+"@tanstack/vue-db": patch
+---
+
+Export `ElectricCollectionUtils` & allow passing generic to `createTransaction`

--- a/packages/db-collections/src/index.ts
+++ b/packages/db-collections/src/index.ts
@@ -1,5 +1,6 @@
 export {
   electricCollectionOptions,
   type ElectricCollectionConfig,
+  type ElectricCollectionUtils,
 } from "./electric"
 export { queryCollectionOptions, type QueryCollectionConfig } from "./query"

--- a/packages/db-collections/tests/electric.test.ts
+++ b/packages/db-collections/tests/electric.test.ts
@@ -26,7 +26,7 @@ vi.mock(`@electric-sql/client`, async () => {
 })
 
 describe(`Electric Integration`, () => {
-  let collection: Collection<Row, ElectricCollectionUtils>
+  let collection: Collection<Row, string | number, ElectricCollectionUtils>
   let subscriber: (messages: Array<Message<Row>>) => void
 
   beforeEach(() => {
@@ -54,7 +54,11 @@ describe(`Electric Integration`, () => {
     const options = electricCollectionOptions(config)
 
     // Create collection with Electric configuration using the new utility exposure pattern
-    collection = createCollection<Row, ElectricCollectionUtils>(options)
+    collection = createCollection<
+      Row,
+      string | number,
+      ElectricCollectionUtils
+    >(options)
   })
 
   it(`should handle incoming insert messages and commit on up-to-date`, () => {
@@ -295,7 +299,7 @@ describe(`Electric Integration`, () => {
       const fakeBackend = {
         data: new Map<number, { txid: string; value: unknown }>(),
         // Simulates persisting data to a backend and returning a txid
-        persist: (mutations: Array<PendingMutation>): Promise<string> => {
+        persist: (mutations: Array<PendingMutation<Row>>): Promise<string> => {
           const txid = String(Date.now())
 
           // Store the changes with the txid
@@ -342,7 +346,9 @@ describe(`Electric Integration`, () => {
       const testMutationFn = vi.fn(
         async ({ transaction }: { transaction: Transaction }) => {
           // Persist to fake backend and get txid
-          const txid = await fakeBackend.persist(transaction.mutations)
+          const txid = await fakeBackend.persist(
+            transaction.mutations as Array<PendingMutation<Row>>
+          )
 
           if (!txid) {
             throw new Error(`No txid found`)
@@ -452,7 +458,7 @@ describe(`Electric Integration`, () => {
       const fakeBackend = {
         data: new Map<string, { txid: string; value: unknown }>(),
         // Simulates persisting data to a backend and returning a txid
-        persist: (mutations: Array<PendingMutation>): Promise<string> => {
+        persist: (mutations: Array<PendingMutation<Row>>): Promise<string> => {
           const txid = String(Date.now())
 
           // Store the changes with the txid

--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -28,7 +28,9 @@ function generateUUID() {
 const transactions: Array<Transaction<any>> = []
 let transactionStack: Array<Transaction<any>> = []
 
-export function createTransaction(config: TransactionConfig): Transaction {
+export function createTransaction<
+  TData extends object = Record<string, unknown>,
+>(config: TransactionConfig<TData>): Transaction<TData> {
   if (typeof config.mutationFn === `undefined`) {
     throw `mutationFn is required when creating a transaction`
   }
@@ -37,7 +39,10 @@ export function createTransaction(config: TransactionConfig): Transaction {
   if (!transactionId) {
     transactionId = generateUUID()
   }
-  const newTransaction = new Transaction({ ...config, id: transactionId })
+  const newTransaction = new Transaction<TData>({
+    ...config,
+    id: transactionId,
+  })
 
   transactions.push(newTransaction)
 


### PR DESCRIPTION
`ElectricCollectionUtils` is needed to type `awaitTxId` in `useOptimisticMutation`