### PR TITLE
Modify `orderBy` to use a fractional index

### DIFF
--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -498,7 +498,10 @@ export class CollectionImpl<
     for (const key of this.keys()) {
       const value = this.get(key)
       if (value !== undefined) {
-        yield value
+        const { _orderByIndex, ...copy } = value as T & {
+          _orderByIndex?: number | string
+        }
+        yield copy as T
       }
     }
   }
@@ -510,7 +513,10 @@ export class CollectionImpl<
     for (const key of this.keys()) {
       const value = this.get(key)
       if (value !== undefined) {
-        yield [key, value]
+        const { _orderByIndex, ...copy } = value as T & {
+          _orderByIndex?: number | string
+        }
+        yield [key, copy as T]
       }
     }
   }

--- a/packages/db/src/query/compiled-query.ts
+++ b/packages/db/src/query/compiled-query.ts
@@ -114,10 +114,27 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
 
     this.graph = graph
     this.inputs = inputs
+
+    const compare = query.orderBy
+      ? (val1: TResults, val2: TResults) => {
+          // The query builder always adds an _orderByIndex property if the results are ordered
+          const x = val1 as TResults & { _orderByIndex: number }
+          const y = val2 as TResults & { _orderByIndex: number }
+          if (x._orderByIndex < y._orderByIndex) {
+            return -1
+          } else if (x._orderByIndex > y._orderByIndex) {
+            return 1
+          } else {
+            return 0
+          }
+        }
+      : undefined
+
     this.resultCollection = createCollection<TResults>({
       getKey: (val: unknown) => {
         return (val as any)._key
       },
+      compare,
       sync: {
         sync: sync as unknown as (params: {
           collection: Collection<

--- a/packages/db/src/query/compiled-query.ts
+++ b/packages/db/src/query/compiled-query.ts
@@ -1,6 +1,7 @@
 import { D2, MultiSet, output } from "@electric-sql/d2mini"
 import { createCollection } from "../collection.js"
 import { compileQueryPipeline } from "./pipeline-compiler.js"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
 import type { Collection } from "../collection.js"
 import type { ChangeMessage, ResolveType, SyncConfig } from "../types.js"
 import type {
@@ -116,7 +117,14 @@ export class CompiledQuery<TResults extends object = Record<string, unknown>> {
     this.inputs = inputs
 
     const compare = query.orderBy
-      ? (val1: TResults, val2: TResults) => {
+      ? (
+          val1: ResolveType<
+            TResults,
+            StandardSchemaV1,
+            Record<string, unknown>
+          >,
+          val2: ResolveType<TResults, StandardSchemaV1, Record<string, unknown>>
+        ): number => {
           // The query builder always adds an _orderByIndex property if the results are ordered
           const x = val1 as TResults & { _orderByIndex: number }
           const y = val2 as TResults & { _orderByIndex: number }

--- a/packages/db/src/query/query-builder.ts
+++ b/packages/db/src/query/query-builder.ts
@@ -268,7 +268,7 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
     // Ensure we have an orderByIndex in the select if we have an orderBy
     // This is required if select is called after orderBy
     if (this._query.orderBy) {
-      validatedSelects.push({ _orderByIndex: { ORDER_INDEX: `numeric` } })
+      validatedSelects.push({ _orderByIndex: { ORDER_INDEX: `fractional` } })
     }
 
     const newBuilder = new BaseQueryBuilder<TContext>(
@@ -735,7 +735,7 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
     // This is required if select is called before orderBy
     newBuilder.query.select = [
       ...(newBuilder.query.select ?? []),
-      { _orderByIndex: { ORDER_INDEX: `numeric` } },
+      { _orderByIndex: { ORDER_INDEX: `fractional` } },
     ]
 
     return newBuilder as QueryBuilder<TContext>

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -237,6 +237,17 @@ export interface CollectionConfig<
    */
   getKey: (item: T) => TKey
   /**
+   * Optional function to compare two items.
+   * This is used to order the items in the collection.
+   * @param x The first item to compare
+   * @param y The second item to compare
+   * @returns A number indicating the order of the items
+   * @example
+   * // For a collection with a 'createdAt' field
+   * compare: (x, y) => x.createdAt.getTime() - y.createdAt.getTime()
+   */
+  compare?: (x: T, y: T) => number
+  /**
    * Optional asynchronous handler function called before an insert operation
    * @param params Object containing transaction and mutation information
    * @returns Promise resolving to any value

--- a/packages/db/tests/collection-subscribe-changes.test.ts
+++ b/packages/db/tests/collection-subscribe-changes.test.ts
@@ -214,7 +214,7 @@ describe(`Collection.subscribeChanges`, () => {
     unsubscribe()
   })
 
-  it(`should emit changes from optimistic operations`, () => {
+  it(`should emit changes from optimistic operations`, async () => {
     const emitter = mitt()
     const callback = vi.fn()
 

--- a/packages/db/tests/query/query-builder/order-by.test.ts
+++ b/packages/db/tests/query/query-builder/order-by.test.ts
@@ -129,7 +129,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
         `@e.id`,
         `@e.name`,
         `@d.name`,
-        { _orderByIndex: { ORDER_INDEX: `numeric` } }, // Added by the orderBy method
+        { _orderByIndex: { ORDER_INDEX: `fractional` } }, // Added by the orderBy method
       ])
     })
   })

--- a/packages/db/tests/query/query-collection.test.ts
+++ b/packages/db/tests/query/query-collection.test.ts
@@ -837,11 +837,11 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify ascending order
-    const ascendingArray = Array.from(ascendingResult.toArray)
+    const ascendingArray = Array.from(ascendingResult.toArray).map(stripIndex)
     expect(ascendingArray).toEqual([
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 0 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 30, _orderByIndex: 1 },
-      { _key: `3`, id: `3`, name: `John Smith`, age: 35, _orderByIndex: 2 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
+      { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
     ])
 
     // Test descending order by age
@@ -858,11 +858,11 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify descending order
-    const descendingArray = Array.from(descendingResult.toArray)
+    const descendingArray = Array.from(descendingResult.toArray).map(stripIndex)
     expect(descendingArray).toEqual([
-      { _key: `3`, id: `3`, name: `John Smith`, age: 35, _orderByIndex: 0 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 30, _orderByIndex: 1 },
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 2 },
+      { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
     ])
 
     // Test descending order by name
@@ -879,11 +879,13 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify descending order by name
-    const descendingNameArray = Array.from(descendingNameResult.toArray)
+    const descendingNameArray = Array.from(descendingNameResult.toArray).map(
+      stripIndex
+    )
     expect(descendingNameArray).toEqual([
-      { _key: `3`, id: `3`, name: `John Smith`, age: 35, _orderByIndex: 0 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 30, _orderByIndex: 1 },
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 2 },
+      { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
     ])
 
     // Test reverse chronological order by createdAt
@@ -904,28 +906,25 @@ describe(`Query Collections`, () => {
     // Verify reverse chronological order
     const reverseChronologicalArray = Array.from(
       reverseChronologicalResult.toArray
-    )
+    ).map(stripIndex)
     expect(reverseChronologicalArray).toEqual([
       {
         _key: `3`,
         id: `3`,
         name: `John Smith`,
         createdAt: new Date(`2024-01-03`),
-        _orderByIndex: 0,
       },
       {
         _key: `1`,
         id: `1`,
         name: `John Doe`,
         createdAt: new Date(`2024-01-02`),
-        _orderByIndex: 1,
       },
       {
         _key: `2`,
         id: `2`,
         name: `Jane Doe`,
         createdAt: new Date(`2024-01-01`),
-        _orderByIndex: 2,
       },
     ])
 
@@ -943,7 +942,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify multiple field ordering
-    const multiOrderArray = Array.from(multiOrderResult.toArray)
+    const multiOrderArray = Array.from(multiOrderResult.toArray).map(stripIndex)
     expect(multiOrderArray).toEqual([
       {
         _key: `3`,
@@ -951,7 +950,6 @@ describe(`Query Collections`, () => {
         name: `John Smith`,
         age: 35,
         isActive: false,
-        _orderByIndex: 0,
       },
       {
         _key: `1`,
@@ -959,7 +957,6 @@ describe(`Query Collections`, () => {
         name: `John Doe`,
         age: 30,
         isActive: true,
-        _orderByIndex: 1,
       },
       {
         _key: `2`,
@@ -967,7 +964,6 @@ describe(`Query Collections`, () => {
         name: `Jane Doe`,
         age: 25,
         isActive: true,
-        _orderByIndex: 2,
       },
     ])
   })
@@ -1016,11 +1012,11 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify initial ordering
-    let currentOrder = Array.from(compiledQuery.results.toArray)
+    let currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 0 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 30, _orderByIndex: 1 },
-      { _key: `3`, id: `3`, name: `John Smith`, age: 35, _orderByIndex: 2 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
+      { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
     ])
 
     // Add a new person with the youngest age
@@ -1040,12 +1036,12 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with the new person at the beginning
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
-      { _key: `4`, id: `4`, name: `Alice Young`, age: 22, _orderByIndex: 0 },
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 1 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 30, _orderByIndex: 2 },
-      { _key: `3`, id: `3`, name: `John Smith`, age: 35, _orderByIndex: 3 },
+      { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
+      { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
     ])
 
     // Update a person's age to move them in the ordering
@@ -1062,12 +1058,12 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with John Doe now at the end
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
-      { _key: `4`, id: `4`, name: `Alice Young`, age: 22, _orderByIndex: 0 },
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 1 },
-      { _key: `3`, id: `3`, name: `John Smith`, age: 35, _orderByIndex: 2 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 40, _orderByIndex: 3 },
+      { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
+      { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 40 },
     ])
 
     // Add a new person with age null
@@ -1087,13 +1083,13 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with Bob Null at the end
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
-      { _key: `5`, id: `5`, name: `Bob Null`, age: null, _orderByIndex: 0 },
-      { _key: `4`, id: `4`, name: `Alice Young`, age: 22, _orderByIndex: 1 },
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 2 },
-      { _key: `3`, id: `3`, name: `John Smith`, age: 35, _orderByIndex: 3 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 40, _orderByIndex: 4 },
+      { _key: `5`, id: `5`, name: `Bob Null`, age: null },
+      { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
+      { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 40 },
     ])
 
     // Delete a person in the middle of the ordering
@@ -1107,12 +1103,12 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with John Smith removed
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
-      { _key: `5`, id: `5`, name: `Bob Null`, age: null, _orderByIndex: 0 },
-      { _key: `4`, id: `4`, name: `Alice Young`, age: 22, _orderByIndex: 1 },
-      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25, _orderByIndex: 2 },
-      { _key: `1`, id: `1`, name: `John Doe`, age: 40, _orderByIndex: 3 },
+      { _key: `5`, id: `5`, name: `Bob Null`, age: null },
+      { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
+      { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
+      { _key: `1`, id: `1`, name: `John Doe`, age: 40 },
     ])
   })
 
@@ -1390,4 +1386,11 @@ describe(`Query Collections`, () => {
 
 async function waitForChanges(ms = 0) {
   await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function stripIndex<T>(v: T): T {
+  const { _orderByIndex, ...copy } = v as T & {
+    _orderByIndex?: number | string
+  }
+  return copy as T
 }

--- a/packages/db/tests/query/query-collection.test.ts
+++ b/packages/db/tests/query/query-collection.test.ts
@@ -837,7 +837,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify ascending order
-    const ascendingArray = Array.from(ascendingResult.toArray).map(stripIndex)
+    const ascendingArray = Array.from(ascendingResult.toArray)
     expect(ascendingArray).toEqual([
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -858,7 +858,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify descending order
-    const descendingArray = Array.from(descendingResult.toArray).map(stripIndex)
+    const descendingArray = Array.from(descendingResult.toArray)
     expect(descendingArray).toEqual([
       { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -879,9 +879,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify descending order by name
-    const descendingNameArray = Array.from(descendingNameResult.toArray).map(
-      stripIndex
-    )
+    const descendingNameArray = Array.from(descendingNameResult.toArray)
     expect(descendingNameArray).toEqual([
       { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -906,7 +904,7 @@ describe(`Query Collections`, () => {
     // Verify reverse chronological order
     const reverseChronologicalArray = Array.from(
       reverseChronologicalResult.toArray
-    ).map(stripIndex)
+    )
     expect(reverseChronologicalArray).toEqual([
       {
         _key: `3`,
@@ -942,7 +940,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify multiple field ordering
-    const multiOrderArray = Array.from(multiOrderResult.toArray).map(stripIndex)
+    const multiOrderArray = Array.from(multiOrderResult.toArray)
     expect(multiOrderArray).toEqual([
       {
         _key: `3`,
@@ -1012,7 +1010,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify initial ordering
-    let currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
+    let currentOrder = Array.from(compiledQuery.results.toArray)
     expect(currentOrder).toEqual([
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -1036,7 +1034,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with the new person at the beginning
-    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
+    currentOrder = Array.from(compiledQuery.results.toArray)
     expect(currentOrder).toEqual([
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
@@ -1058,7 +1056,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with John Doe now at the end
-    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
+    currentOrder = Array.from(compiledQuery.results.toArray)
     expect(currentOrder).toEqual([
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
@@ -1083,7 +1081,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with Bob Null at the end
-    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
+    currentOrder = Array.from(compiledQuery.results.toArray)
     expect(currentOrder).toEqual([
       { _key: `5`, id: `5`, name: `Bob Null`, age: null },
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
@@ -1103,7 +1101,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with John Smith removed
-    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
+    currentOrder = Array.from(compiledQuery.results.toArray)
     expect(currentOrder).toEqual([
       { _key: `5`, id: `5`, name: `Bob Null`, age: null },
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
@@ -1386,11 +1384,4 @@ describe(`Query Collections`, () => {
 
 async function waitForChanges(ms = 0) {
   await new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-function stripIndex<T>(v: T): T {
-  const { _orderByIndex, ...copy } = v as T & {
-    _orderByIndex?: number | string
-  }
-  return copy as T
 }

--- a/packages/db/tests/query/query-collection.test.ts
+++ b/packages/db/tests/query/query-collection.test.ts
@@ -837,7 +837,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify ascending order
-    const ascendingArray = Array.from(ascendingResult.toArray)
+    const ascendingArray = Array.from(ascendingResult.toArray).map(stripIndex)
     expect(ascendingArray).toEqual([
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -858,7 +858,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify descending order
-    const descendingArray = Array.from(descendingResult.toArray)
+    const descendingArray = Array.from(descendingResult.toArray).map(stripIndex)
     expect(descendingArray).toEqual([
       { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -879,7 +879,9 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify descending order by name
-    const descendingNameArray = Array.from(descendingNameResult.toArray)
+    const descendingNameArray = Array.from(descendingNameResult.toArray).map(
+      stripIndex
+    )
     expect(descendingNameArray).toEqual([
       { _key: `3`, id: `3`, name: `John Smith`, age: 35 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -904,7 +906,7 @@ describe(`Query Collections`, () => {
     // Verify reverse chronological order
     const reverseChronologicalArray = Array.from(
       reverseChronologicalResult.toArray
-    )
+    ).map(stripIndex)
     expect(reverseChronologicalArray).toEqual([
       {
         _key: `3`,
@@ -940,7 +942,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify multiple field ordering
-    const multiOrderArray = Array.from(multiOrderResult.toArray)
+    const multiOrderArray = Array.from(multiOrderResult.toArray).map(stripIndex)
     expect(multiOrderArray).toEqual([
       {
         _key: `3`,
@@ -1010,7 +1012,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify initial ordering
-    let currentOrder = Array.from(compiledQuery.results.toArray)
+    let currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
       { _key: `1`, id: `1`, name: `John Doe`, age: 30 },
@@ -1034,7 +1036,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with the new person at the beginning
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
@@ -1056,7 +1058,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with John Doe now at the end
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
       { _key: `2`, id: `2`, name: `Jane Doe`, age: 25 },
@@ -1081,7 +1083,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with Bob Null at the end
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
       { _key: `5`, id: `5`, name: `Bob Null`, age: null },
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
@@ -1101,7 +1103,7 @@ describe(`Query Collections`, () => {
     await waitForChanges()
 
     // Verify order is updated with John Smith removed
-    currentOrder = Array.from(compiledQuery.results.toArray)
+    currentOrder = Array.from(compiledQuery.results.toArray).map(stripIndex)
     expect(currentOrder).toEqual([
       { _key: `5`, id: `5`, name: `Bob Null`, age: null },
       { _key: `4`, id: `4`, name: `Alice Young`, age: 22 },
@@ -1384,4 +1386,11 @@ describe(`Query Collections`, () => {
 
 async function waitForChanges(ms = 0) {
   await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function stripIndex<T>(v: T): T {
+  const { _orderByIndex, ...copy } = v as T & {
+    _orderByIndex?: number | string
+  }
+  return copy as T
 }

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -124,18 +124,18 @@ describe(`Query Collections`, () => {
     expect(result.current.state.size).toBe(1)
     expect(result.current.state.get(`3`)).toEqual({
       _key: `3`,
-      _orderByIndex: 0,
       id: `3`,
       name: `John Smith`,
     })
 
     expect(result.current.data.length).toBe(1)
-    expect(result.current.data[0]).toEqual({
-      _key: `3`,
-      _orderByIndex: 0,
-      id: `3`,
-      name: `John Smith`,
-    })
+    expect(result.current.data).toEqual([
+      {
+        _key: `3`,
+        id: `3`,
+        name: `John Smith`,
+      },
+    ])
 
     // Insert a new person
     act(() => {
@@ -158,30 +158,28 @@ describe(`Query Collections`, () => {
     expect(result.current.state.size).toBe(2)
     expect(result.current.state.get(`3`)).toEqual({
       _key: `3`,
-      _orderByIndex: 0,
       id: `3`,
       name: `John Smith`,
     })
     expect(result.current.state.get(`4`)).toEqual({
       _key: `4`,
-      _orderByIndex: 1,
       id: `4`,
       name: `Kyle Doe`,
     })
 
     expect(result.current.data.length).toBe(2)
-    expect(result.current.data).toContainEqual({
-      _key: `3`,
-      _orderByIndex: 0,
-      id: `3`,
-      name: `John Smith`,
-    })
-    expect(result.current.data).toContainEqual({
-      _key: `4`,
-      _orderByIndex: 1,
-      id: `4`,
-      name: `Kyle Doe`,
-    })
+    expect(result.current.data).toEqual([
+      {
+        _key: `3`,
+        id: `3`,
+        name: `John Smith`,
+      },
+      {
+        _key: `4`,
+        id: `4`,
+        name: `Kyle Doe`,
+      },
+    ])
 
     // Update the person
     act(() => {
@@ -201,18 +199,23 @@ describe(`Query Collections`, () => {
     expect(result.current.state.size).toBe(2)
     expect(result.current.state.get(`4`)).toEqual({
       _key: `4`,
-      _orderByIndex: 1,
       id: `4`,
       name: `Kyle Doe 2`,
     })
 
     expect(result.current.data.length).toBe(2)
-    expect(result.current.data).toContainEqual({
-      _key: `4`,
-      _orderByIndex: 1,
-      id: `4`,
-      name: `Kyle Doe 2`,
-    })
+    expect(result.current.data).toEqual([
+      {
+        _key: `3`,
+        id: `3`,
+        name: `John Smith`,
+      },
+      {
+        _key: `4`,
+        id: `4`,
+        name: `Kyle Doe 2`,
+      },
+    ])
 
     // Delete the person
     act(() => {
@@ -232,12 +235,13 @@ describe(`Query Collections`, () => {
     expect(result.current.state.get(`4`)).toBeUndefined()
 
     expect(result.current.data.length).toBe(1)
-    expect(result.current.data).toContainEqual({
-      _key: `3`,
-      _orderByIndex: 0,
-      id: `3`,
-      name: `John Smith`,
-    })
+    expect(result.current.data).toEqual([
+      {
+        _key: `3`,
+        id: `3`,
+        name: `John Smith`,
+      },
+    ])
   })
 
   it(`should join collections and return combined results`, async () => {

--- a/packages/vue-db/tests/useLiveQuery.test.ts
+++ b/packages/vue-db/tests/useLiveQuery.test.ts
@@ -120,19 +120,19 @@ describe(`Query Collections`, () => {
 
     expect(state.value.size).toBe(1)
     expect(state.value.get(`3`)).toEqual({
-      _orderByIndex: 0,
       id: `3`,
       _key: `3`,
       name: `John Smith`,
     })
 
     expect(data.value.length).toBe(1)
-    expect(data.value[0]).toEqual({
-      _orderByIndex: 0,
-      id: `3`,
-      _key: `3`,
-      name: `John Smith`,
-    })
+    expect(data.value).toEqual([
+      {
+        id: `3`,
+        _key: `3`,
+        name: `John Smith`,
+      },
+    ])
 
     // Insert a new person
     emitter.emit(`sync`, [
@@ -152,31 +152,29 @@ describe(`Query Collections`, () => {
 
     expect(state.value.size).toBe(2)
     expect(state.value.get(`3`)).toEqual({
-      _orderByIndex: 0,
       id: `3`,
       _key: `3`,
       name: `John Smith`,
     })
     expect(state.value.get(`4`)).toEqual({
-      _orderByIndex: 1,
       id: `4`,
       _key: `4`,
       name: `Kyle Doe`,
     })
 
     expect(data.value.length).toBe(2)
-    expect(data.value).toContainEqual({
-      _orderByIndex: 0,
-      id: `3`,
-      _key: `3`,
-      name: `John Smith`,
-    })
-    expect(data.value).toContainEqual({
-      _orderByIndex: 1,
-      id: `4`,
-      _key: `4`,
-      name: `Kyle Doe`,
-    })
+    expect(data.value).toEqual([
+      {
+        id: `3`,
+        _key: `3`,
+        name: `John Smith`,
+      },
+      {
+        id: `4`,
+        _key: `4`,
+        name: `Kyle Doe`,
+      },
+    ])
 
     // Update the person
     emitter.emit(`sync`, [
@@ -193,19 +191,24 @@ describe(`Query Collections`, () => {
 
     expect(state.value.size).toBe(2)
     expect(state.value.get(`4`)).toEqual({
-      _orderByIndex: 1,
       id: `4`,
       _key: `4`,
       name: `Kyle Doe 2`,
     })
 
     expect(data.value.length).toBe(2)
-    expect(data.value).toContainEqual({
-      _orderByIndex: 1,
-      id: `4`,
-      _key: `4`,
-      name: `Kyle Doe 2`,
-    })
+    expect(data.value).toEqual([
+      {
+        id: `3`,
+        _key: `3`,
+        name: `John Smith`,
+      },
+      {
+        id: `4`,
+        _key: `4`,
+        name: `Kyle Doe 2`,
+      },
+    ])
 
     // Delete the person
     emitter.emit(`sync`, [
@@ -223,12 +226,13 @@ describe(`Query Collections`, () => {
     expect(state.value.get(`4`)).toBeUndefined()
 
     expect(data.value.length).toBe(1)
-    expect(data.value).toContainEqual({
-      _orderByIndex: 0,
-      id: `3`,
-      _key: `3`,
-      name: `John Smith`,
-    })
+    expect(data.value).toEqual([
+      {
+        id: `3`,
+        _key: `3`,
+        name: `John Smith`,
+      },
+    ])
   })
 
   it(`should join collections and return combined results`, async () => {


### PR DESCRIPTION
This PR modifies the collection's `orderBy` method to use a fractional index which is more efficient than the numeric index. I also modified the collection such that it internally keeps a sorted map of key-value pairs (`public syncedData: Map<TKey, T> | SortedMap<TKey, T>`) when the query results are ordered. I modified the `SortedMap` implementation to use binary search for finding the insert position instead of appending and re-sorting the array on each insert. For delete, we also use binary search instead of doing a linear search.