### PR TITLE
WIP functional variants of the select, where and having query builder methods

### DIFF
--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -17,9 +17,9 @@ export interface Query {
   offset?: Offset
 
   // Functional variants
-  fnSelect: (row: NamespacedRow) => any
-  fnWhere: Array<(row: NamespacedRow) => any>
-  fnHaving: Array<(row: NamespacedRow) => any>
+  fnSelect?: (row: NamespacedRow) => any
+  fnWhere?: Array<(row: NamespacedRow) => any>
+  fnHaving?: Array<(row: NamespacedRow) => any>
 }
 
 export type From = CollectionRef | QueryRef

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -3,6 +3,7 @@ This is the intermediate representation of the query.
 */
 
 import type { CollectionImpl } from "../collection"
+import type { NamespacedRow } from "../types"
 
 export interface Query {
   from: From
@@ -14,6 +15,11 @@ export interface Query {
   orderBy?: OrderBy
   limit?: Limit
   offset?: Offset
+
+  // Functional variants
+  fnSelect: (row: NamespacedRow) => any
+  fnWhere: Array<(row: NamespacedRow) => any>
+  fnHaving: Array<(row: NamespacedRow) => any>
 }
 
 export type From = CollectionRef | QueryRef

--- a/packages/db/tests/query/builder/functional-variants.test.ts
+++ b/packages/db/tests/query/builder/functional-variants.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "vitest"
+import { CollectionImpl } from "../../../src/collection.js"
+import { BaseQueryBuilder, getQuery } from "../../../src/query/builder/index.js"
+import { eq, gt } from "../../../src/query/builder/functions.js"
+
+// Test schema
+interface Employee {
+  id: number
+  name: string
+  department_id: number | null
+  salary: number
+  active: boolean
+}
+
+interface Department {
+  id: number
+  name: string
+}
+
+// Test collections
+const employeesCollection = new CollectionImpl<Employee>({
+  id: `employees`,
+  getKey: (item) => item.id,
+  sync: { sync: () => {} },
+})
+
+const departmentsCollection = new CollectionImpl<Department>({
+  id: `departments`,
+  getKey: (item) => item.id,
+  sync: { sync: () => {} },
+})
+
+describe(`QueryBuilder functional variants (fn)`, () => {
+  describe(`fn.select`, () => {
+    it(`sets fnSelect function and removes regular select`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .select(({ employees }) => ({ id: employees.id })) // This should be removed
+        .fn.select((row) => ({ customName: row.employees.name.toUpperCase() }))
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnSelect).toBeDefined()
+      expect(typeof builtQuery.fnSelect).toBe(`function`)
+      expect(builtQuery.select).toBeUndefined() // Regular select should be removed
+    })
+
+    it(`works without previous select clause`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .fn.select((row) => row.employees.name)
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnSelect).toBeDefined()
+      expect(typeof builtQuery.fnSelect).toBe(`function`)
+      expect(builtQuery.select).toBeUndefined()
+    })
+
+    it(`supports complex transformations`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .fn.select((row) => ({
+          displayName: `${row.employees.name} (ID: ${row.employees.id})`,
+          salaryTier: row.employees.salary > 75000 ? `high` : `low`,
+          isActiveDepartment:
+            row.employees.department_id !== null && row.employees.active,
+        }))
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnSelect).toBeDefined()
+    })
+
+    it(`works with joins`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+        .fn.select((row) => ({
+          employeeName: row.employees.name,
+          departmentName: row.departments?.name || `No Department`,
+        }))
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnSelect).toBeDefined()
+    })
+  })
+
+  describe(`fn.where`, () => {
+    it(`adds to fnWhere array`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .fn.where((row) => row.employees.active)
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnWhere).toBeDefined()
+      expect(Array.isArray(builtQuery.fnWhere)).toBe(true)
+      expect(builtQuery.fnWhere).toHaveLength(1)
+      expect(typeof builtQuery.fnWhere![0]).toBe(`function`)
+    })
+
+    it(`accumulates multiple fn.where calls`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .fn.where((row) => row.employees.active)
+        .fn.where((row) => row.employees.salary > 50000)
+        .fn.where((row) => row.employees.name.includes(`John`))
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnWhere).toBeDefined()
+      expect(builtQuery.fnWhere).toHaveLength(3)
+    })
+
+    it(`works alongside regular where clause`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .where(({ employees }) => gt(employees.id, 0)) // Regular where
+        .fn.where((row) => row.employees.active) // Functional where
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.where).toBeDefined() // Regular where still exists
+      expect(builtQuery.fnWhere).toBeDefined()
+      expect(builtQuery.fnWhere).toHaveLength(1)
+    })
+
+    it(`supports complex conditions`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .fn.where(
+          (row) =>
+            row.employees.active &&
+            row.employees.salary > 60000 &&
+            (row.employees.department_id === 1 ||
+              row.employees.department_id === 2)
+        )
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnWhere).toHaveLength(1)
+    })
+
+    it(`works with joins`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+        .fn.where(
+          (row) =>
+            row.employees.active &&
+            row.departments !== undefined &&
+            row.departments.name !== `HR`
+        )
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnWhere).toHaveLength(1)
+    })
+  })
+
+  describe(`fn.having`, () => {
+    it(`adds to fnHaving array`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .groupBy(({ employees }) => employees.department_id)
+        .fn.having((row) => row.employees.salary > 50000)
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnHaving).toBeDefined()
+      expect(Array.isArray(builtQuery.fnHaving)).toBe(true)
+      expect(builtQuery.fnHaving).toHaveLength(1)
+      expect(typeof builtQuery.fnHaving![0]).toBe(`function`)
+    })
+
+    it(`accumulates multiple fn.having calls`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .groupBy(({ employees }) => employees.department_id)
+        .fn.having((row) => row.employees.active)
+        .fn.having((row) => row.employees.salary > 50000)
+        .fn.having((row) => row.employees.name.length > 3)
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnHaving).toBeDefined()
+      expect(builtQuery.fnHaving).toHaveLength(3)
+    })
+
+    it(`works alongside regular having clause`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .groupBy(({ employees }) => employees.department_id)
+        .having(({ employees }) => gt(employees.id, 0)) // Regular having
+        .fn.having((row) => row.employees.active) // Functional having
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.having).toBeDefined() // Regular having still exists
+      expect(builtQuery.fnHaving).toBeDefined()
+      expect(builtQuery.fnHaving).toHaveLength(1)
+    })
+
+    it(`supports complex aggregation conditions`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .groupBy(({ employees }) => employees.department_id)
+        .fn.having((row) => {
+          // Complex condition involving grouped data
+          const avgSalary = row.employees.salary // In real usage, this would be computed from grouped data
+          return avgSalary > 70000 && row.employees.active
+        })
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnHaving).toHaveLength(1)
+    })
+
+    it(`works with joins and grouping`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+        .groupBy(({ departments }) => departments.name)
+        .fn.having(
+          (row) =>
+            row.employees.salary > 60000 &&
+            row.departments !== undefined &&
+            row.departments.name !== `Temp`
+        )
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnHaving).toHaveLength(1)
+    })
+  })
+
+  describe(`combinations`, () => {
+    it(`supports all functional variants together`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+        .fn.where((row) => row.employees.active)
+        .fn.where((row) => row.employees.salary > 40000)
+        .groupBy(({ departments }) => departments.name)
+        .fn.having((row) => row.employees.salary > 70000)
+        .fn.select((row) => ({
+          departmentName: row.departments?.name || `Unknown`,
+          employeeInfo: `${row.employees.name} - $${row.employees.salary}`,
+          isHighEarner: row.employees.salary > 80000,
+        }))
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.fnWhere).toHaveLength(2)
+      expect(builtQuery.fnHaving).toHaveLength(1)
+      expect(builtQuery.fnSelect).toBeDefined()
+      expect(builtQuery.select).toBeUndefined() // Regular select should be removed
+    })
+
+    it(`works with regular clauses mixed in`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .where(({ employees }) => gt(employees.id, 0)) // Regular where
+        .fn.where((row) => row.employees.active) // Functional where
+        .select(({ employees }) => ({ id: employees.id })) // Regular select (will be removed)
+        .fn.select((row) => ({ name: row.employees.name })) // Functional select
+
+      const builtQuery = getQuery(query)
+      expect(builtQuery.where).toBeDefined()
+      expect(builtQuery.fnWhere).toHaveLength(1)
+      expect(builtQuery.select).toBeUndefined() // Should be removed by fn.select
+      expect(builtQuery.fnSelect).toBeDefined()
+    })
+  })
+
+  describe(`error handling`, () => {
+    it(`maintains query validity with functional variants`, () => {
+      const builder = new BaseQueryBuilder()
+
+      // Should not throw when building query with functional variants
+      expect(() => {
+        const query = builder
+          .from({ employees: employeesCollection })
+          .fn.where((row) => row.employees.active)
+          .fn.select((row) => row.employees.name)
+
+        getQuery(query)
+      }).not.toThrow()
+    })
+
+    it(`allows empty functional variant arrays`, () => {
+      const builder = new BaseQueryBuilder()
+      const query = builder.from({ employees: employeesCollection })
+
+      const builtQuery = getQuery(query)
+      // These should be undefined/empty when no functional variants are used
+      expect(builtQuery.fnWhere).toBeUndefined()
+      expect(builtQuery.fnHaving).toBeUndefined()
+      expect(builtQuery.fnSelect).toBeUndefined()
+    })
+  })
+})

