### PR TITLE
ci: Add build check for React todo example

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,8 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Setup Tools
         uses: tanstack/config/.github/setup@main
+      - name: Build Packages
+        run: pnpm run build
       - name: Build Example Site
         run: |
           cd examples/react/todo

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,3 +57,15 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./packages/react-db/dist/**/*.{js,mjs}"
           comment-key: "react-db-package-size"
+  build-example:
+    name: Build Example Site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Setup Tools
+        uses: tanstack/config/.github/setup@main
+      - name: Build Example Site
+        run: |
+          cd examples/react/todo
+          pnpm build


### PR DESCRIPTION
## Summary
- Added a new GitHub Actions job to build the React todo example site
- The check runs `pnpm build` in the `examples/react/todo/` directory
- Build succeeds/fails based on the exit code of the build command

Fixes https://github.com/TanStack/db/issues/188

## Test plan
- [x] Verify the new workflow job runs on PRs
- [x] Confirm build failures are properly caught and reported

🤖 Generated with [Claude Code](https://claude.ai/code)