### PR TITLE
fix: ensure LiveQueryCollection markReady is called when source collections have no data

### DIFF
--- a/.changeset/ninety-parts-check.md
+++ b/.changeset/ninety-parts-check.md
@@ -5,4 +5,9 @@
 
 Fix LiveQueryCollection hanging when source collections have no data
 
-Fixed an issue where `LiveQueryCollection.preload()` would hang indefinitely when source collections call `markReady()` without data changes (e.g., when queryFn returns empty array). The LiveQueryCollection now properly detects when all source collections are ready, even without data changes, by polling collection status until all dependencies are ready.
+Fixed an issue where `LiveQueryCollection.preload()` would hang indefinitely when source collections call `markReady()` without data changes (e.g., when queryFn returns empty array). 
+
+The fix implements a proper event-based solution:
+- Collections now emit empty change events when becoming ready with no data
+- WHERE clause filtered subscriptions now correctly pass through empty ready signals
+- Both regular and WHERE clause optimized LiveQueryCollections now work correctly with empty source collections

--- a/.changeset/ninety-parts-check.md
+++ b/.changeset/ninety-parts-check.md
@@ -1,0 +1,8 @@
+---
+"@tanstack/query-db-collection": patch
+"@tanstack/db": patch
+---
+
+Fix LiveQueryCollection hanging when source collections have no data
+
+Fixed an issue where `LiveQueryCollection.preload()` would hang indefinitely when source collections call `markReady()` without data changes (e.g., when queryFn returns empty array). The LiveQueryCollection now properly detects when all source collections are ready, even without data changes, by polling collection status until all dependencies are ready.

--- a/.changeset/ninety-parts-check.md
+++ b/.changeset/ninety-parts-check.md
@@ -5,9 +5,10 @@
 
 Fix LiveQueryCollection hanging when source collections have no data
 
-Fixed an issue where `LiveQueryCollection.preload()` would hang indefinitely when source collections call `markReady()` without data changes (e.g., when queryFn returns empty array). 
+Fixed an issue where `LiveQueryCollection.preload()` would hang indefinitely when source collections call `markReady()` without data changes (e.g., when queryFn returns empty array).
 
 The fix implements a proper event-based solution:
+
 - Collections now emit empty change events when becoming ready with no data
 - WHERE clause filtered subscriptions now correctly pass through empty ready signals
 - Both regular and WHERE clause optimized LiveQueryCollections now work correctly with empty source collections

--- a/packages/db/src/change-events.ts
+++ b/packages/db/src/change-events.ts
@@ -250,7 +250,9 @@ export function createFilteredCallback<T extends object>(
       }
     }
 
-    if (filteredChanges.length > 0) {
+    // Always call the original callback if we have filtered changes OR
+    // if the original changes array was empty (which indicates a ready signal)
+    if (filteredChanges.length > 0 || changes.length === 0) {
       originalCallback(filteredChanges)
     }
   }

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -321,6 +321,12 @@ export class CollectionImpl<
         const callbacks = [...this.onFirstReadyCallbacks]
         this.onFirstReadyCallbacks = []
         callbacks.forEach((callback) => callback())
+
+        // If the collection is empty when it becomes ready, emit an empty change event
+        // to notify subscribers (like LiveQueryCollection) that the collection is ready
+        if (this.size === 0 && this.changeListeners.size > 0) {
+          this.emitEmptyReadyEvent()
+        }
       }
     }
   }
@@ -871,6 +877,17 @@ export class CollectionImpl<
       return previousUpserts.get(key)
     }
     return this.syncedData.get(key)
