### PR TITLE
If a schema is passed, use that for the collection type

### DIFF
--- a/.changeset/tiny-adults-shave.md
+++ b/.changeset/tiny-adults-shave.md
@@ -6,4 +6,3 @@
 If a schema is passed, use that for the collection type.
 
 You now must either pass an explicit type or schema - passing both will conflict.
-

--- a/.changeset/tiny-adults-shave.md
+++ b/.changeset/tiny-adults-shave.md
@@ -5,4 +5,5 @@
 
 If a schema is passed, use that for the collection type.
 
-You now must either pass an explict type or schema - passing both will conflict.
+You now must either pass an explicit type or schema - passing both will conflict.
+

--- a/.changeset/tiny-adults-shave.md
+++ b/.changeset/tiny-adults-shave.md
@@ -1,0 +1,8 @@
+---
+"@tanstack/db-collections": patch
+"@tanstack/db": patch
+---
+
+If a schema is passed, use that for the collection type.
+
+You now must either pass an explict type or schema - passing both will conflict.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,8 @@ jobs:
         uses: tanstack/config/.github/setup@main
       - name: Build Packages
         run: pnpm run build
+      - name: Publish Previews
+        run: pnpx pkg-pr-new publish --pnpm --compact './packages/*' --template './examples/*/*'
       - name: Compressed Size Action - DB Package
         uses: preactjs/compressed-size-action@v2
         with:
@@ -55,5 +57,3 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./packages/react-db/dist/**/*.{js,mjs}"
           comment-key: "react-db-package-size"
-      - name: Publish Previews
-        run: pnpx pkg-pr-new publish --pnpm --compact './packages/*' --template './examples/*/*'

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -163,14 +163,18 @@ You can also use:
 
 All collections optionally support a `schema`.
 