--- a/packages/db/tests/query/functional-variants.test-d.ts
+++ b/packages/db/tests/query/functional-variants.test-d.ts
@@ -1,0 +1,471 @@
+import { describe, expectTypeOf, test } from "vitest"
+import {
+  count,
+  createLiveQueryCollection,
+  eq,
+  gt,
+} from "../../src/query/index.js"
+import { createCollection } from "../../src/collection.js"
+import { mockSyncCollectionOptions } from "../utls.js"
+
+// Sample user type for tests
+type User = {
+  id: number
+  name: string
+  age: number
+  email: string
+  active: boolean
+  department_id: number | null
+  salary: number
+}
+
+type Department = {
+  id: number
+  name: string
+}
+
+// Sample data for tests
+const sampleUsers: Array<User> = [
+  {
+    id: 1,
+    name: `Alice`,
+    age: 25,
+    email: `alice@example.com`,
+    active: true,
+    department_id: 1,
+    salary: 75000,
+  },
+  {
+    id: 2,
+    name: `Bob`,
+    age: 19,
+    email: `bob@example.com`,
+    active: true,
+    department_id: 1,
+    salary: 45000,
+  },
+]
+
+const sampleDepartments: Array<Department> = [
+  { id: 1, name: `Engineering` },
+  { id: 2, name: `Marketing` },
+]
+
+function createUsersCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<User>({
+      id: `test-users`,
+      getKey: (user) => user.id,
+      initialData: sampleUsers,
+    })
+  )
+}
+
+function createDepartmentsCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<Department>({
+      id: `test-departments`,
+      getKey: (dept) => dept.id,
+      initialData: sampleDepartments,
+    })
+  )
+}
+
+describe(`Functional Variants Types`, () => {
+  const usersCollection = createUsersCollection()
+  const departmentsCollection = createDepartmentsCollection()
+
+  test(`fn.select return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q.from({ user: usersCollection }).fn.select((row) => ({
+          displayName: `${row.user.name} (${row.user.id})`,
+          salaryTier:
+            row.user.salary > 60000 ? (`senior` as const) : (`junior` as const),
+          emailDomain: row.user.email.split(`@`)[1]!,
+        })),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        displayName: string
+        salaryTier: `senior` | `junior`
+        emailDomain: string
+      }>
+    >()
+  })
+
+  test(`fn.select with complex transformation return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q.from({ user: usersCollection }).fn.select((row) => {
+          const salaryGrade =
+            row.user.salary > 80000
+              ? (`A` as const)
+              : row.user.salary > 60000
+                ? (`B` as const)
+                : (`C` as const)
+          return {
+            profile: {
+              name: row.user.name,
+              age: row.user.age,
+            },
+            compensation: {
+              salary: row.user.salary,
+              grade: salaryGrade,
+              bonus_eligible: salaryGrade === `A`,
+            },
+          }
+        }),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        profile: {
+          name: string
+          age: number
+        }
+        compensation: {
+          salary: number
+          grade: `A` | `B` | `C`
+          bonus_eligible: boolean
+        }
+      }>
+    >()
+  })
+
+  test(`fn.where with filtered original type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .fn.where((row) => row.user.active && row.user.age >= 25),
+    })
+
+    const results = liveCollection.toArray
+    // Should return the original User type since no select transformation
+    expectTypeOf(results).toEqualTypeOf<Array<User>>()
+  })
+
+  test(`fn.where with regular where clause`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) => gt(user.age, 20))
+          .fn.where((row) => row.user.active),
+    })
+
+    const results = liveCollection.toArray
+    // Should return the original User type
+    expectTypeOf(results).toEqualTypeOf<Array<User>>()
+  })
+
+  test(`fn.having with GROUP BY return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .groupBy(({ user }) => user.department_id)
+          .fn.having((row) => row.user.department_id !== null)
+          .select(({ user }) => ({
+            department_id: user.department_id,
+            employee_count: count(user.id),
+          })),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        department_id: number | null
+        employee_count: number
+      }>
+    >()
+  })
+
+  test(`fn.having without GROUP BY return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .fn.having((row) => row.user.salary > 70000),
+    })
+
+    const results = liveCollection.toArray
+    // Should return the original User type when used as filter
+    expectTypeOf(results).toEqualTypeOf<Array<User>>()
+  })
+
+  test(`joins with fn.select return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .join({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .fn.select((row) => ({
+            employeeInfo: `${row.user.name} works in ${row.dept?.name || `Unknown`}`,
+            isHighEarner: row.user.salary > 70000,
+            departmentDetails: row.dept
+              ? {
+                  id: row.dept.id,
+                  name: row.dept.name,
+                }
+              : null,
+          })),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        employeeInfo: string
+        isHighEarner: boolean
+        departmentDetails: {
+          id: number
+          name: string
+        } | null
+      }>
+    >()
+  })
+
+  test(`joins with fn.where return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .join({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .fn.where(
+            (row) =>
+              row.user.active && (row.dept?.name === `Engineering` || false)
+          ),
+    })
+
+    const results = liveCollection.toArray
+    // Should return namespaced joined type since no select
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        user: User
+        dept: Department | undefined
+      }>
+    >()
+  })
+
+  test(`combination of all functional variants return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .join({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .fn.where((row) => row.user.active)
+          .fn.where((row) => row.user.salary > 60000)
+          .fn.select((row) => ({
+            departmentName: row.dept?.name || `Unknown`,
+            employeeName: row.user.name,
+            salary: row.user.salary,
+          })),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        departmentName: string
+        employeeName: string
+        salary: number
+      }>
+    >()
+  })
+
+  test(`mixed regular and functional clauses return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) => gt(user.age, 20)) // Regular where
+          .fn.where((row) => row.user.active) // Functional where
+          .select(({ user }) => ({
+            // Regular select (will be replaced)
+            id: user.id,
+            name: user.name,
+          }))
+          .fn.select((row) => ({
+            // Functional select (replaces regular)
+            employeeId: row.user.id,
+            displayName: `Employee: ${row.user.name}`,
+            status: row.user.active
+              ? (`Active` as const)
+              : (`Inactive` as const),
+          })),
+    })
+
+    const results = liveCollection.toArray
+    // Should use functional select type, not regular select type
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        employeeId: number
+        displayName: string
+        status: `Active` | `Inactive`
+      }>
+    >()
+  })
+
+  test(`fn.select replaces regular select return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .select(({ user }) => ({
+            // This should be replaced
+            id: user.id,
+            name: user.name,
+            age: user.age,
+          }))
+          .fn.select((row) => ({
+            // This should be the final type
+            customName: row.user.name.toUpperCase(),
+            isAdult: row.user.age >= 18,
+          })),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        customName: string
+        isAdult: boolean
+      }>
+    >()
+  })
+
+  test(`complex business logic transformation return type`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .fn.where((row) => {
+            // Complex business rule should not affect return type inference
+            return (
+              row.user.active && (row.user.salary > 70000 || row.user.age > 25)
+            )
+          })
+          .fn.select((row) => {
+            // Complex transformation with conditional logic
+            const salaryGrade =
+              row.user.salary > 80000
+                ? (`A` as const)
+                : row.user.salary > 60000
+                  ? (`B` as const)
+                  : (`C` as const)
+            const experienceLevel =
+              row.user.age > 30
+                ? (`Senior` as const)
+                : row.user.age > 25
+                  ? (`Mid` as const)
+                  : (`Junior` as const)
+
+            return {
+              profile: `${row.user.name} (${experienceLevel})`,
+              compensation: {
+                salary: row.user.salary,
+                grade: salaryGrade,
+                bonus_eligible: salaryGrade === `A`,
+              },
+              metrics: {
+                age: row.user.age,
+                years_to_retirement: Math.max(0, 65 - row.user.age),
+                performance_bracket: salaryGrade,
+              },
+            }
+          }),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        profile: string
+        compensation: {
+          salary: number
+          grade: `A` | `B` | `C`
+          bonus_eligible: boolean
+        }
+        metrics: {
+          age: number
+          years_to_retirement: number
+          performance_bracket: `A` | `B` | `C`
+        }
+      }>
+    >()
+  })
+
+  test(`query function syntax with functional variants`, () => {
+    const liveCollection = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .fn.where((row) => row.user.active)
+        .fn.select((row) => ({
+          name: row.user.name,
+          isActive: row.user.active,
+        }))
+    )
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        name: string
+        isActive: boolean
+      }>
+    >()
+  })
+
+  test(`functional variants with custom getKey`, () => {
+    const liveCollection = createLiveQueryCollection({
+      id: `custom-key-functional`,
+      query: (q) =>
+        q.from({ user: usersCollection }).fn.select((row) => ({
+          userId: row.user.id,
+          displayName: row.user.name.toUpperCase(),
+        })),
+      getKey: (item) => item.userId,
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        userId: number
+        displayName: string
+      }>
+    >()
+  })
+
+  test(`fn.having with complex aggregation types`, () => {
+    const liveCollection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .join({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .groupBy(({ dept }) => dept.name)
+          .fn.having((row) => row.dept?.name !== `HR`)
+          .select(({ dept, user }) => ({
+            departmentId: dept.id,
+            departmentName: dept.name,
+            totalEmployees: count(user.id),
+          })),
+    })
+
+    const results = liveCollection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        departmentId: number | undefined
+        departmentName: string | undefined
+        totalEmployees: number
+      }>
+    >()
+  })
+})

