### PR TITLE
collections: export QueryCollectionUtils.

### DIFF
--- a/packages/db-collections/src/index.ts
+++ b/packages/db-collections/src/index.ts
@@ -3,4 +3,8 @@ export {
   type ElectricCollectionConfig,
   type ElectricCollectionUtils,
 } from "./electric"
-export { queryCollectionOptions, type QueryCollectionConfig } from "./query"
+export {
+  queryCollectionOptions,
+  type QueryCollectionConfig,
+  type QueryCollectionUtils,
+} from "./query"


### PR DESCRIPTION
Currently the ElectricCollectionUtils are exported but the QueryCollectionUtils aren't.

This PR also exports the `QueryCollectionUtils` so you can use them in your collection definition for type safe `utils.refetch()` usage.