### PR TITLE
Some minor drive-by fixes and cleanups for the electric collection.

### DIFF
--- a/packages/db-collections/src/electric.ts
+++ b/packages/db-collections/src/electric.ts
@@ -198,14 +198,18 @@ export function electricCollectionOptions<
           ResolveType<TExplicit, TSchema, TFallback>
         >
       ) => {
-        const handlerResult = await config.onInsert!(params)
-        if (!handlerResult.txid) {
+        // Runtime check (that doesn't follow type)
+        // eslint-disable-next-line
+        const handlerResult = (await config.onInsert!(params)) ?? {}
+        const txid = (handlerResult as { txid?: string }).txid
+
+        if (!txid) {
           throw new Error(
             `Electric collection onInsert handler must return a txid`
           )
         }
 
-        await awaitTxId(handlerResult.txid)
+        await awaitTxId(txid)
         return handlerResult
       }
     : undefined
@@ -216,14 +220,18 @@ export function electricCollectionOptions<
           ResolveType<TExplicit, TSchema, TFallback>
         >
       ) => {
-        const handlerResult = await config.onUpdate!(params)
-        if (!handlerResult.txid) {
+        // Runtime check (that doesn't follow type)
+        // eslint-disable-next-line
+        const handlerResult = (await config.onUpdate!(params)) ?? {}
+        const txid = (handlerResult as { txid?: string }).txid
+
+        if (!txid) {
           throw new Error(
             `Electric collection onUpdate handler must return a txid`
           )
         }
 
-        await awaitTxId(handlerResult.txid)
+        await awaitTxId(txid)
         return handlerResult
       }
     : undefined
@@ -343,7 +351,7 @@ function createElectricSync<T extends Row<unknown>>(
 
             write({
               type: message.headers.operation,
-              value: message.value as T,
+              value: message.value,
               // Include the primary key and relation info in the metadata
               metadata: {
                 ...message.headers,

--- a/packages/db-collections/tests/electric.test.ts
+++ b/packages/db-collections/tests/electric.test.ts
@@ -662,7 +662,7 @@ describe(`Electric Integration`, () => {
           value: { id: 1, name: `Test` },
           headers: {
             operation: `insert`,
-            txids: [100, 200],
+            txids: [`100`, `200`],
           },
         },
         {
@@ -959,7 +959,7 @@ describe(`Electric Integration`, () => {
         {
           headers: {
             control: `up-to-date`,
-            txids: [300, 400],
+            txids: [`300`, `400`],
           },
         },
       ])


### PR DESCRIPTION
After studying the electric integration for my TrailBase integration, I did some playing around and cleaning to further my own understanding. This change should pretty much be a noop.

I'm still wondering if `seenTxids` is a memory leak.