### PR TITLE
Delay initializing periodic cleanup until sync has actually started.

### DIFF
--- a/examples/react/todo/src/routes/trailbase.tsx
+++ b/examples/react/todo/src/routes/trailbase.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute(`/trailbase`)({
 })
 
 function TrailBasePage() {
-  // Get data using live queries with Electric collections
+  // Get data using live queries with TrailBase collections
   const { data: todos } = useLiveQuery((q) =>
     q
       .from({ todo: trailBaseTodoCollection })


### PR DESCRIPTION
Also avoid use of WeakRef by explicitly tying the cleanup lifetime to the livelihood of the reader.