--- a/packages/db/tests/query/functional-variants.test.ts
+++ b/packages/db/tests/query/functional-variants.test.ts
@@ -1,0 +1,653 @@
+import { beforeEach, describe, expect, test } from "vitest"
+import {
+  count,
+  createLiveQueryCollection,
+  eq,
+  gt,
+} from "../../src/query/index.js"
+import { createCollection } from "../../src/collection.js"
+import { mockSyncCollectionOptions } from "../utls.js"
+
+// Sample user type for tests
+type User = {
+  id: number
+  name: string
+  age: number
+  email: string
+  active: boolean
+  department_id: number | null
+  salary: number
+}
+
+type Department = {
+  id: number
+  name: string
+}
+
+// Sample data for tests
+const sampleUsers: Array<User> = [
+  {
+    id: 1,
+    name: `Alice`,
+    age: 25,
+    email: `alice@example.com`,
+    active: true,
+    department_id: 1,
+    salary: 75000,
+  },
+  {
+    id: 2,
+    name: `Bob`,
+    age: 19,
+    email: `bob@example.com`,
+    active: true,
+    department_id: 1,
+    salary: 45000,
+  },
+  {
+    id: 3,
+    name: `Charlie`,
+    age: 30,
+    email: `charlie@example.com`,
+    active: false,
+    department_id: 2,
+    salary: 85000,
+  },
+  {
+    id: 4,
+    name: `Dave`,
+    age: 22,
+    email: `dave@example.com`,
+    active: true,
+    department_id: 2,
+    salary: 65000,
+  },
+  {
+    id: 5,
+    name: `Eve`,
+    age: 28,
+    email: `eve@example.com`,
+    active: true,
+    department_id: null,
+    salary: 55000,
+  },
+]
+
+const sampleDepartments: Array<Department> = [
+  { id: 1, name: `Engineering` },
+  { id: 2, name: `Marketing` },
+  { id: 3, name: `HR` },
+]
+
+function createUsersCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<User>({
+      id: `test-users`,
+      getKey: (user) => user.id,
+      initialData: sampleUsers,
+    })
+  )
+}
+
+function createDepartmentsCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<Department>({
+      id: `test-departments`,
+      getKey: (dept) => dept.id,
+      initialData: sampleDepartments,
+    })
+  )
+}
+
+describe(`Functional Variants Query`, () => {
+  describe(`fn.select`, () => {
+    let usersCollection: ReturnType<typeof createUsersCollection>
+
+    beforeEach(() => {
+      usersCollection = createUsersCollection()
+    })
+
+    test(`should create live query with functional select transformation`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q.from({ user: usersCollection }).fn.select((row) => ({
+            displayName: `${row.user.name} (${row.user.id})`,
+            salaryTier: row.user.salary > 60000 ? `senior` : `junior`,
+            emailDomain: row.user.email.split(`@`)[1],
+          })),
+      })
+
+      const results = liveCollection.toArray
+
+      expect(results).toHaveLength(5)
+
+      // Verify transformations
+      const alice = results.find((u) => u.displayName.includes(`Alice`))
+      expect(alice).toEqual({
+        displayName: `Alice (1)`,
+        salaryTier: `senior`,
+        emailDomain: `example.com`,
+      })
+
+      const bob = results.find((u) => u.displayName.includes(`Bob`))
+      expect(bob).toEqual({
+        displayName: `Bob (2)`,
+        salaryTier: `junior`,
+        emailDomain: `example.com`,
+      })
+
+      // Insert a new user and verify transformation
+      const newUser = {
+        id: 6,
+        name: `Frank`,
+        age: 35,
+        email: `frank@company.com`,
+        active: true,
+        department_id: 1,
+        salary: 95000,
+      }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `insert`, value: newUser })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(6)
+      const frank = liveCollection.get(6)
+      expect(frank).toEqual({
+        displayName: `Frank (6)`,
+        salaryTier: `senior`,
+        emailDomain: `company.com`,
+      })
+
+      // Update and verify transformation changes
+      const updatedUser = { ...newUser, name: `Franklin`, salary: 50000 }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `update`, value: updatedUser })
+      usersCollection.utils.commit()
+
+      const franklin = liveCollection.get(6)
+      expect(franklin).toEqual({
+        displayName: `Franklin (6)`,
+        salaryTier: `junior`, // Changed due to salary update
+        emailDomain: `company.com`,
+      })
+
+      // Delete and verify removal
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `delete`, value: updatedUser })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(5)
+      expect(liveCollection.get(6)).toBeUndefined()
+    })
+
+    test(`should work with joins and functional select`, () => {
+      const departmentsCollection = createDepartmentsCollection()
+
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .join({ dept: departmentsCollection }, ({ user, dept }) =>
+              eq(user.department_id, dept.id)
+            )
+            .fn.select((row) => ({
+              employeeInfo: `${row.user.name} works in ${row.dept?.name || `Unknown`}`,
+              isHighEarner: row.user.salary > 70000,
+              yearsToRetirement: Math.max(0, 65 - row.user.age),
+            })),
+      })
+
+      const results = liveCollection.toArray
+
+      // Left join includes all users, even those with null department_id
+      // But since dept will be undefined for Eve, she'll show as "works in Unknown"
+      expect(results).toHaveLength(5) // All 5 users included with left join
+
+      const alice = results.find((r) => r.employeeInfo.includes(`Alice`))
+      expect(alice).toEqual({
+        employeeInfo: `Alice works in Engineering`,
+        isHighEarner: true,
+        yearsToRetirement: 40,
+      })
+
+      const eve = results.find((r) => r.employeeInfo.includes(`Eve`))
+      expect(eve).toEqual({
+        employeeInfo: `Eve works in Unknown`,
+        isHighEarner: false,
+        yearsToRetirement: 37,
+      })
+    })
+  })
+
+  describe(`fn.where`, () => {
+    let usersCollection: ReturnType<typeof createUsersCollection>
+
+    beforeEach(() => {
+      usersCollection = createUsersCollection()
+    })
+
+    test(`should filter with single functional where condition`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .fn.where((row) => row.user.active && row.user.age >= 25),
+      })
+
+      const results = liveCollection.toArray
+
+      expect(results).toHaveLength(2) // Alice (25, active) and Eve (28, active)
+      expect(results.map((u) => u.name)).toEqual(
+        expect.arrayContaining([`Alice`, `Eve`])
+      )
+
+      // Insert user that meets criteria
+      const newUser = {
+        id: 6,
+        name: `Frank`,
+        age: 30,
+        email: `frank@example.com`,
+        active: true,
+        department_id: 1,
+        salary: 70000,
+      }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `insert`, value: newUser })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(3)
+      expect(liveCollection.get(6)).toEqual(newUser)
+
+      // Insert user that doesn't meet criteria (too young)
+      const youngUser = {
+        id: 7,
+        name: `Grace`,
+        age: 20,
+        email: `grace@example.com`,
+        active: true,
+        department_id: 1,
+        salary: 40000,
+      }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `insert`, value: youngUser })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(3) // Should not include Grace
+      expect(liveCollection.get(7)).toBeUndefined()
+
+      // Update Grace to meet age criteria
+      const olderGrace = { ...youngUser, age: 26 }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `update`, value: olderGrace })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(4) // Now includes Grace
+      expect(liveCollection.get(7)).toEqual(olderGrace)
+
+      // Clean up
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `delete`, value: newUser })
+      usersCollection.utils.write({ type: `delete`, value: olderGrace })
+      usersCollection.utils.commit()
+    })
+
+    test(`should combine multiple functional where conditions (AND logic)`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .fn.where((row) => row.user.active)
+            .fn.where((row) => row.user.salary > 50000)
+            .fn.where((row) => row.user.department_id !== null),
+      })
+
+      const results = liveCollection.toArray
+
+      // Should only include: Alice (active, 75k, dept 1), Dave (active, 65k, dept 2)
+      expect(results).toHaveLength(2)
+      expect(results.map((u) => u.name)).toEqual(
+        expect.arrayContaining([`Alice`, `Dave`])
+      )
+
+      // All results should meet all criteria
+      results.forEach((user) => {
+        expect(user.active).toBe(true)
+        expect(user.salary).toBeGreaterThan(50000)
+        expect(user.department_id).not.toBeNull()
+      })
+    })
+
+    test(`should work alongside regular where clause`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) => gt(user.age, 20)) // Regular where
+            .fn.where((row) => row.user.active) // Functional where
+            .fn.where((row) => row.user.salary > 60000), // Another functional where
+      })
+
+      const results = liveCollection.toArray
+
+      // Should include: Alice (25, active, 75k), Dave (22, active, 65k)
+      expect(results).toHaveLength(2)
+      expect(results.map((u) => u.name)).toEqual(
+        expect.arrayContaining([`Alice`, `Dave`])
+      )
+
+      results.forEach((user) => {
+        expect(user.age).toBeGreaterThan(20)
+        expect(user.active).toBe(true)
+        expect(user.salary).toBeGreaterThan(60000)
+      })
+    })
+  })
+
+  describe(`fn.having`, () => {
+    let usersCollection: ReturnType<typeof createUsersCollection>
+
+    beforeEach(() => {
+      usersCollection = createUsersCollection()
+    })
+
+    test(`should filter groups with functional having`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .groupBy(({ user }) => user.department_id)
+            .select(({ user }) => ({
+              department_id: user.department_id,
+              employee_count: count(user.id),
+            }))
+            .fn.having((row) => (row as any).result.employee_count > 1),
+      })
+
+      const results = liveCollection.toArray
+
+      // Should only include departments with more than 1 employee
+      // Dept 1: Alice, Bob (2 employees)
+      // Dept 2: Charlie, Dave (2 employees)
+      // Dept null: Eve (1 employee) - excluded
+      expect(results).toHaveLength(2)
+
+      results.forEach((result) => {
+        expect(result.employee_count).toBeGreaterThan(1)
+      })
+
+      const dept1 = results.find((r) => r.department_id === 1)
+      const dept2 = results.find((r) => r.department_id === 2)
+
+      expect(dept1).toEqual({ department_id: 1, employee_count: 2 })
+      expect(dept2).toEqual({ department_id: 2, employee_count: 2 })
+
+      // Add another user to department 1
+      const newUser = {
+        id: 6,
+        name: `Frank`,
+        age: 35,
+        email: `frank@example.com`,
+        active: true,
+        department_id: 1,
+        salary: 70000,
+      }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `insert`, value: newUser })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(2) // Still 2 departments
+      const updatedDept1 = liveCollection.get(1)
+      expect(updatedDept1).toEqual({ department_id: 1, employee_count: 3 }) // Now 3 employees
+
+      // Remove one user from department 1
+      const bobUser = sampleUsers.find((u) => u.name === `Bob`)
+      if (bobUser) {
+        usersCollection.utils.begin()
+        usersCollection.utils.write({ type: `delete`, value: bobUser })
+        usersCollection.utils.commit()
+
+        expect(liveCollection.size).toBe(2) // Still 2 departments (dept 1 has Alice+Frank, dept 2 has Charlie+Dave)
+        const dept1After = liveCollection.get(1)
+        expect(dept1After).toEqual({ department_id: 1, employee_count: 2 }) // Alice + Frank = 2 employees
+
+        // Clean up
+        usersCollection.utils.begin()
+        usersCollection.utils.write({ type: `insert`, value: bobUser }) // Re-add Bob
+        usersCollection.utils.write({ type: `delete`, value: newUser })
+        usersCollection.utils.commit()
+      }
+    })
+
+    test(`should work without GROUP BY as additional filter`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .fn.having((row) => row.user.salary > 70000 && row.user.age < 30),
+      })
+
+      const results = liveCollection.toArray
+
+      // Should include: Alice (75k, 25 years)
+      expect(results).toHaveLength(1)
+      const firstResult = results[0]
+      if (firstResult) {
+        expect(firstResult.name).toBe(`Alice`)
+        expect(firstResult.salary).toBeGreaterThan(70000)
+        expect(firstResult.age).toBeLessThan(30)
+      }
+
+      // Insert user that meets criteria
+      const newUser = {
+        id: 6,
+        name: `Frank`,
+        age: 27,
+        email: `frank@example.com`,
+        active: true,
+        department_id: 1,
+        salary: 80000,
+      }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `insert`, value: newUser })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(2)
+      expect(liveCollection.get(6)).toEqual(newUser)
+
+      // Update to not meet criteria (too old)
+      const olderFrank = { ...newUser, age: 35 }
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `update`, value: olderFrank })
+      usersCollection.utils.commit()
+
+      expect(liveCollection.size).toBe(1) // Frank excluded
+      expect(liveCollection.get(6)).toBeUndefined()
+
+      // Clean up
+      usersCollection.utils.begin()
+      usersCollection.utils.write({ type: `delete`, value: olderFrank })
+      usersCollection.utils.commit()
+    })
+  })
+
+  describe(`combinations`, () => {
+    let usersCollection: ReturnType<typeof createUsersCollection>
+    let departmentsCollection: ReturnType<typeof createDepartmentsCollection>
+
+    beforeEach(() => {
+      usersCollection = createUsersCollection()
+      departmentsCollection = createDepartmentsCollection()
+    })
+
+    test(`should combine all functional variants together`, () => {
+      // Simplified test without complex GROUP BY + functional having combination
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .join({ dept: departmentsCollection }, ({ user, dept }) =>
+              eq(user.department_id, dept.id)
+            )
+            .fn.where((row) => row.user.active)
+            .fn.where((row) => row.user.salary > 60000)
+            .fn.select((row) => ({
+              departmentName: row.dept?.name || `Unknown`,
+              employeeName: row.user.name,
+              salary: row.user.salary,
+            })),
+      })
+
+      const results = liveCollection.toArray
+
+      // Should include: Alice (active, 75k), Dave (active, 65k)
+      // Charlie excluded (inactive), Bob excluded (45k salary), Eve excluded (null dept)
+      expect(results).toHaveLength(2)
+
+      const alice = results.find((r) => r.employeeName === `Alice`)
+      expect(alice).toEqual({
+        departmentName: `Engineering`,
+        employeeName: `Alice`,
+        salary: 75000,
+      })
+
+      const dave = results.find((r) => r.employeeName === `Dave`)
+      expect(dave).toEqual({
+        departmentName: `Marketing`,
+        employeeName: `Dave`,
+        salary: 65000,
+      })
+    })
+
+    test(`should work with regular and functional clauses mixed`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) => gt(user.age, 20)) // Regular where
+            .fn.where((row) => row.user.active) // Functional where
+            .select(({ user }) => ({
+              // Regular select (will be replaced)
+              id: user.id,
+              name: user.name,
+            }))
+            .fn.select((row) => ({
+              // Functional select (replaces regular)
+              employeeId: row.user.id,
+              displayName: `Employee: ${row.user.name}`,
+              status: row.user.active ? `Active` : `Inactive`,
+            })),
+      })
+
+      const results = liveCollection.toArray
+
+      // Should include active users over 20: Alice, Dave, Eve
+      expect(results).toHaveLength(3)
+
+      // Should use functional select format, not regular select
+      results.forEach((result) => {
+        expect(result).toHaveProperty(`employeeId`)
+        expect(result).toHaveProperty(`displayName`)
+        expect(result).toHaveProperty(`status`)
+        expect(result).not.toHaveProperty(`id`) // From regular select
+        expect(result).not.toHaveProperty(`name`) // From regular select
+        expect(result.status).toBe(`Active`)
+      })
+
+      const alice = results.find((r) => r.displayName.includes(`Alice`))
+      expect(alice).toEqual({
+        employeeId: 1,
+        displayName: `Employee: Alice`,
+        status: `Active`,
+      })
+    })
+
+    test(`should handle complex business logic transformations`, () => {
+      const liveCollection = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .fn.where((row) => {
+              // Complex business rule: active employees with good salary or senior age
+              return (
+                row.user.active &&
+                (row.user.salary > 70000 || row.user.age > 25)
+              )
+            })
+            .fn.select((row) => {
+              // Complex transformation with multiple calculations
+              const salaryGrade =
+                row.user.salary > 80000
+                  ? `A`
+                  : row.user.salary > 60000
+                    ? `B`
+                    : `C`
+              const experienceLevel =
+                row.user.age > 30
+                  ? `Senior`
+                  : row.user.age >= 25
+                    ? `Mid`
+                    : `Junior`
+
+              return {
+                profile: `${row.user.name} (${experienceLevel})`,
+                compensation: {
+                  salary: row.user.salary,
+                  grade: salaryGrade,
+                  bonus_eligible: salaryGrade === `A`,
+                },
+                metrics: {
+                  age: row.user.age,
+                  years_to_retirement: Math.max(0, 65 - row.user.age),
+                  performance_bracket: salaryGrade,
+                },
+              }
+            }),
+      })
+
+      const results = liveCollection.toArray
+
+      // Should include: Alice (active, 75k), Eve (active, 28 years old)
+      expect(results).toHaveLength(2)
+
+      const alice = results.find((r) => r.profile.includes(`Alice`))
+      expect(alice).toEqual({
+        profile: `Alice (Mid)`,
+        compensation: {
+          salary: 75000,
+          grade: `B`,
+          bonus_eligible: false,
+        },
+        metrics: {
+          age: 25,
+          years_to_retirement: 40,
+          performance_bracket: `B`,
+        },
+      })
+
+      const eve = results.find((r) => r.profile.includes(`Eve`))
+      expect(eve).toEqual({
+        profile: `Eve (Mid)`,
+        compensation: {
+          salary: 55000,
+          grade: `C`,
+          bonus_eligible: false,
+        },
+        metrics: {
+          age: 28,
+          years_to_retirement: 37,
+          performance_bracket: `C`,
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
stacked on #185

In the old query builder you could call the same methods with a callback for the functional behaviour, but with the new query builder its always a callback with makes the api very hard to function as both an expression builder or functional callback. Because of that I think it's best to split these variates out as distinct functions.

For this first pass I have namespaces these under `.fn` on the query builder, but we could have then on the main object with a prefix/suffix.

```ts
const liveCollection = createLiveQueryCollection({
  startSync: true,
  query: (q) =>
    q
      .from({ user: usersCollection })
      .fn.select((row) => ({
        displayName: `${row.user.name} (${row.user.id})`,
        salaryTier: row.user.salary > 60000 ? `senior` : `junior`,
        emailDomain: row.user.email.split(`@`)[1],
      })),
})
  ```

I like the namespace as it nicely groups them as well as moving deeper in the editor prompts, somewhat demoting them to a second tier.

Looking for feedback on this before finishing touches (if were happy its 95% done)