### PR TITLE
fix transaction sorting order and enforce them having an id

### DIFF
--- a/.changeset/khaki-cougars-give.md
+++ b/.changeset/khaki-cougars-give.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+add a sequence number to transactions to when sorting we can ensure that those created in the same ms are sorted in the correct order

--- a/.changeset/open-foxes-say.md
+++ b/.changeset/open-foxes-say.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Ensure that all transactions are given an id, fixes a potential bug with direct mutations

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -1,7 +1,8 @@
 import { Store } from "@tanstack/store"
 import { withArrayChangeTracking, withChangeTracking } from "./proxy"
-import { Transaction, getActiveTransaction } from "./transactions"
+import { createTransaction, getActiveTransaction } from "./transactions"
 import { SortedMap } from "./SortedMap"
+import type { Transaction } from "./transactions"
 import type {
   ChangeListener,
   ChangeMessage,
@@ -1242,7 +1243,7 @@ export class CollectionImpl<
       return ambientTransaction
     } else {
       // Create a new transaction with a mutation function that calls the onInsert handler
-      const directOpTransaction = new Transaction<T>({
+      const directOpTransaction = createTransaction<T>({
         mutationFn: async (params) => {
           // Call the onInsert handler with the transaction
           return this.config.onInsert!(params)
@@ -1444,7 +1445,7 @@ export class CollectionImpl<
 
     // If no changes were made, return an empty transaction early
     if (mutations.length === 0) {
-      const emptyTransaction = new Transaction({
+      const emptyTransaction = createTransaction({
         mutationFn: async () => {},
       })
       emptyTransaction.commit()
@@ -1464,7 +1465,7 @@ export class CollectionImpl<
     // No need to check for onUpdate handler here as we've already checked at the beginning
 
     // Create a new transaction with a mutation function that calls the onUpdate handler
-    const directOpTransaction = new Transaction<T>({
+    const directOpTransaction = createTransaction<T>({
       mutationFn: async (params) => {
         // Call the onUpdate handler with the transaction
         return this.config.onUpdate!(params)
@@ -1559,7 +1560,7 @@ export class CollectionImpl<
     }
 
     // Create a new transaction with a mutation function that calls the onDelete handler
-    const directOpTransaction = new Transaction<T>({
+    const directOpTransaction = createTransaction<T>({
       autoCommit: true,
       mutationFn: async (params) => {
         // Call the onDelete handler with the transaction

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -277,8 +277,8 @@ export class CollectionImpl<
       throw new Error(`Collection requires a sync config`)
     }
 
-    this.transactions = new SortedMap<string, Transaction<any>>(
-      (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+    this.transactions = new SortedMap<string, Transaction<any>>((a, b) =>
+      a.compareCreatedAt(b)
     )
 
     this.config = config

--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -15,21 +15,8 @@ let transactionStack: Array<Transaction<any>> = []
 export function createTransaction<
   TData extends object = Record<string, unknown>,
 >(config: TransactionConfig<TData>): Transaction<TData> {
-  if (typeof config.mutationFn === `undefined`) {
-    throw `mutationFn is required when creating a transaction`
-  }
-
-  let transactionId = config.id
-  if (!transactionId) {
-    transactionId = crypto.randomUUID()
-  }
-  const newTransaction = new Transaction<TData>({
-    ...config,
-    id: transactionId,
-  })
-
+  const newTransaction = new Transaction<TData>(config)
   transactions.push(newTransaction)
-
   return newTransaction
 }
 
@@ -74,7 +61,10 @@ export class Transaction<
   }
 
   constructor(config: TransactionConfig<T>) {
-    this.id = config.id!
+    if (typeof config.mutationFn === `undefined`) {
+      throw `mutationFn is required when creating a transaction`
+    }
+    this.id = config.id ?? crypto.randomUUID()
     this.mutationFn = config.mutationFn
     this.state = `pending`
     this.mutations = []

--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -45,7 +45,7 @@ function removeFromPendingList(tx: Transaction<any>) {
   }
 }
 
-export class Transaction<
+class Transaction<
   T extends object = Record<string, unknown>,
   TOperation extends OperationType = OperationType,
 > {
@@ -220,3 +220,5 @@ export class Transaction<
     return this.sequenceNumber - other.sequenceNumber
   }
 }
+
+export type { Transaction }


### PR DESCRIPTION
While working on #204 I found two bugs:

1. direct insert/update/delete mutations where not settings an id on the transaction, this resulted in them being overwritten with further synchronous mutations as they had an id or `undefined` when being looked up. I have fixed that by ensuring that a transaction id will always fallback to a new uuid if not set.
  @KyleAMathews you used `new Transaction()` rather than `createTransaction()` in these mutations, this means they are not added to the global list of transactions. Is this intentional or should then use `createTransaction()`? If so I will fix that here as it's a very related bug, the id was enforced in `createTransaction`, but not in the Transaction constructor.

2. transactions were sorted by `createdAt` when rebasing over the latest synced data, however if two transactions happened in the same ms they would be ordered arbitrarily. This could result in the optimistic mutations happing in the wrong order - in #204 this manifested as a very strange situation where half the tests would fail, but if you only ran one of the failing tests it would work... I think this is also *highly* likely the cause of a flaky test I have seen when running the tests locally but never seen in CI.
  To fix this I have added an additional `sequenceNumber` to transaction, a monotonic counter in the current session - when we sort we compare by `createdAt` first, then fall back to `sequenceNumber` when they are created at the same time. I have left `createdAt` as this will be useful in future when we have some level of persistence for optimistic mutations.