### PR TITLE
fix join expression order bug and add validation

### DIFF
--- a/.changeset/pink-ducks-fix.md
+++ b/.changeset/pink-ducks-fix.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fixed an issue with joins where a specific order of references in the `eq()` expression was required, and added additional validation

--- a/packages/db/src/query/compiler/joins.ts
+++ b/packages/db/src/query/compiler/joins.ts
@@ -163,7 +163,7 @@ function analyzeJoinExpressions(
     return { mainExpr: right, joinedExpr: left }
   }
 
-  // If both expressions refer to the same table, this is an invalid join
+  // If both expressions refer to the same alias, this is an invalid join
   if (leftTableAlias === rightTableAlias) {
     throw new Error(
       `Invalid join condition: both expressions refer to the same table "${leftTableAlias}"`
@@ -203,10 +203,8 @@ function getTableAliasFromExpression(expr: BasicExpression): string | null {
       // If all arguments refer to the same table, return that table alias
       return tableAliases.size === 1 ? Array.from(tableAliases)[0]! : null
     }
-    case `val`:
-      // Values don't reference any table
-      return null
     default:
+      // Values (type='val') don't reference any table
       return null
   }
 }

--- a/packages/db/src/query/compiler/joins.ts
+++ b/packages/db/src/query/compiler/joins.ts
@@ -7,7 +7,12 @@ import {
 import { compileExpression } from "./evaluators.js"
 import { compileQuery } from "./index.js"
 import type { IStreamBuilder, JoinType } from "@electric-sql/d2mini"
-import type { CollectionRef, JoinClause, QueryRef } from "../ir.js"
+import type {
+  BasicExpression,
+  CollectionRef,
+  JoinClause,
+  QueryRef,
+} from "../ir.js"
 import type {
   KeyedStream,
   NamespacedAndKeyedStream,
@@ -75,18 +80,26 @@ function processJoin(
         ? `full`
         : (joinClause.type as JoinType)
 
+  // Analyze which table each expression refers to and swap if necessary
+  const { mainExpr, joinedExpr } = analyzeJoinExpressions(
+    joinClause.left,
+    joinClause.right,
+    mainTableAlias,
+    joinedTableAlias
+  )
+
   // Pre-compile the join expressions
-  const compiledLeftExpr = compileExpression(joinClause.left)
-  const compiledRightExpr = compileExpression(joinClause.right)
+  const compiledMainExpr = compileExpression(mainExpr)
+  const compiledJoinedExpr = compileExpression(joinedExpr)
 
   // Prepare the main pipeline for joining
   const mainPipeline = pipeline.pipe(
     map(([currentKey, namespacedRow]) => {
-      // Extract the join key from the left side of the join condition
-      const leftKey = compiledLeftExpr(namespacedRow)
+      // Extract the join key from the main table expression
+      const mainKey = compiledMainExpr(namespacedRow)
 
       // Return [joinKey, [originalKey, namespacedRow]]
-      return [leftKey, [currentKey, namespacedRow]] as [
+      return [mainKey, [currentKey, namespacedRow]] as [
         unknown,
         [string, typeof namespacedRow],
       ]
@@ -99,11 +112,11 @@ function processJoin(
       // Wrap the row in a namespaced structure
       const namespacedRow: NamespacedRow = { [joinedTableAlias]: row }
 
-      // Extract the join key from the right side of the join condition
-      const rightKey = compiledRightExpr(namespacedRow)
+      // Extract the join key from the joined table expression
+      const joinedKey = compiledJoinedExpr(namespacedRow)
 
       // Return [joinKey, [originalKey, namespacedRow]]
-      return [rightKey, [currentKey, namespacedRow]] as [
+      return [joinedKey, [currentKey, namespacedRow]] as [
         unknown,
         [string, typeof namespacedRow],
       ]
@@ -119,6 +132,83 @@ function processJoin(
     consolidate(),
     processJoinResults(joinClause.type)
   )
+}
+
+/**
+ * Analyzes join expressions to determine which refers to which table
+ * and returns them in the correct order (main table expression first, joined table expression second)
+ */
+function analyzeJoinExpressions(
+  left: BasicExpression,
+  right: BasicExpression,
+  mainTableAlias: string,
+  joinedTableAlias: string
+): { mainExpr: BasicExpression; joinedExpr: BasicExpression } {
+  const leftTableAlias = getTableAliasFromExpression(left)
+  const rightTableAlias = getTableAliasFromExpression(right)
+
+  // If left expression refers to main table and right refers to joined table, keep as is
+  if (
+    leftTableAlias === mainTableAlias &&
+    rightTableAlias === joinedTableAlias
+  ) {
+    return { mainExpr: left, joinedExpr: right }
+  }
+
+  // If left expression refers to joined table and right refers to main table, swap them
+  if (
+    leftTableAlias === joinedTableAlias &&
+    rightTableAlias === mainTableAlias
+  ) {
+    return { mainExpr: right, joinedExpr: left }
+  }
+
+  // If both expressions refer to the same table, this is an invalid join
+  if (leftTableAlias === rightTableAlias) {
+    throw new Error(
+      `Invalid join condition: both expressions refer to the same table "${leftTableAlias}"`
+    )
+  }
+
+  // If one expression doesn't refer to either table, this is an invalid join
+  if (!leftTableAlias || !rightTableAlias) {
+    throw new Error(
+      `Invalid join condition: expressions must reference table aliases "${mainTableAlias}" and "${joinedTableAlias}"`
+    )
+  }
+
+  // If expressions refer to tables not involved in this join, this is an invalid join
+  throw new Error(
+    `Invalid join condition: expressions reference tables "${leftTableAlias}" and "${rightTableAlias}" but join is between "${mainTableAlias}" and "${joinedTableAlias}"`
+  )
+}
+
+/**
+ * Extracts the table alias from a join expression
+ */
+function getTableAliasFromExpression(expr: BasicExpression): string | null {
+  switch (expr.type) {
+    case `ref`:
+      // PropRef path has the table alias as the first element
+      return expr.path[0] || null
+    case `func`: {
+      // For function expressions, we need to check if all arguments refer to the same table
+      const tableAliases = new Set<string>()
+      for (const arg of expr.args) {
+        const alias = getTableAliasFromExpression(arg)
+        if (alias) {
+          tableAliases.add(alias)
+        }
+      }
+      // If all arguments refer to the same table, return that table alias
+      return tableAliases.size === 1 ? Array.from(tableAliases)[0]! : null
+    }
+    case `val`:
+      // Values don't reference any table
+      return null
+    default:
+      return null
+  }
 }
 
 /**


### PR DESCRIPTION
fixes #277

Currently the order of the references in the join `eq(left.prop, right.prop)` was required but not validated. This changes it to work either way (you can specify them in reverse) and validates and rejects other mistakes.