+  }
+
+  /**
+   * Emit an empty ready event to notify subscribers that the collection is ready
+   * This bypasses the normal empty array check in emitEvents
+   */
+  private emitEmptyReadyEvent(): void {
+    // Emit empty array directly to all listeners
+    for (const listener of this.changeListeners) {
+      listener([])
+    }
   }
 
   /**

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -360,42 +360,13 @@ export function liveQueryCollectionOptions<
         }
       })
 
-      // Poll for collection readiness in case collections become ready without data changes
-      // This handles the case where a collection calls markReady() but has no data
-      // TODO: Replace with proper event-based mechanism when available
-      let pollInterval: ReturnType<typeof setInterval> | undefined
-      let hasCalledMarkReady = false
-
-      const startPolling = () => {
-        pollInterval = setInterval(() => {
-          if (!hasCalledMarkReady && allCollectionsReady()) {
-            hasCalledMarkReady = true
-            maybeRunGraph()
-            // Stop polling once we've successfully called markReady
-            if (pollInterval) {
-              clearInterval(pollInterval)
-              pollInterval = undefined
-            }
-          }
-        }, 10) // Check every 10ms for responsiveness
-      }
-
-      // Start polling immediately
-      startPolling()
-
-      // Stop polling when cleanup is called
-      const originalCleanup = () => {
-        unsubscribeCallbacks.forEach((unsubscribe) => unsubscribe())
-        if (pollInterval) {
-          clearInterval(pollInterval)
-        }
-      }
-
       // Initial run
       maybeRunGraph()
 
       // Return the unsubscribe function
-      return originalCleanup
+      return () => {
+        unsubscribeCallbacks.forEach((unsubscribe) => unsubscribe())
+      }
     },
   }
 

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -360,13 +360,42 @@ export function liveQueryCollectionOptions<
         }
       })
 
+      // Poll for collection readiness in case collections become ready without data changes
+      // This handles the case where a collection calls markReady() but has no data
+      // TODO: Replace with proper event-based mechanism when available
+      let pollInterval: ReturnType<typeof setInterval> | undefined
+      let hasCalledMarkReady = false
+
+      const startPolling = () => {
+        pollInterval = setInterval(() => {
+          if (!hasCalledMarkReady && allCollectionsReady()) {
+            hasCalledMarkReady = true
+            maybeRunGraph()
+            // Stop polling once we've successfully called markReady
+            if (pollInterval) {
+              clearInterval(pollInterval)
+              pollInterval = undefined
+            }
+          }
+        }, 10) // Check every 10ms for responsiveness
+      }
+
+      // Start polling immediately
+      startPolling()
+
+      // Stop polling when cleanup is called
+      const originalCleanup = () => {
+        unsubscribeCallbacks.forEach((unsubscribe) => unsubscribe())
+        if (pollInterval) {
+          clearInterval(pollInterval)
+        }
+      }
+
       // Initial run
       maybeRunGraph()
 
       // Return the unsubscribe function
-      return () => {
-        unsubscribeCallbacks.forEach((unsubscribe) => unsubscribe())
-      }
+      return originalCleanup
     },
   }
 

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -88,4 +88,58 @@ describe(`createLiveQueryCollection`, () => {
     expect(activeUsers1.size).toBe(2)
     expect(activeUsers2.size).toBe(2)
   })
+
+  it(`should call markReady when source collection returns empty array`, async () => {
+    // Create an empty source collection using the mock sync options
+    const emptyUsersCollection = createCollection(
+      mockSyncCollectionOptions<User>({
+        id: `empty-test-users`,
+        getKey: (user) => user.id,
+        initialData: [], // Empty initial data
+      })
+    )
+
+    // Create a live query collection that depends on the empty source collection
+    const liveQuery = createLiveQueryCollection((q) =>
+      q
+        .from({ user: emptyUsersCollection })
+        .where(({ user }) => eq(user.active, true))
+    )
+
+    // This should resolve and not hang, even though the source collection is empty
+    await liveQuery.preload()
+
+    expect(liveQuery.status).toBe(`ready`)
+    expect(liveQuery.size).toBe(0)
+  })
+
+  it(`should call markReady when source collection sync doesn't call begin/commit (reproduction case)`, async () => {
+    // Create a collection with sync that only calls markReady (like the reproduction case)
+    const problemCollection = createCollection<User>({
+      id: `problem-collection`,
+      sync: {
+        sync: ({ markReady }) => {
+          // Simulate async operation without begin/commit (like empty queryFn case)
+          setTimeout(() => {
+            markReady()
+          }, 50)
+          return () => {} // cleanup function
+        },
+      },
+      getKey: (user) => user.id,
+    })
+
+    // Create a live query collection that depends on the problematic source collection
+    const liveQuery = createLiveQueryCollection((q) =>
+      q
+        .from({ user: problemCollection })
+        .where(({ user }) => eq(user.active, true))
+    )
+
+    // This should resolve and not hang, even though the source collection doesn't commit data
+    await liveQuery.preload()
+
+    expect(liveQuery.status).toBe(`ready`)
+    expect(liveQuery.size).toBe(0)
+  })
 })

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -1016,4 +1016,38 @@ describe(`QueryCollection`, () => {
       expect(finalItem?.name).toMatch(/^Item \d+$/)
     })
   })
+
+  it(`should call markReady when queryFn returns an empty array`, async () => {
+    const queryKey = [`emptyArrayTest`]
+    const queryFn = vi.fn().mockResolvedValue([])
+
+    const config: QueryCollectionConfig<TestItem> = {
+      id: `test`,
+      queryClient,
+      queryKey,
+      queryFn,
+      getKey,
+      startSync: true,
+    }
+
+    const options = queryCollectionOptions(config)
+    const collection = createCollection(options)
+
+    // Wait for the query to complete
+    await vi.waitFor(
+      () => {
+        expect(queryFn).toHaveBeenCalledTimes(1)
+        // The collection should be marked as ready even with empty array
+        expect(collection.status).toBe(`ready`)
+      },
+      {
+        timeout: 1000,
+        interval: 50,
+      }
+    )
+
+    // Verify the collection is empty but ready
+    expect(collection.size).toBe(0)
+    expect(collection.status).toBe(`ready`)
+  })
 })


### PR DESCRIPTION
## Summary

Fixed an issue where `LiveQueryCollection.preload()` would hang indefinitely when source collections call `markReady()` without data changes (e.g., when queryFn returns empty array from query-db-collection).

## Root Cause

The bug occurred when source collections became ready but had no data to emit:
1. LiveQueryCollection waits for source collections to reach `ready` or `initialCommit` status
2. Collections that call `markReady()` without data changes don't emit change events  
3. LiveQueryCollection never receives notification that these collections are ready
4. This was especially problematic with WHERE clause optimized subscriptions

## Solution

Implemented a proper event-based solution with two parts:

1. **Collection Level**: Modified `markReady()` in `collection.ts` to emit empty change events when a collection becomes ready with no data
2. **Filtering Level**: Updated `createFilteredCallback` in `change-events.ts` to distinguish between empty filtered results (normal) and empty original events (ready signals), ensuring WHERE clause subscriptions pass through ready signals

## Test Coverage

Added comprehensive tests that reproduce the bug:
- Source collections that only call `markReady()` without `begin()`/`commit()`
- Both regular and WHERE clause optimized LiveQueryCollections
- All tests now pass correctly

## Files Changed

- `packages/db/src/collection.ts` - Added empty ready event emission
- `packages/db/src/change-events.ts` - Fixed filtered callback logic for ready signals
- `packages/db/tests/query/live-query-collection.test.ts` - Added reproduction tests

Fixes #306

🤖 Generated with [Claude Code](https://claude.ai/code)