-If provided, this should be a [Standard Schema](https://standardschema.dev) compatible schema instance, such as a [Zod](https://zod.dev) or [Effect](https://effect.website/docs/schema/introduction/) schema.
+If provided, this must be a [Standard Schema](https://standardschema.dev) compatible schema instance, such as a [Zod](https://zod.dev) or [Effect](https://effect.website/docs/schema/introduction/) schema.
+
+The collection will use the schema for its type so if you provide a schema, you can't also pass in an explicit
+type (e.g. `createCollection<Todo>()`).
+
 
 #### `QueryCollection`
 
 [TanStack Query](https://tanstack.com/query) fetches data using managed queries. Use `queryCollectionOptions` to fetch data into a collection using TanStack Query:
 
 ```ts
-const todoCollection = createCollection<Todo>(queryCollectionOptions({
+const todoCollection = createCollection(queryCollectionOptions({
   queryKey: ['todoItems'],
   queryFn: async () => fetch('/api/todos'),
   getKey: (item) => item.id,
@@ -190,7 +194,7 @@ Electric's main primitive for sync is a [Shape](https://electric-sql.com/docs/gu
 import { createCollection } from '@tanstack/react-db'
 import { electricCollectionOptions } from '@tanstack/db-collections'
 
-export const todoCollection = createCollection<Todo>(electricCollectionOptions({
+export const todoCollection = createCollection(electricCollectionOptions({
   id: 'todos',
   shapeOptions: {
     url: 'https://example.com/v1/shape',
@@ -215,7 +219,7 @@ When you create the collection, sync starts automatically.
 Electric shapes allow you to filter data using where clauses:
 
 ```ts
-export const myPendingTodos = createCollection<Todo>(electricCollectionOptions({
+export const myPendingTodos = createCollection(electricCollectionOptions({
   id: 'todos',
   shapeOptions: {
     url: 'https://example.com/v1/shape',

--- a/examples/react/todo/src/App.tsx
+++ b/examples/react/todo/src/App.tsx
@@ -6,9 +6,9 @@ import {
 } from "@tanstack/db-collections"
 // import { DevTools } from "./DevTools"
 import { QueryClient } from "@tanstack/query-core"
-import { updateConfigSchema, updateTodoSchema } from "./db/validation"
+import { selectConfigSchema, selectTodoSchema } from "./db/validation"
 import type { Collection } from "@tanstack/react-db"
-import type { UpdateConfig, UpdateTodo } from "./db/validation"
+import type { SelectConfig, SelectTodo } from "./db/validation"
 import type { FormEvent } from "react"
 
 // API helper for todos and config
@@ -17,21 +17,21 @@ const API_BASE_URL = `http://localhost:3001/api`
 const api = {
   // Todo API methods
   todos: {
-    getAll: async (): Promise<Array<UpdateTodo>> => {
+    getAll: async (): Promise<Array<SelectTodo>> => {
       const response = await fetch(`${API_BASE_URL}/todos`)
       if (!response.ok)
         throw new Error(`HTTP error! Status: ${response.status}`)
       return response.json()
     },
-    getById: async (id: number): Promise<UpdateTodo> => {
+    getById: async (id: number): Promise<SelectTodo> => {
       const response = await fetch(`${API_BASE_URL}/todos/${id}`)
       if (!response.ok)
         throw new Error(`HTTP error! Status: ${response.status}`)
       return response.json()
     },
     create: async (
-      todo: Partial<UpdateTodo>
-    ): Promise<{ todo: UpdateTodo; txid: number }> => {
+      todo: Partial<SelectTodo>
+    ): Promise<{ todo: SelectTodo; txid: number }> => {
       const response = await fetch(`${API_BASE_URL}/todos`, {
         method: `POST`,
         headers: { "Content-Type": `application/json` },
@@ -43,8 +43,8 @@ const api = {
     },
     update: async (
       id: unknown,
-      changes: Partial<UpdateTodo>
-    ): Promise<{ todo: UpdateTodo; txid: number }> => {
+      changes: Partial<SelectTodo>
+    ): Promise<{ todo: SelectTodo; txid: number }> => {
       const response = await fetch(`${API_BASE_URL}/todos/${id}`, {
         method: `PUT`,
         headers: { "Content-Type": `application/json` },
@@ -68,21 +68,21 @@ const api = {
 
   // Config API methods
   config: {
-    getAll: async (): Promise<Array<UpdateConfig>> => {
+    getAll: async (): Promise<Array<SelectConfig>> => {
       const response = await fetch(`${API_BASE_URL}/config`)
       if (!response.ok)
         throw new Error(`HTTP error! Status: ${response.status}`)
       return response.json()
     },
-    getById: async (id: number): Promise<UpdateConfig> => {
+    getById: async (id: number): Promise<SelectConfig> => {
       const response = await fetch(`${API_BASE_URL}/config/${id}`)
       if (!response.ok)
         throw new Error(`HTTP error! Status: ${response.status}`)
       return response.json()
     },
     create: async (
-      config: Partial<UpdateConfig>
-    ): Promise<{ config: UpdateConfig; txid: number }> => {
+      config: Partial<SelectConfig>
+    ): Promise<{ config: SelectConfig; txid: number }> => {
       const response = await fetch(`${API_BASE_URL}/config`, {
         method: `POST`,
         headers: { "Content-Type": `application/json` },
@@ -94,8 +94,8 @@ const api = {
     },
     update: async (
       id: number,
-      changes: Partial<UpdateConfig>
-    ): Promise<{ config: UpdateConfig; txid: number }> => {
+      changes: Partial<SelectConfig>
+    ): Promise<{ config: SelectConfig; txid: number }> => {
       const response = await fetch(`${API_BASE_URL}/config/${id}`, {
         method: `PUT`,
         headers: { "Content-Type": `application/json` },
@@ -130,12 +130,12 @@ const collectionsCache = new Map()
 // Function to create the appropriate todo collection based on type
 const createTodoCollection = (type: CollectionType) => {
   if (collectionsCache.has(`todo`)) {
-    return collectionsCache.get(`todo`) as Collection<UpdateTodo>
+    return collectionsCache.get(`todo`) as Collection<SelectTodo>
   } else {
-    let newCollection: Collection<UpdateTodo>
+    let newCollection: Collection<SelectTodo>
     if (type === CollectionType.Electric) {
       newCollection = createCollection(
-        electricCollectionOptions<UpdateTodo>({
+        electricCollectionOptions({
           id: `todos`,
           shapeOptions: {
             url: `http://localhost:3003/v1/shape`,
@@ -147,8 +147,8 @@ const createTodoCollection = (type: CollectionType) => {
               timestamptz: (date: string) => new Date(date),
             },
           },
-          getKey: (item) => item.id!,
-          schema: updateTodoSchema,
+          getKey: (item) => item.id,
+          schema: selectTodoSchema,
           onInsert: async ({ transaction }) => {
             const modified = transaction.mutations[0].modified
             const response = await api.todos.create(modified)
@@ -165,7 +165,7 @@ const createTodoCollection = (type: CollectionType) => {
               })
             )
 
-            return { txid: String(txids[0].txid) }
+            return { txid: String(txids[0]!.txid) }
           },
           onDelete: async ({ transaction }) => {
             const txids = await Promise.all(
@@ -177,7 +177,7 @@ const createTodoCollection = (type: CollectionType) => {
               })
             )
 
-            return { txid: String(txids[0].txid) }
+            return { txid: String(txids[0]!.txid) }
           },
         })
       )
@@ -190,19 +190,15 @@ const createTodoCollection = (type: CollectionType) => {
           refetchInterval: 3000,
           queryFn: async () => {
             const todos = await api.todos.getAll()
-            // Turn date strings into Dates if needed
+            // Turn date strings into Dates
             return todos.map((todo) => ({
               ...todo,
-              created_at: todo.created_at
-                ? new Date(todo.created_at)
-                : undefined,
-              updated_at: todo.updated_at
-                ? new Date(todo.updated_at)
-                : undefined,
+              created_at: new Date(todo.created_at),
+              updated_at: new Date(todo.updated_at),
             }))
           },
-          getKey: (item: UpdateTodo) => item.id!,
-          schema: updateTodoSchema,
+          getKey: (item: SelectTodo) => item.id,
+          schema: selectTodoSchema,
           queryClient,
           onInsert: async ({ transaction }) => {
             const modified = transaction.mutations[0].modified
@@ -235,9 +231,9 @@ const createTodoCollection = (type: CollectionType) => {
 // Function to create the appropriate config collection based on type
 const createConfigCollection = (type: CollectionType) => {
   if (collectionsCache.has(`config`)) {
-    return collectionsCache.get(`config`)
+    return collectionsCache.get(`config`) as Collection<SelectConfig>
   } else {
-    let newCollection: Collection<UpdateConfig>
+    let newCollection: Collection<SelectConfig>
     if (type === CollectionType.Electric) {
       newCollection = createCollection(
         electricCollectionOptions({
@@ -254,8 +250,8 @@ const createConfigCollection = (type: CollectionType) => {
               },
             },
           },
-          getKey: (item: UpdateConfig) => item.id!,
-          schema: updateConfigSchema,
+          getKey: (item: SelectConfig) => item.id,
+          schema: selectConfigSchema,
           onInsert: async ({ transaction }) => {
             const modified = transaction.mutations[0].modified
             const response = await api.config.create(modified)
@@ -286,19 +282,15 @@ const createConfigCollection = (type: CollectionType) => {
           refetchInterval: 3000,
           queryFn: async () => {
             const configs = await api.config.getAll()
-            // Turn date strings into Dates if needed
+            // Turn date strings into Dates
             return configs.map((config) => ({
               ...config,
-              created_at: config.created_at
-                ? new Date(config.created_at)
-                : undefined,
-              updated_at: config.updated_at
-                ? new Date(config.updated_at)
-                : undefined,
+              created_at: new Date(config.created_at),
+              updated_at: new Date(config.updated_at),
             }))
           },
-          getKey: (item: UpdateConfig) => item.id,
-          schema: updateConfigSchema,
+          getKey: (item: SelectConfig) => item.id,
+          schema: selectConfigSchema,
           queryClient,
           onInsert: async ({ transaction }) => {
             const modified = transaction.mutations[0].modified
@@ -345,15 +337,12 @@ export default function App() {
 
   // Always call useLiveQuery hooks
   const { data: todos } = useLiveQuery((q) =>
-    q
-      .from({ todoCollection: todoCollection })
-      .orderBy(`@created_at`)
-      .select(`@id`, `@created_at`, `@text`, `@completed`)
+    q.from({ todoCollection: todoCollection }).orderBy(`@created_at`)
   )
 
   const { data: configData } = useLiveQuery((q) =>
     q
-      .from({ configCollection: configCollection as Collection<UpdateConfig> })
+      .from({ configCollection: configCollection })
       .select(`@id`, `@key`, `@value`)
   )
 
@@ -371,7 +360,7 @@ export default function App() {
   const getConfigValue = (key: string): string => {
     for (const config of configData) {
       if (config.key === key) {
-        return config.value!
+        return config.value
       }
     }
     return ``
@@ -391,8 +380,11 @@ export default function App() {
 
     // If the config doesn't exist yet, create it
     configCollection.insert({
+      id: Math.random(),
       key,
       value,
+      created_at: new Date(),
+      updated_at: new Date(),
     })
   }
 
@@ -457,11 +449,13 @@ export default function App() {
       text: newTodo,
       completed: false,
       id: Math.round(Math.random() * 1000000),
+      created_at: new Date(),
+      updated_at: new Date(),
     })
     setNewTodo(``)
   }
 
-  const toggleTodo = (todo: UpdateTodo) => {
+  const toggleTodo = (todo: SelectTodo) => {
     console.log(todoCollection)
     todoCollection.update(todo.id, (draft) => {
       draft.completed = !draft.completed

--- a/packages/db-collections/package.json
+++ b/packages/db-collections/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@tanstack/db": "workspace:*",
     "@tanstack/query-core": "^5.75.7",
+    "@standard-schema/spec": "^1.0.0",
     "@tanstack/store": "^0.7.0"
   },
   "devDependencies": {

--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -61,7 +61,7 @@ export interface ElectricCollectionConfig<
    */
   onInsert?: (
     params: InsertMutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
-  ) => Promise<{ txid: string } | undefined>
+  ) => Promise<{ txid: string }>
 
   /**
    * Optional asynchronous handler function called before an update operation
@@ -71,7 +71,7 @@ export interface ElectricCollectionConfig<
    */
   onUpdate?: (
     params: UpdateMutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
-  ) => Promise<{ txid: string } | undefined>
+  ) => Promise<{ txid: string }>
 
   /**
    * Optional asynchronous handler function called before a delete operation
@@ -81,7 +81,7 @@ export interface ElectricCollectionConfig<
    */
   onDelete?: (
     params: DeleteMutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
-  ) => Promise<{ txid: string } | undefined>
+  ) => Promise<{ txid: string }>
 }
 
 function isUpToDateMessage<T extends Row<unknown>>(
@@ -167,8 +167,12 @@ export function electricCollectionOptions<
   // Create wrapper handlers for direct persistence operations that handle txid awaiting
   const wrappedOnInsert = config.onInsert
     ? async (
-        params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+        params: InsertMutationFnParams<
+          ResolveType<TExplicit, TSchema, TFallback>
+        >
       ) => {
+        // Runtime check (that doesn't follow type)
+        // eslint-disable-next-line
         const handlerResult = (await config.onInsert!(params)) ?? {}
         const txid = (handlerResult as { txid?: string }).txid
 
@@ -185,9 +189,13 @@ export function electricCollectionOptions<
 
   const wrappedOnUpdate = config.onUpdate
     ? async (
-        params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+        params: UpdateMutationFnParams<
+          ResolveType<TExplicit, TSchema, TFallback>
+        >
       ) => {
-        const handlerResult = await config.onUpdate!(params)
+        // Runtime check (that doesn't follow type)
+        // eslint-disable-next-line
+        const handlerResult = (await config.onUpdate!(params)) ?? {}
         const txid = (handlerResult as { txid?: string }).txid
 
         if (!txid) {
@@ -203,9 +211,13 @@ export function electricCollectionOptions<
 
   const wrappedOnDelete = config.onDelete
     ? async (
-        params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+        params: DeleteMutationFnParams<
+          ResolveType<TExplicit, TSchema, TFallback>
+        >
       ) => {
-        const handlerResult = await config.onDelete!(params)
+        // Runtime check (that doesn't follow type)
+        // eslint-disable-next-line
+        const handlerResult = (await config.onDelete!(params)) ?? {}
         const txid = (handlerResult as { txid?: string }).txid
 
         if (!txid) {

--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -24,6 +24,14 @@ import type {
  * @template TExplicit - The explicit type of items in the collection (highest priority)
  * @template TSchema - The schema type for validation and type inference (second priority)
  * @template TFallback - The fallback type if no explicit or schema type is provided
+ *
+ * @remarks
+ * Type resolution follows a priority order:
+ * 1. If you provide an explicit type via generic parameter, it will be used
+ * 2. If no explicit type is provided but a schema is, the schema's output type will be inferred
+ * 3. If neither explicit type nor schema is provided, the fallback type will be used
+ *
+ * You should provide EITHER an explicit type OR a schema, but not both, as they would conflict.
  */
 export interface ElectricCollectionConfig<
   TExplicit = unknown,

--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -74,14 +74,14 @@ export interface ElectricCollectionConfig<
   ) => Promise<{ txid: string } | undefined>
 }
 
-function isUpToDateMessage<T>(
+function isUpToDateMessage<T extends Row<unknown>>(
   message: Message<T>
 ): message is ControlMessage & { up_to_date: true } {
   return isControlMessage(message) && message.headers.control === `up-to-date`
 }
 
 // Check if a message contains txids in its headers
-function hasTxids<T>(
+function hasTxids<T extends Row<unknown>>(
   message: Message<T>
 ): message is Message<T> & { headers: { txids?: Array<number> } } {
   return (
@@ -233,7 +233,7 @@ export function electricCollectionOptions<
 /**
  * Internal function to create ElectricSQL sync configuration
  */
-function createElectricSync<T>(
+function createElectricSync<T extends object>(
   shapeOptions: ShapeStreamOptions,
   options: {
     seenTxids: Store<Set<string>>

--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -6,9 +6,11 @@ import {
 import { Store } from "@tanstack/store"
 import type {
   CollectionConfig,
-  MutationFnParams,
+  DeleteMutationFnParams,
+  InsertMutationFnParams,
   ResolveType,
   SyncConfig,
+  UpdateMutationFnParams,
   UtilsRecord,
 } from "@tanstack/db"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
@@ -58,7 +60,7 @@ export interface ElectricCollectionConfig<
    * @returns Promise resolving to an object with txid
    */
   onInsert?: (
-    params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+    params: InsertMutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
   ) => Promise<{ txid: string } | undefined>
 
   /**
@@ -68,7 +70,7 @@ export interface ElectricCollectionConfig<
    * @returns Promise resolving to an object with txid
    */
   onUpdate?: (
-    params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+    params: UpdateMutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
   ) => Promise<{ txid: string } | undefined>
 
   /**
@@ -78,7 +80,7 @@ export interface ElectricCollectionConfig<
    * @returns Promise resolving to an object with txid
    */
   onDelete?: (
-    params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+    params: DeleteMutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
   ) => Promise<{ txid: string } | undefined>
 }
 

--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -7,9 +7,11 @@ import { Store } from "@tanstack/store"
 import type {
   CollectionConfig,
   MutationFnParams,
+  ResolveType,
   SyncConfig,
   UtilsRecord,
 } from "@tanstack/db"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
 import type {
   ControlMessage,
   Message,
@@ -19,8 +21,15 @@ import type {
 
 /**
  * Configuration interface for Electric collection options
+ * @template TExplicit - The explicit type of items in the collection (highest priority)
+ * @template TSchema - The schema type for validation and type inference (second priority)
+ * @template TFallback - The fallback type if no explicit or schema type is provided
  */
-export interface ElectricCollectionConfig<T extends Row<unknown>> {
+export interface ElectricCollectionConfig<
+  TExplicit = unknown,
+  TSchema extends StandardSchemaV1 = never,
+  TFallback extends Row<unknown> = Row<unknown>,
+> {
   /**
    * Configuration options for the ElectricSQL ShapeStream
    */
@@ -30,9 +39,9 @@ export interface ElectricCollectionConfig<T extends Row<unknown>> {
    * All standard Collection configuration properties
    */
   id?: string
-  schema?: CollectionConfig<T>[`schema`]
-  getKey: CollectionConfig<T>[`getKey`]
-  sync?: CollectionConfig<T>[`sync`]
+  schema?: TSchema
+  getKey: CollectionConfig<ResolveType<TExplicit, TSchema, TFallback>>[`getKey`]
+  sync?: CollectionConfig<ResolveType<TExplicit, TSchema, TFallback>>[`sync`]
 
   /**
    * Optional asynchronous handler function called before an insert operation
@@ -41,7 +50,7 @@ export interface ElectricCollectionConfig<T extends Row<unknown>> {
    * @returns Promise resolving to an object with txid
    */
   onInsert?: (
-    params: MutationFnParams<T>
+    params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
   ) => Promise<{ txid: string } | undefined>
 
   /**
@@ -51,7 +60,7 @@ export interface ElectricCollectionConfig<T extends Row<unknown>> {
    * @returns Promise resolving to an object with txid
    */
   onUpdate?: (
-    params: MutationFnParams<T>
+    params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
   ) => Promise<{ txid: string } | undefined>
 
   /**
@@ -61,18 +70,18 @@ export interface ElectricCollectionConfig<T extends Row<unknown>> {
    * @returns Promise resolving to an object with txid
    */
   onDelete?: (
-    params: MutationFnParams<T>
+    params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
   ) => Promise<{ txid: string } | undefined>
 }
 
-function isUpToDateMessage<T extends Row<unknown>>(
+function isUpToDateMessage<T>(
   message: Message<T>
 ): message is ControlMessage & { up_to_date: true } {
   return isControlMessage(message) && message.headers.control === `up-to-date`
 }
 
 // Check if a message contains txids in its headers
-function hasTxids<T extends Row<unknown> = Row>(
+function hasTxids<T>(
   message: Message<T>
 ): message is Message<T> & { headers: { txids?: Array<number> } } {
   return (
@@ -97,16 +106,24 @@ export interface ElectricCollectionUtils extends UtilsRecord {
 /**
  * Creates Electric collection options for use with a standard Collection
  *
+ * @template TExplicit - The explicit type of items in the collection (highest priority)
+ * @template TSchema - The schema type for validation and type inference (second priority)
+ * @template TFallback - The fallback type if no explicit or schema type is provided
  * @param config - Configuration options for the Electric collection
  * @returns Collection options with utilities
  */
-export function electricCollectionOptions<T extends Row<unknown>>(
-  config: ElectricCollectionConfig<T>
-) {
+export function electricCollectionOptions<
+  TExplicit = unknown,
+  TSchema extends StandardSchemaV1 = never,
+  TFallback extends Row<unknown> = Row<unknown>,
+>(config: ElectricCollectionConfig<TExplicit, TSchema, TFallback>) {
   const seenTxids = new Store<Set<string>>(new Set([`${Math.random()}`]))
-  const sync = createElectricSync<T>(config.shapeOptions, {
-    seenTxids,
-  })
+  const sync = createElectricSync<ResolveType<TExplicit, TSchema, TFallback>>(
+    config.shapeOptions,
+    {
+      seenTxids,
+    }
+  )
 
   /**
    * Wait for a specific transaction ID to be synced
@@ -139,7 +156,9 @@ export function electricCollectionOptions<T extends Row<unknown>>(
 
   // Create wrapper handlers for direct persistence operations that handle txid awaiting
   const wrappedOnInsert = config.onInsert
-    ? async (params: MutationFnParams<T>) => {
+    ? async (
+        params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+      ) => {
         const handlerResult = (await config.onInsert!(params)) ?? {}
         const txid = (handlerResult as { txid?: string }).txid
 
@@ -155,7 +174,9 @@ export function electricCollectionOptions<T extends Row<unknown>>(
     : undefined
 
   const wrappedOnUpdate = config.onUpdate
-    ? async (params: MutationFnParams<T>) => {
+    ? async (
+        params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+      ) => {
         const handlerResult = await config.onUpdate!(params)
         const txid = (handlerResult as { txid?: string }).txid
 
@@ -171,7 +192,9 @@ export function electricCollectionOptions<T extends Row<unknown>>(
     : undefined
 
   const wrappedOnDelete = config.onDelete
-    ? async (params: MutationFnParams<T>) => {
+    ? async (
+        params: MutationFnParams<ResolveType<TExplicit, TSchema, TFallback>>
+      ) => {
         const handlerResult = await config.onDelete!(params)
         const txid = (handlerResult as { txid?: string }).txid
 
@@ -210,7 +233,7 @@ export function electricCollectionOptions<T extends Row<unknown>>(
 /**
  * Internal function to create ElectricSQL sync configuration
  */
-function createElectricSync<T extends Row<unknown>>(
+function createElectricSync<T>(
   shapeOptions: ShapeStreamOptions,
   options: {
     seenTxids: Store<Set<string>>

--- a/packages/db-collections/src/query.ts
+++ b/packages/db-collections/src/query.ts
@@ -79,6 +79,7 @@ export interface QueryCollectionConfig<
    * @returns Promise resolving to void or { refetch?: boolean } to control refetching
    */
   onDelete?: CollectionConfig<TItem>[`onDelete`]
+  // TODO type returning { refetch: boolean }
 }
 
 /**

--- a/packages/db-collections/tests/electric.test-d.ts
+++ b/packages/db-collections/tests/electric.test-d.ts
@@ -116,7 +116,7 @@ describe(`Electric collection type resolution tests`, () => {
       onDelete: (params) => {
         // Verify that the mutation value has the correct type
         expectTypeOf(params.transaction.mutations[0].original).toEqualTypeOf<
-          Partial<ExplicitType>
+          ExplicitType | {}
         >()
         return Promise.resolve({ txid: `test` })
       },

--- a/packages/db-collections/tests/electric.test-d.ts
+++ b/packages/db-collections/tests/electric.test-d.ts
@@ -1,0 +1,144 @@
+import { describe, expectTypeOf, it } from "vitest"
+import { z } from "zod"
+import { electricCollectionOptions } from "../src/electric"
+import type { ElectricCollectionConfig } from "../src/electric"
+import type { MutationFnParams, ResolveType } from "@tanstack/db"
+import type { Row } from "@electric-sql/client"
+
+describe(`Electric collection type resolution tests`, () => {
+  // Define test types
+  type ExplicitType = { id: string; explicit: boolean }
+  type FallbackType = { id: string; fallback: boolean }
+
+  // Define a schema
+  const testSchema = z.object({
+    id: z.string(),
+    schema: z.boolean(),
+  })
+
+  type SchemaType = z.infer<typeof testSchema>
+
+  it(`should prioritize explicit type in ElectricCollectionConfig`, () => {
+    const options = electricCollectionOptions<ExplicitType>({
+      shapeOptions: {
+        url: `foo`,
+        params: { table: `test_table` },
+      },
+      getKey: (item) => item.id,
+    })
+
+    type ExpectedType = ResolveType<ExplicitType, never, Row<unknown>>
+    // The getKey function should have the resolved type
+    expectTypeOf(options.getKey).parameters.toEqualTypeOf<[ExplicitType]>()
+    expectTypeOf<ExpectedType>().toEqualTypeOf<ExplicitType>()
+  })
+
+  it(`should use schema type when explicit type is not provided`, () => {
+    const options = electricCollectionOptions({
+      shapeOptions: {
+        url: `foo`,
+        params: { table: `test_table` },
+      },
+      schema: testSchema,
+      getKey: (item) => item.id,
+    })
+
+    type ExpectedType = ResolveType<unknown, typeof testSchema, Row<unknown>>
+    // The getKey function should have the resolved type
+    expectTypeOf(options.getKey).parameters.toEqualTypeOf<[SchemaType]>()
+    expectTypeOf<ExpectedType>().toEqualTypeOf<SchemaType>()
+  })
+
+  it(`should use fallback type when neither explicit nor schema type is provided`, () => {
+    const config: ElectricCollectionConfig<unknown, never, FallbackType> = {
+      shapeOptions: {
+        url: `foo`,
+        params: { table: `test_table` },
+      },
+      getKey: (item) => item.id,
+    }
+
+    const options = electricCollectionOptions<unknown, never, FallbackType>(
+      config
+    )
+
+    type ExpectedType = ResolveType<unknown, never, FallbackType>
+    // The getKey function should have the resolved type
+    expectTypeOf(options.getKey).parameters.toEqualTypeOf<[FallbackType]>()
+    expectTypeOf<ExpectedType>().toEqualTypeOf<FallbackType>()
+  })
+
+  it(`should correctly resolve type with all three types provided`, () => {
+    const options = electricCollectionOptions<
+      ExplicitType,
+      typeof testSchema,
+      FallbackType
+    >({
+      shapeOptions: {
+        url: `test_shape`,
+        params: { table: `test_table` },
+      },
+      schema: testSchema,
+      getKey: (item) => item.id,
+    })
+
+    type ExpectedType = ResolveType<
+      ExplicitType,
+      typeof testSchema,
+      FallbackType
+    >
+    // The getKey function should have the resolved type
+    expectTypeOf(options.getKey).parameters.toEqualTypeOf<[ExplicitType]>()
+    expectTypeOf<ExpectedType>().toEqualTypeOf<ExplicitType>()
+  })
+
+  it(`should properly type the onInsert, onUpdate, and onDelete handlers`, () => {
+    const options = electricCollectionOptions<ExplicitType>({
+      shapeOptions: {
+        url: `test_shape`,
+        params: { table: `test_table` },
+      },
+      getKey: (item) => item.id,
+      onInsert: (params) => {
+        // Verify that the mutation value has the correct type
+        expectTypeOf(
+          params.transaction.mutations[0].modified
+        ).toEqualTypeOf<ExplicitType>()
+        return Promise.resolve({ txid: `test` })
+      },
+      onUpdate: (params) => {
+        // Verify that the mutation value has the correct type
+        expectTypeOf(
+          params.transaction.mutations[0].modified
+        ).toEqualTypeOf<ExplicitType>()
+        return Promise.resolve({ txid: `test` })
+      },
+      onDelete: (params) => {
+        // Verify that the mutation value has the correct type
+        expectTypeOf(params.transaction.mutations[0].original).toEqualTypeOf<
+          Partial<ExplicitType>
+        >()
+        return Promise.resolve({ txid: `test` })
+      },
+    })
+
+    // Verify that the handlers are properly typed
+    if (options.onInsert) {
+      expectTypeOf(options.onInsert).parameters.toEqualTypeOf<
+        [MutationFnParams<ExplicitType>]
+      >()
+    }
+
+    if (options.onUpdate) {
+      expectTypeOf(options.onUpdate).parameters.toEqualTypeOf<
+        [MutationFnParams<ExplicitType>]
+      >()
+    }
+
+    if (options.onDelete) {
+      expectTypeOf(options.onDelete).parameters.toEqualTypeOf<
+        [MutationFnParams<ExplicitType>]
+      >()
+    }
+  })
+})

--- a/packages/db-collections/tests/electric.test-d.ts
+++ b/packages/db-collections/tests/electric.test-d.ts
@@ -2,7 +2,12 @@ import { describe, expectTypeOf, it } from "vitest"
 import { z } from "zod"
 import { electricCollectionOptions } from "../src/electric"
 import type { ElectricCollectionConfig } from "../src/electric"
-import type { MutationFnParams, ResolveType } from "@tanstack/db"
+import type {
+  DeleteMutationFnParams,
+  InsertMutationFnParams,
+  ResolveType,
+  UpdateMutationFnParams,
+} from "@tanstack/db"
 import type { Row } from "@electric-sql/client"
 
 describe(`Electric collection type resolution tests`, () => {
@@ -115,9 +120,9 @@ describe(`Electric collection type resolution tests`, () => {
       },
       onDelete: (params) => {
         // Verify that the mutation value has the correct type
-        expectTypeOf(params.transaction.mutations[0].original).toEqualTypeOf<
-          ExplicitType | {}
-        >()
+        expectTypeOf(
+          params.transaction.mutations[0].original
+        ).toEqualTypeOf<ExplicitType>()
         return Promise.resolve({ txid: `test` })
       },
     })
@@ -125,19 +130,19 @@ describe(`Electric collection type resolution tests`, () => {
     // Verify that the handlers are properly typed
     if (options.onInsert) {
       expectTypeOf(options.onInsert).parameters.toEqualTypeOf<
-        [MutationFnParams<ExplicitType>]
+        [InsertMutationFnParams<ExplicitType>]
       >()
     }
 
     if (options.onUpdate) {
       expectTypeOf(options.onUpdate).parameters.toEqualTypeOf<
-        [MutationFnParams<ExplicitType>]
+        [UpdateMutationFnParams<ExplicitType>]
       >()
     }
 
     if (options.onDelete) {
       expectTypeOf(options.onDelete).parameters.toEqualTypeOf<
-        [MutationFnParams<ExplicitType>]
+        [DeleteMutationFnParams<ExplicitType>]
       >()
     }
   })

--- a/packages/db-collections/tests/query.test.ts
+++ b/packages/db-collections/tests/query.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { QueryClient } from "@tanstack/query-core"
 import { createCollection } from "@tanstack/db"
 import { queryCollectionOptions } from "../src/query"
-import type { MutationFnParams, Transaction } from "@tanstack/db"
+import type {
+  MutationFnParams,
+  Transaction,
+  TransactionWithMutations,
+} from "@tanstack/db"
 import type { QueryCollectionConfig } from "../src/query"
 
 interface TestItem {
@@ -423,8 +427,12 @@ describe(`QueryCollection`, () => {
       const queryFn = vi.fn().mockResolvedValue(items)
 
       // Create a mock transaction for testing
-      const mockTransaction = { id: `test-transaction` } as Transaction
-      const mockParams: MutationFnParams = { transaction: mockTransaction }
+      const mockTransaction = {
+        id: `test-transaction`,
+      } as Transaction<TestItem>
+      const mockParams: MutationFnParams<TestItem> = {
+        transaction: mockTransaction as TransactionWithMutations<TestItem>,
+      }
 
       // Create handlers
       const onInsert = vi.fn().mockResolvedValue(undefined)
@@ -457,8 +465,12 @@ describe(`QueryCollection`, () => {
 
     it(`should call refetch based on handler return value`, async () => {
       // Create a mock transaction for testing
-      const mockTransaction = { id: `test-transaction` } as Transaction
-      const mockParams: MutationFnParams = { transaction: mockTransaction }
+      const mockTransaction = {
+        id: `test-transaction`,
+      } as Transaction<TestItem>
+      const mockParams: MutationFnParams<TestItem> = {
+        transaction: mockTransaction as TransactionWithMutations<TestItem>,
+      }
 
       // Create handlers with different return values
       const onInsertDefault = vi.fn().mockResolvedValue(undefined) // Default behavior should refetch

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -8,14 +8,12 @@ import type {
   CollectionConfig,
   Fn,
   InsertConfig,
-  MutationFnParams,
   OperationConfig,
   OptimisticChangeMessage,
   PendingMutation,
   ResolveType,
   StandardSchema,
   Transaction as TransactionType,
-  TransactionWithMutations,
   UtilsRecord,
 } from "./types"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
@@ -789,11 +787,8 @@ export class CollectionImpl<
       // Create a new transaction with a mutation function that calls the onInsert handler
       const directOpTransaction = new Transaction<T>({
         mutationFn: async (params) => {
-          const insertParams = params as MutationFnParams<T> & {
-            transaction: TransactionWithMutations<T, `insert`>
-          }
           // Call the onInsert handler with the transaction
-          return this.config.onInsert!(insertParams)
+          return this.config.onInsert!(params)
         },
       })
 
@@ -1012,12 +1007,8 @@ export class CollectionImpl<
     // Create a new transaction with a mutation function that calls the onUpdate handler
     const directOpTransaction = new Transaction<T>({
       mutationFn: async (params) => {
-        const updateParams = params as MutationFnParams<T> & {
-          transaction: TransactionWithMutations<T, `update`>
-        }
-
         // Call the onUpdate handler with the transaction
-        return this.config.onUpdate!(updateParams)
+        return this.config.onUpdate!(params)
       },
     })
 
@@ -1110,12 +1101,8 @@ export class CollectionImpl<
     const directOpTransaction = new Transaction<T>({
       autoCommit: true,
       mutationFn: async (params) => {
-        const deleteParams = params as MutationFnParams<T> & {
-          transaction: TransactionWithMutations<T, `delete`>
-        }
-
         // Call the onDelete handler with the transaction
-        return this.config.onDelete!(deleteParams)
+        return this.config.onDelete!(params)
       },
     })
 

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -44,12 +44,34 @@ export interface Collection<
  * Creates a new Collection instance with the given configuration
  *
  * @template TExplicit - The explicit type of items in the collection (highest priority)
- * @template TSchema - The schema type for validation and type inference (second priority)
- * @template TFallback - The fallback type if no explicit or schema type is provided
  * @template TKey - The type of the key for the collection
  * @template TUtils - The utilities record type
+ * @template TSchema - The schema type for validation and type inference (second priority)
+ * @template TFallback - The fallback type if no explicit or schema type is provided
  * @param options - Collection options with optional utilities
  * @returns A new Collection with utilities exposed both at top level and under .utils
+ *
+ * @example
+ * // Using explicit type
+ * const todos = createCollection<Todo>({
+ *   getKey: (todo) => todo.id,
+ *   sync: { sync: () => {} }
+ * })
+ *
+ * // Using schema for type inference (preferred as it also gives you client side validation)
+ * const todoSchema = z.object({
+ *   id: z.string(),
+ *   title: z.string(),
+ *   completed: z.boolean()
+ * })
+ *
+ * const todos = createCollection({
+ *   schema: todoSchema,
+ *   getKey: (todo) => todo.id,
+ *   sync: { sync: () => {} }
+ * })
+ *
+ * // Note: You must provide either an explicit type or a schema, but not both
  */
 export function createCollection<
   TExplicit = unknown,

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -1060,6 +1060,11 @@ export class CollectionImpl<
     const mutations: Array<PendingMutation<T>> = []
 
     for (const key of keysArray) {
+      if (!this.has(key)) {
+        throw new Error(
+          `Collection.delete was called with key '${key}' but there is no item in the collection with this key`
+        )
+      }
       const globalKey = this.generateGlobalKey(key, this.get(key)!)
       const mutation: PendingMutation<T> = {
         mutationId: crypto.randomUUID(),

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -125,7 +125,7 @@ export class SchemaValidationError extends Error {
   ) {
     const defaultMessage = `${type === `insert` ? `Insert` : `Update`} validation failed: ${issues
       .map((issue) => `\n- ${issue.message} - path: ${issue.path}`)
-      .join(`\n`)}`
+      .join(``)}`
 
     super(message || defaultMessage)
     this.name = `SchemaValidationError`

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -124,8 +124,8 @@ export class SchemaValidationError extends Error {
     message?: string
   ) {
     const defaultMessage = `${type === `insert` ? `Insert` : `Update`} validation failed: ${issues
-      .map((issue) => issue.message)
-      .join(`, `)}`
+      .map((issue) => `\n- ${issue.message} - path: ${issue.path}`)
+      .join(`\n`)}`
 
     super(message || defaultMessage)
     this.name = `SchemaValidationError`

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -8,12 +8,14 @@ import type {
   CollectionConfig,
   Fn,
   InsertConfig,
+  MutationFnParams,
   OperationConfig,
   OptimisticChangeMessage,
   PendingMutation,
   ResolveType,
   StandardSchema,
   Transaction as TransactionType,
+  TransactionWithMutations,
   UtilsRecord,
 } from "./types"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
@@ -787,8 +789,11 @@ export class CollectionImpl<
       // Create a new transaction with a mutation function that calls the onInsert handler
       const directOpTransaction = new Transaction<T>({
         mutationFn: async (params) => {
+          const insertParams = params as MutationFnParams<T> & {
+            transaction: TransactionWithMutations<T, `insert`>
+          }
           // Call the onInsert handler with the transaction
-          return this.config.onInsert!(params)
+          return this.config.onInsert!(insertParams)
         },
       })
 
@@ -1007,8 +1012,12 @@ export class CollectionImpl<
     // Create a new transaction with a mutation function that calls the onUpdate handler
     const directOpTransaction = new Transaction<T>({
       mutationFn: async (params) => {
+        const updateParams = params as MutationFnParams<T> & {
+          transaction: TransactionWithMutations<T, `update`>
+        }
+
         // Call the onUpdate handler with the transaction
-        return this.config.onUpdate!(params)
+        return this.config.onUpdate!(updateParams)
       },
     })
 
@@ -1101,8 +1110,12 @@ export class CollectionImpl<
     const directOpTransaction = new Transaction<T>({
       autoCommit: true,
       mutationFn: async (params) => {
+        const deleteParams = params as MutationFnParams<T> & {
+          transaction: TransactionWithMutations<T, `delete`>
+        }
+
         // Call the onDelete handler with the transaction
-        return this.config.onDelete!(params)
+        return this.config.onDelete!(deleteParams)
       },
     })
 

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -965,9 +965,9 @@ export class CollectionImpl<
 
         return {
           mutationId: crypto.randomUUID(),
-          original: originalItem as Record<string, unknown>,
-          modified: modifiedItem as Record<string, unknown>,
-          changes: validatedUpdatePayload as Record<string, unknown>,
+          original: originalItem,
+          modified: modifiedItem,
+          changes: validatedUpdatePayload as Partial<T>,
           globalKey,
           key,
           metadata: config.metadata as unknown,
@@ -1063,9 +1063,9 @@ export class CollectionImpl<
       const globalKey = this.generateGlobalKey(key, this.get(key)!)
       const mutation: PendingMutation<T> = {
         mutationId: crypto.randomUUID(),
-        original: this.get(key) || {},
+        original: this.get(key)!,
         modified: this.get(key)!,
-        changes: this.get(key) || {},
+        changes: this.get(key)!,
         globalKey,
         key,
         metadata: config?.metadata as unknown,

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -743,7 +743,7 @@ export class CollectionImpl<
     }
 
     const items = Array.isArray(data) ? data : [data]
-    const mutations: Array<PendingMutation<T>> = []
+    const mutations: Array<PendingMutation<T, `insert`>> = []
 
     // Create mutations for each item
     items.forEach((item) => {
@@ -757,7 +757,7 @@ export class CollectionImpl<
       }
       const globalKey = this.generateGlobalKey(key, item)
 
-      const mutation: PendingMutation<T> = {
+      const mutation: PendingMutation<T, `insert`> = {
         mutationId: crypto.randomUUID(),
         original: {},
         modified: validatedData,
@@ -927,7 +927,7 @@ export class CollectionImpl<
     }
 
     // Create mutations for each object that has changes
-    const mutations: Array<PendingMutation<T>> = keysArray
+    const mutations: Array<PendingMutation<T, `update`>> = keysArray
       .map((key, index) => {
         const itemChanges = changesArray[index] // User-provided changes for this specific item
 
@@ -981,7 +981,7 @@ export class CollectionImpl<
           collection: this,
         }
       })
-      .filter(Boolean) as Array<PendingMutation<T>>
+      .filter(Boolean) as Array<PendingMutation<T, `update`>>
 
     // If no changes were made, return an empty transaction early
     if (mutations.length === 0) {
@@ -1057,7 +1057,7 @@ export class CollectionImpl<
     }
 
     const keysArray = Array.isArray(keys) ? keys : [keys]
-    const mutations: Array<PendingMutation<T>> = []
+    const mutations: Array<PendingMutation<T, `delete`>> = []
 
     for (const key of keysArray) {
       if (!this.has(key)) {
@@ -1066,7 +1066,7 @@ export class CollectionImpl<
         )
       }
       const globalKey = this.generateGlobalKey(key, this.get(key)!)
-      const mutation: PendingMutation<T> = {
+      const mutation: PendingMutation<T, `delete`> = {
         mutationId: crypto.randomUUID(),
         original: this.get(key)!,
         modified: this.get(key)!,

--- a/packages/db/src/query/compiled-query.ts
+++ b/packages/db/src/query/compiled-query.ts
@@ -83,8 +83,9 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
                   type: `insert`,
                 })
               } else if (
-                inserts >= deletes &&
-                collection.has(valueWithKey._key as string | number)
+                inserts > deletes ||
+                (inserts === deletes &&
+                  collection.has(valueWithKey._key as string | number))
               ) {
                 console.log(2)
                 write({

--- a/packages/db/src/query/compiled-query.ts
+++ b/packages/db/src/query/compiled-query.ts
@@ -43,7 +43,12 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
     )
 
     // Use TResults directly to ensure type compatibility
-    const sync: SyncConfig<TResults>[`sync`] = ({ begin, write, commit }) => {
+    const sync: SyncConfig<TResults>[`sync`] = ({
+      begin,
+      write,
+      commit,
+      collection,
+    }) => {
       compileQueryPipeline<IStreamBuilder<[unknown, TResults]>>(
         query,
         inputs
@@ -75,7 +80,10 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
                   value: valueWithKey,
                   type: `insert`,
                 })
-              } else if (inserts >= deletes) {
+              } else if (
+                inserts >= deletes &&
+                collection.has(valueWithKey._key as string | number)
+              ) {
                 write({
                   value: valueWithKey,
                   type: `update`,

--- a/packages/db/src/query/compiled-query.ts
+++ b/packages/db/src/query/compiled-query.ts
@@ -74,8 +74,10 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
             }, new Map<unknown, { deletes: number; inserts: number; value: TResults }>())
             .forEach((changes, rawKey) => {
               const { deletes, inserts, value } = changes
+              console.log({ deletes, inserts, value, _key: rawKey })
               const valueWithKey = { ...value, _key: rawKey }
               if (inserts && !deletes) {
+                console.log(1)
                 write({
                   value: valueWithKey,
                   type: `insert`,
@@ -84,16 +86,19 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
                 inserts >= deletes &&
                 collection.has(valueWithKey._key as string | number)
               ) {
+                console.log(2)
                 write({
                   value: valueWithKey,
                   type: `update`,
                 })
               } else if (deletes > 0) {
+                console.log(3)
                 write({
                   value: valueWithKey,
                   type: `delete`,
                 })
               }
+              console.log(4)
             })
           commit()
         })

--- a/packages/db/src/query/compiled-query.ts
+++ b/packages/db/src/query/compiled-query.ts
@@ -100,6 +100,10 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
                   value: valueWithKey,
                   type: `delete`,
                 })
+              } else {
+                throw new Error(
+                  `This should never happen ${JSON.stringify(changes)}`
+                )
               }
             })
           commit()

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -54,7 +54,7 @@ export type UtilsRecord = Record<string, Fn>
  */
 export interface PendingMutation<T extends object = Record<string, unknown>> {
   mutationId: string
-  original: T
+  original: T | {}
   modified: T
   changes: Partial<T>
   globalKey: string

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -189,6 +189,33 @@ export interface InsertConfig {
   metadata?: Record<string, unknown>
 }
 
+export type UpdateMutationFnParams<T extends object = Record<string, unknown>> =
+  {
+    transaction: TransactionWithMutations<T, `update`>
+  }
+
+export type InsertMutationFnParams<T extends object = Record<string, unknown>> =
+  {
+    transaction: TransactionWithMutations<T, `insert`>
+  }
+
+export type DeleteMutationFnParams<T extends object = Record<string, unknown>> =
+  {
+    transaction: TransactionWithMutations<T, `delete`>
+  }
+
+export type InsertMutationFn<T extends object = Record<string, unknown>> = (
+  params: InsertMutationFnParams<T>
+) => Promise<any>
+
+export type UpdateMutationFn<T extends object = Record<string, unknown>> = (
+  params: UpdateMutationFnParams<T>
+) => Promise<any>
+
+export type DeleteMutationFn<T extends object = Record<string, unknown>> = (
+  params: DeleteMutationFnParams<T>
+) => Promise<any>
+
 export interface CollectionConfig<
   T extends object = Record<string, unknown>,
   TKey extends string | number = string | number,
@@ -214,19 +241,19 @@ export interface CollectionConfig<
    * @param params Object containing transaction and mutation information
    * @returns Promise resolving to any value
    */
-  onInsert?: MutationFn<T>
+  onInsert?: InsertMutationFn<T>
   /**
    * Optional asynchronous handler function called before an update operation
    * @param params Object containing transaction and mutation information
    * @returns Promise resolving to any value
    */
-  onUpdate?: MutationFn<T>
+  onUpdate?: UpdateMutationFn<T>
   /**
    * Optional asynchronous handler function called before a delete operation
    * @param params Object containing transaction and mutation information
    * @returns Promise resolving to any value
    */
-  onDelete?: MutationFn<T>
+  onDelete?: DeleteMutationFn<T>
 }
 
 export type ChangesPayload<T extends object = Record<string, unknown>> = Array<

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -5,6 +5,8 @@ import type { Transaction } from "./transactions"
 
 /**
  * Helper type to extract the output type from a standard schema
+ *
+ * @internal This is used by the type resolution system
  */
 export type InferSchemaOutput<T> = T extends StandardSchemaV1
   ? StandardSchemaV1.InferOutput<T> extends object
@@ -17,6 +19,10 @@ export type InferSchemaOutput<T> = T extends StandardSchemaV1
  * 1. Explicit generic TExplicit (if not 'unknown')
  * 2. Schema output type (if schema provided)
  * 3. Fallback type TFallback
+ *
+ * @remarks
+ * This type is used internally to resolve the collection item type based on the provided generics and schema.
+ * Users should not need to use this type directly, but understanding the priority order helps when defining collections.
  */
 export type ResolveType<
   TExplicit,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -54,7 +54,7 @@ export type UtilsRecord = Record<string, Fn>
  */
 export interface PendingMutation<T extends object = Record<string, unknown>> {
   mutationId: string
-  original: Partial<T>
+  original: T
   modified: T
   changes: Partial<T>
   globalKey: string

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -59,7 +59,11 @@ export interface PendingMutation<
   mutationId: string
   original: TOperation extends `insert` ? {} : T
   modified: T
-  changes: TOperation extends `insert` ? T : Partial<T>
+  changes: TOperation extends `insert`
+    ? T
+    : TOperation extends `delete`
+      ? T
+      : Partial<T>
   globalKey: string
   key: any
   type: OperationType
@@ -92,8 +96,9 @@ export type NonEmptyArray<T> = [T, ...Array<T>]
  */
 export type TransactionWithMutations<
   T extends object = Record<string, unknown>,
+  TOperation extends OperationType = OperationType,
 > = Transaction<T> & {
-  mutations: NonEmptyArray<PendingMutation<T>>
+  mutations: NonEmptyArray<PendingMutation<T, TOperation>>
 }
 
 export interface TransactionConfig<T extends object = Record<string, unknown>> {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -52,11 +52,14 @@ export type UtilsRecord = Record<string, Fn>
  * Represents a pending mutation within a transaction
  * Contains information about the original and modified data, as well as metadata
  */
-export interface PendingMutation<T extends object = Record<string, unknown>> {
+export interface PendingMutation<
+  T extends object = Record<string, unknown>,
+  TOperation extends OperationType = OperationType,
+> {
   mutationId: string
-  original: T | {}
+  original: TOperation extends `insert` ? {} : T
   modified: T
-  changes: Partial<T>
+  changes: TOperation extends `insert` ? T : Partial<T>
   globalKey: string
   key: any
   type: OperationType

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -515,17 +515,11 @@ describe(`Collection`, () => {
     const tx1 = createTransaction({ mutationFn })
     tx1.mutate(() => collection.insert(item))
 
-    // Should not throw when trying to delete a non-existent ID
+    // Throw when trying to delete a non-existent ID
     const tx2 = createTransaction({ mutationFn })
     expect(() =>
       tx2.mutate(() => collection.delete(`non-existent-id`))
-    ).not.toThrow()
-
-    // Should not throw when deleting by string key (even if key doesn't exist)
-    const tx4 = createTransaction({ mutationFn })
-    expect(() =>
-      tx4.mutate(() => collection.delete(`non-existent-key`))
-    ).not.toThrow()
+    ).toThrow()
 
     // Should not throw when deleting by ID
     const tx5 = createTransaction({ mutationFn })
@@ -612,7 +606,7 @@ describe(`Collection`, () => {
     )
 
     // Test delete handler
-    tx.mutate(() => collection.delete(`1`)) // Convert number to string to match expected type
+    tx.mutate(() => collection.delete(1))
 
     // Verify the handler functions were defined correctly
     // We're not testing actual invocation since that would require modifying the Collection class
@@ -674,7 +668,7 @@ describe(`Collection`, () => {
     expect(onUpdateMock).toHaveBeenCalledTimes(1)
 
     // Test direct delete operation
-    const deleteTx = collection.delete(`1`) // Convert number to string to match expected type
+    const deleteTx = collection.delete(1)
     expect(deleteTx).toBeDefined()
     expect(onDeleteMock).toHaveBeenCalledTimes(1)
 

--- a/packages/db/tests/query/query-collection.test.ts
+++ b/packages/db/tests/query/query-collection.test.ts
@@ -258,12 +258,30 @@ describe(`Query Collections`, () => {
           id: `4`,
         },
       },
+      {
+        key: `5`,
+        type: `insert`,
+        changes: {
+          id: `5`,
+          name: `Kyle Doe5`,
+          age: 40,
+          email: `kyle.doe@example.com`,
+          isActive: true,
+        },
+      },
+      {
+        type: `update`,
+        changes: {
+          id: `5`,
+          name: `Kyle Doe 5`,
+        },
+      },
     ])
 
     await waitForChanges()
 
-    expect(result.state.size).toBe(3)
-    expect(result.asStoreArray().state.length).toBe(3)
+    expect(result.state.size).toBe(4)
+    expect(result.asStoreArray().state.length).toBe(4)
     expect(result.state.get(`4`)).toBeUndefined()
   })
 

--- a/packages/db/tests/query/query-collection.test.ts
+++ b/packages/db/tests/query/query-collection.test.ts
@@ -187,7 +187,7 @@ describe(`Query Collections`, () => {
     expect(result.state.get(`4`)).toBeUndefined()
   })
 
-  it(`should handle deletes`, async () => {
+  it(`should handle multiple operations corrrectly`, async () => {
     const emitter = mitt()
 
     // Create collection with mutation capability

--- a/packages/db/tests/query/query-collection.test.ts
+++ b/packages/db/tests/query/query-collection.test.ts
@@ -187,6 +187,86 @@ describe(`Query Collections`, () => {
     expect(result.state.get(`4`)).toBeUndefined()
   })
 
+  it(`should handle deletes`, async () => {
+    const emitter = mitt()
+
+    // Create collection with mutation capability
+    const collection = createCollection<Person>({
+      id: `optimistic-changes-test`,
+      getKey: (item) => item.id,
+      sync: {
+        sync: ({ begin, write, commit }) => {
+          // Listen for sync events
+          emitter.on(`sync`, (changes) => {
+            begin()
+            ;(changes as Array<PendingMutation>).forEach((change) => {
+              write({
+                type: change.type,
+                value: change.changes as Person,
+              })
+            })
+            commit()
+          })
+        },
+      },
+    })
+
+    // Sync from initial state
+    emitter.emit(
+      `sync`,
+      initialPersons.map((person) => ({
+        type: `insert`,
+        changes: person,
+      }))
+    )
+
+    const query = queryBuilder().from({ person: collection })
+
+    const compiledQuery = compileQuery(query)
+
+    compiledQuery.start()
+
+    const result = compiledQuery.results
+
+    expect(result.state.size).toBe(3)
+    expect(result.state.get(`3`)).toEqual({
+      _key: `3`,
+      age: 35,
+      email: `john.smith@example.com`,
+      id: `3`,
+      isActive: false,
+      name: `John Smith`,
+      createdAt: new Date(`2024-01-03`),
+    })
+
+    // Insert a new person and then delete it
+    emitter.emit(`sync`, [
+      {
+        key: `4`,
+        type: `insert`,
+        changes: {
+          id: `4`,
+          name: `Kyle Doe`,
+          age: 40,
+          email: `kyle.doe@example.com`,
+          isActive: true,
+        },
+      },
+      {
+        type: `delete`,
+        changes: {
+          id: `4`,
+        },
+      },
+    ])
+
+    await waitForChanges()
+
+    expect(result.state.size).toBe(3)
+    expect(result.asStoreArray().state.length).toBe(3)
+    expect(result.state.get(`4`)).toBeUndefined()
+  })
+
   it(`should be able to query a collection without a select using a callback for the where clause`, async () => {
     const emitter = mitt()
 
@@ -313,6 +393,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     expect(result.state.size).toBe(1)
+    expect(result.asStoreArray().state.length).toBe(1)
     expect(result.state.get(`4`)).toBeUndefined()
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
 
   packages/db-collections:
     dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@tanstack/db':
         specifier: workspace:*
         version: link:../db

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,6 @@ importers:
 
   packages/db-collections:
     dependencies:
-      '@standard-schema/spec':
-        specifier: ^1.0.0
-        version: 1.0.0
       '@tanstack/db':
         specifier: workspace:*
         version: link:../db


### PR DESCRIPTION
You now must either pass an explicit type or schema - passing both will conflict.

I also removed the broken `preloadCollection` so I didn't have to fix its types 😆 the plan is make collections lazy by default and expose a `.start()` method which returns a promise that resolves when the collection finishes loading.

Fix #116 #76