### PR TITLE
add `leftJoin`, `rightJoin`, `innerJoin` and `fullJoin` aliases of the main `join` method

### DIFF
--- a/.changeset/loud-cycles-spend.md
+++ b/.changeset/loud-cycles-spend.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Add `leftJoin`, `rightJoin`, `innerJoin` and `fullJoin` aliases of the main `join` method on the query builder.

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -185,6 +185,110 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
   }
 
   /**
+   * Perform a LEFT JOIN with another table or subquery
+   *
+   * @param source - An object with a single key-value pair where the key is the table alias and the value is a Collection or subquery
+   * @param onCallback - A function that receives table references and returns the join condition
+   * @returns A QueryBuilder with the left joined table available
+   *
+   * @example
+   * ```ts
+   * // Left join users with posts
+   * query
+   *   .from({ users: usersCollection })
+   *   .leftJoin({ posts: postsCollection }, ({users, posts}) => eq(users.id, posts.userId))
+   * ```
+   */
+  leftJoin<TSource extends Source>(
+    source: TSource,
+    onCallback: JoinOnCallback<
+      MergeContext<TContext, SchemaFromSource<TSource>>
+    >
+  ): QueryBuilder<
+    MergeContextWithJoinType<TContext, SchemaFromSource<TSource>, `left`>
+  > {
+    return this.join(source, onCallback, `left`)
+  }
+
+  /**
+   * Perform a RIGHT JOIN with another table or subquery
+   *
+   * @param source - An object with a single key-value pair where the key is the table alias and the value is a Collection or subquery
+   * @param onCallback - A function that receives table references and returns the join condition
+   * @returns A QueryBuilder with the right joined table available
+   *
+   * @example
+   * ```ts
+   * // Right join users with posts
+   * query
+   *   .from({ users: usersCollection })
+   *   .rightJoin({ posts: postsCollection }, ({users, posts}) => eq(users.id, posts.userId))
+   * ```
+   */
+  rightJoin<TSource extends Source>(
+    source: TSource,
+    onCallback: JoinOnCallback<
+      MergeContext<TContext, SchemaFromSource<TSource>>
+    >
+  ): QueryBuilder<
+    MergeContextWithJoinType<TContext, SchemaFromSource<TSource>, `right`>
+  > {
+    return this.join(source, onCallback, `right`)
+  }
+
+  /**
+   * Perform an INNER JOIN with another table or subquery
+   *
+   * @param source - An object with a single key-value pair where the key is the table alias and the value is a Collection or subquery
+   * @param onCallback - A function that receives table references and returns the join condition
+   * @returns A QueryBuilder with the inner joined table available
+   *
+   * @example
+   * ```ts
+   * // Inner join users with posts
+   * query
+   *   .from({ users: usersCollection })
+   *   .innerJoin({ posts: postsCollection }, ({users, posts}) => eq(users.id, posts.userId))
+   * ```
+   */
+  innerJoin<TSource extends Source>(
+    source: TSource,
+    onCallback: JoinOnCallback<
+      MergeContext<TContext, SchemaFromSource<TSource>>
+    >
+  ): QueryBuilder<
+    MergeContextWithJoinType<TContext, SchemaFromSource<TSource>, `inner`>
+  > {
+    return this.join(source, onCallback, `inner`)
+  }
+
+  /**
+   * Perform a FULL JOIN with another table or subquery
+   *
+   * @param source - An object with a single key-value pair where the key is the table alias and the value is a Collection or subquery
+   * @param onCallback - A function that receives table references and returns the join condition
+   * @returns A QueryBuilder with the full joined table available
+   *
+   * @example
+   * ```ts
+   * // Full join users with posts
+   * query
+   *   .from({ users: usersCollection })
+   *   .fullJoin({ posts: postsCollection }, ({users, posts}) => eq(users.id, posts.userId))
+   * ```
+   */
+  fullJoin<TSource extends Source>(
+    source: TSource,
+    onCallback: JoinOnCallback<
+      MergeContext<TContext, SchemaFromSource<TSource>>
+    >
+  ): QueryBuilder<
+    MergeContextWithJoinType<TContext, SchemaFromSource<TSource>, `full`>
+  > {
+    return this.join(source, onCallback, `full`)
+  }
+
+  /**
    * Filter rows based on a condition
    *
    * @param callback - A function that receives table references and returns an expression

--- a/packages/db/tests/query/builder/join.test.ts
+++ b/packages/db/tests/query/builder/join.test.ts
@@ -232,4 +232,173 @@ describe(`QueryBuilder.join`, () => {
     expect(builtQuery.select).toHaveProperty(`employee`)
     expect(builtQuery.select).toHaveProperty(`department`)
   })
+
+  describe(`join alias methods`, () => {
+    it(`leftJoin produces same result as join with 'left' type`, () => {
+      const builder = new Query()
+      const explicitQuery = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id),
+          `left`
+        )
+
+      const aliasQuery = builder
+        .from({ employees: employeesCollection })
+        .leftJoin(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+
+      const explicitQueryIR = getQueryIR(explicitQuery)
+      const aliasQueryIR = getQueryIR(aliasQuery)
+
+      expect(aliasQueryIR.join).toEqual(explicitQueryIR.join)
+      expect(aliasQueryIR.join![0]!.type).toBe(`left`)
+    })
+
+    it(`rightJoin produces same result as join with 'right' type`, () => {
+      const builder = new Query()
+      const explicitQuery = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id),
+          `right`
+        )
+
+      const aliasQuery = builder
+        .from({ employees: employeesCollection })
+        .rightJoin(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+
+      const explicitQueryIR = getQueryIR(explicitQuery)
+      const aliasQueryIR = getQueryIR(aliasQuery)
+
+      expect(aliasQueryIR.join).toEqual(explicitQueryIR.join)
+      expect(aliasQueryIR.join![0]!.type).toBe(`right`)
+    })
+
+    it(`innerJoin produces same result as join with 'inner' type`, () => {
+      const builder = new Query()
+      const explicitQuery = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id),
+          `inner`
+        )
+
+      const aliasQuery = builder
+        .from({ employees: employeesCollection })
+        .innerJoin(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+
+      const explicitQueryIR = getQueryIR(explicitQuery)
+      const aliasQueryIR = getQueryIR(aliasQuery)
+
+      expect(aliasQueryIR.join).toEqual(explicitQueryIR.join)
+      expect(aliasQueryIR.join![0]!.type).toBe(`inner`)
+    })
+
+    it(`fullJoin produces same result as join with 'full' type`, () => {
+      const builder = new Query()
+      const explicitQuery = builder
+        .from({ employees: employeesCollection })
+        .join(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id),
+          `full`
+        )
+
+      const aliasQuery = builder
+        .from({ employees: employeesCollection })
+        .fullJoin(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+
+      const explicitQueryIR = getQueryIR(explicitQuery)
+      const aliasQueryIR = getQueryIR(aliasQuery)
+
+      expect(aliasQueryIR.join).toEqual(explicitQueryIR.join)
+      expect(aliasQueryIR.join![0]!.type).toBe(`full`)
+    })
+
+    it(`supports chaining join aliases with different types`, () => {
+      const projectsCollection = new CollectionImpl<{
+        id: number
+        name: string
+        department_id: number
+      }>({
+        id: `projects`,
+        getKey: (item) => item.id,
+        sync: { sync: () => {} },
+      })
+
+      const builder = new Query()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .leftJoin(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+        .innerJoin(
+          { projects: projectsCollection },
+          ({ departments, projects }) =>
+            eq(departments.id, projects.department_id)
+        )
+
+      const builtQuery = getQueryIR(query)
+      expect(builtQuery.join).toBeDefined()
+      expect(builtQuery.join).toHaveLength(2)
+
+      const firstJoin = builtQuery.join![0]!
+      const secondJoin = builtQuery.join![1]!
+
+      expect(firstJoin.type).toBe(`left`)
+      expect(firstJoin.from.alias).toBe(`departments`)
+      expect(secondJoin.type).toBe(`inner`)
+      expect(secondJoin.from.alias).toBe(`projects`)
+    })
+
+    it(`join aliases work in select and where clauses`, () => {
+      const builder = new Query()
+      const query = builder
+        .from({ employees: employeesCollection })
+        .innerJoin(
+          { departments: departmentsCollection },
+          ({ employees, departments }) =>
+            eq(employees.department_id, departments.id)
+        )
+        .where(({ departments }) => gt(departments.budget, 1000000))
+        .select(({ employees, departments }) => ({
+          id: employees.id,
+          name: employees.name,
+          department_name: departments.name,
+          department_budget: departments.budget,
+        }))
+
+      const builtQuery = getQueryIR(query)
+      expect(builtQuery.join).toBeDefined()
+      expect(builtQuery.join![0]!.type).toBe(`inner`)
+      expect(builtQuery.where).toBeDefined()
+      expect(builtQuery.select).toBeDefined()
+      expect(builtQuery.select).toHaveProperty(`department_name`)
+    })
+  })
 })

--- a/packages/db/tests/query/join.test-d.ts
+++ b/packages/db/tests/query/join.test-d.ts
@@ -224,3 +224,254 @@ describe(`Join Types - Type Safety`, () => {
     >()
   })
 })
+
+describe(`Join Alias Methods - Type Safety`, () => {
+  test(`leftJoin should have same types as join with 'left' type`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    const leftJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .leftJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          ),
+    })
+
+    const results = leftJoinQuery.toArray
+
+    // For left joins, user is required, dept is optional
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        user: User
+        dept: Department | undefined
+      }>
+    >()
+  })
+
+  test(`rightJoin should have same types as join with 'right' type`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    const rightJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .rightJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          ),
+    })
+
+    const results = rightJoinQuery.toArray
+
+    // For right joins, dept is required, user is optional
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        user: User | undefined
+        dept: Department
+      }>
+    >()
+  })
+
+  test(`innerJoin should have same types as join with 'inner' type`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    const innerJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .innerJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          ),
+    })
+
+    const results = innerJoinQuery.toArray
+
+    // For inner joins, both user and dept should be required
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        user: User
+        dept: Department
+      }>
+    >()
+  })
+
+  test(`fullJoin should have same types as join with 'full' type`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    const fullJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .fullJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          ),
+    })
+
+    const results = fullJoinQuery.toArray
+
+    // For full joins, both user and dept are optional
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        user: User | undefined
+        dept: Department | undefined
+      }>
+    >()
+  })
+
+  test(`chaining different join aliases should handle optionality correctly`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    // Create a projects collection for multiple joins
+    type Project = {
+      id: number
+      name: string
+      user_id: number
+    }
+
+    const projectsCollection = createCollection(
+      mockSyncCollectionOptions<Project>({
+        id: `test-projects`,
+        getKey: (project) => project.id,
+        initialData: [],
+      })
+    )
+
+    const multipleJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .leftJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .rightJoin({ project: projectsCollection }, ({ user, project }) =>
+            eq(user.id, project.user_id)
+          ),
+    })
+
+    const results = multipleJoinQuery.toArray
+
+    // Complex join scenario with aliases:
+    // - user should be optional (due to right join with project)
+    // - dept should be optional (due to left join)
+    // - project should be required (right join target)
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        user: User | undefined
+        dept: Department | undefined
+        project: Project
+      }>
+    >()
+  })
+
+  test(`join aliases with select should maintain correct optionality`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    const selectJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .leftJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .select(({ user, dept }) => ({
+            userName: user.name,
+            deptName: dept.name, // This should be string | undefined due to left join
+            deptBudget: dept.budget,
+          })),
+    })
+
+    const results = selectJoinQuery.toArray
+
+    // Select should return the projected type with correct optionality
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        userName: string
+        deptName: string | undefined
+        deptBudget: number | undefined
+      }>
+    >()
+  })
+
+  test(`innerJoin select should not have undefined properties`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    const selectInnerJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .innerJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .select(({ user, dept }) => ({
+            userName: user.name,
+            deptName: dept.name, // This should be string (not undefined) due to inner join
+            deptBudget: dept.budget,
+          })),
+    })
+
+    const results = selectInnerJoinQuery.toArray
+
+    // Select should return the projected type without undefined for inner join
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        userName: string
+        deptName: string
+        deptBudget: number
+      }>
+    >()
+  })
+
+  test(`mixed join aliases and explicit join types should work together`, () => {
+    const usersCollection = createUsersCollection()
+    const departmentsCollection = createDepartmentsCollection()
+
+    type Project = {
+      id: number
+      name: string
+      department_id: number
+    }
+
+    const projectsCollection = createCollection(
+      mockSyncCollectionOptions<Project>({
+        id: `test-projects`,
+        getKey: (project) => project.id,
+        initialData: [],
+      })
+    )
+
+    const mixedJoinQuery = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .leftJoin({ dept: departmentsCollection }, ({ user, dept }) =>
+            eq(user.department_id, dept.id)
+          )
+          .join(
+            { project: projectsCollection },
+            ({ dept, project }) => eq(dept.id, project.department_id),
+            `inner`
+          ),
+    })
+
+    const results = mixedJoinQuery.toArray
+
+    // Mixed joins:
+    // - user should be required (from clause)
+    // - dept should be optional (left join)
+    // - project should be required (inner join)
+    expectTypeOf(results).toEqualTypeOf<
+      Array<{
+        user: User
+        dept: Department | undefined
+        project: Project
+      }>
+    >()
+  })
+})


### PR DESCRIPTION
This was previously discussed and noted in #242 