### PR TITLE
Configuration options for sortBy

### DIFF
--- a/.changeset/late-icons-fly.md
+++ b/.changeset/late-icons-fly.md
@@ -2,4 +2,4 @@
 "@tanstack/db": patch
 ---
 
-Configurable ordering of null values in orderBy
+Add option to configure how orderBy compares values. This includes ascending/descending order, ordering of null values, and lexical vs locale comparison for strings.

--- a/.changeset/late-icons-fly.md
+++ b/.changeset/late-icons-fly.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Configurable ordering of null values in orderBy

--- a/packages/db/src/indexes/btree-index.ts
+++ b/packages/db/src/indexes/btree-index.ts
@@ -1,5 +1,5 @@
-import { ascComparator } from "../utils/comparison.js"
 import { BTree } from "../utils/btree.js"
+import { defaultComparator } from "../utils/comparison.js"
 import { BaseIndex } from "./base-index.js"
 import type { BasicExpression } from "../query/ir.js"
 import type { IndexOperation } from "./base-index.js"
@@ -43,7 +43,7 @@ export class BTreeIndex<
   private orderedEntries: BTree<any, undefined> // we don't associate values with the keys of the B+ tree (the keys are indexed values)
   private valueMap = new Map<any, Set<TKey>>() // instead we store a mapping of indexed values to a set of PKs
   private indexedKeys = new Set<TKey>()
-  private compareFn: (a: any, b: any) => number = ascComparator
+  private compareFn: (a: any, b: any) => number = defaultComparator
 
   constructor(
     id: number,
@@ -52,7 +52,7 @@ export class BTreeIndex<
     options?: any
   ) {
     super(id, expression, name, options)
-    this.compareFn = options?.compareFn ?? ascComparator
+    this.compareFn = options?.compareFn ?? defaultComparator
     this.orderedEntries = new BTree(this.compareFn)
   }
 

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -478,7 +478,8 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
    */
   orderBy(
     callback: OrderByCallback<TContext>,
-    direction: OrderByDirection = `asc`
+    direction: OrderByDirection = `asc`,
+    nulls: `first` | `last` = `first`
   ): QueryBuilder<TContext> {
     const aliases = this._getCurrentAliases()
     const refProxy = createRefProxy(aliases) as RefProxyForContext<TContext>
@@ -488,6 +489,7 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
     const orderByClause: OrderByClause = {
       expression: toExpression(result),
       direction,
+      nulls,
     }
 
     const existingOrderBy: OrderBy = this.query.orderBy || []

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -19,6 +19,7 @@ import type {
   QueryIR,
 } from "../ir.js"
 import type {
+  CompareOptions,
   Context,
   GroupByCallback,
   JoinOnCallback,
@@ -485,22 +486,25 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
     const refProxy = createRefProxy(aliases) as RefProxyForContext<TContext>
     const result = callback(refProxy)
 
-    const opts: Required<OrderByOptions> =
+    const opts: CompareOptions =
       typeof options === `string`
-        ? { direction: options, nulls: `first` }
+        ? { direction: options, nulls: `first`, stringSort: `locale` }
         : {
-            direction:
-              typeof options === `string`
-                ? options
-                : (options.direction ?? `asc`),
+            direction: options.direction ?? `asc`,
             nulls: options.nulls ?? `first`,
+            stringSort: options.stringSort ?? `locale`,
+            locale:
+              options.stringSort === `locale` ? options.locale : undefined,
+            localeOptions:
+              options.stringSort === `locale`
+                ? options.localeOptions
+                : undefined,
           }
 
     // Create the new OrderBy structure with expression and direction
     const orderByClause: OrderByClause = {
       expression: toExpression(result),
-      direction: opts.direction,
-      nulls: opts.nulls,
+      compareOptions: opts,
     }
 
     const existingOrderBy: OrderBy = this.query.orderBy || []

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -25,6 +25,7 @@ import type {
   MergeContext,
   MergeContextWithJoinType,
   OrderByCallback,
+  OrderByOptions,
   RefProxyForContext,
   ResultTypeFromSelect,
   SchemaFromSource,
@@ -478,18 +479,28 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
    */
   orderBy(
     callback: OrderByCallback<TContext>,
-    direction: OrderByDirection = `asc`,
-    nulls: `first` | `last` = `first`
+    options: OrderByDirection | OrderByOptions = `asc`
   ): QueryBuilder<TContext> {
     const aliases = this._getCurrentAliases()
     const refProxy = createRefProxy(aliases) as RefProxyForContext<TContext>
     const result = callback(refProxy)
 
+    const opts: Required<OrderByOptions> =
+      typeof options === `string`
+        ? { direction: options, nulls: `first` }
+        : {
+            direction:
+              typeof options === `string`
+                ? options
+                : (options.direction ?? `asc`),
+            nulls: options.nulls ?? `first`,
+          }
+
     // Create the new OrderBy structure with expression and direction
     const orderByClause: OrderByClause = {
       expression: toExpression(result),
-      direction,
-      nulls,
+      direction: opts.direction,
+      nulls: opts.nulls,
     }
 
     const existingOrderBy: OrderBy = this.query.orderBy || []

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -78,6 +78,24 @@ export type OrderByCallback<TContext extends Context> = (
 export type OrderByOptions = {
   direction?: OrderByDirection
   nulls?: `first` | `last`
+} & StringSortOpts
+
+export type StringSortOpts =
+  | {
+      stringSort?: `lexical`
+    }
+  | {
+      stringSort?: `locale`
+      locale?: string
+      localeOptions?: object
+    }
+
+export type CompareOptions = {
+  direction: OrderByDirection
+  nulls: `first` | `last`
+  stringSort: `lexical` | `locale`
+  locale?: string
+  localeOptions?: object
 }
 
 // Callback type for groupBy clauses

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -1,5 +1,5 @@
 import type { CollectionImpl } from "../../collection.js"
-import type { Aggregate, BasicExpression } from "../ir.js"
+import type { Aggregate, BasicExpression, OrderByDirection } from "../ir.js"
 import type { QueryBuilder } from "./index.js"
 
 export interface Context {
@@ -74,6 +74,11 @@ export type ResultTypeFromSelect<TSelectObject> = {
 export type OrderByCallback<TContext extends Context> = (
   refs: RefProxyForContext<TContext>
 ) => any
+
+export type OrderByOptions = {
+  direction?: OrderByDirection
+  nulls?: `first` | `last`
+}
 
 // Callback type for groupBy clauses
 export type GroupByCallback<TContext extends Context> = (

--- a/packages/db/src/query/compiler/order-by.ts
+++ b/packages/db/src/query/compiler/order-by.ts
@@ -20,6 +20,7 @@ export function processOrderBy(
   const compiledOrderBy = orderByClause.map((clause) => ({
     compiledExpression: compileExpression(clause.expression),
     direction: clause.direction,
+    nulls: clause.nulls,
   }))
 
   // Create a value extractor function for the orderBy operator
@@ -60,10 +61,12 @@ export function processOrderBy(
         const arrayA = a as Array<unknown>
         const arrayB = b as Array<unknown>
         for (let i = 0; i < orderByClause.length; i++) {
-          const direction = orderByClause[i]!.direction
+          const clause = orderByClause[i]!
+          const direction = clause.direction
+          const nulls = clause.nulls
           const compareFn =
             direction === `desc` ? descComparator : ascComparator
-          const result = compareFn(arrayA[i], arrayB[i])
+          const result = compareFn(arrayA[i], arrayB[i], nulls)
           if (result !== 0) {
             return result
           }
@@ -73,11 +76,15 @@ export function processOrderBy(
 
       // Single property comparison
       if (orderByClause.length === 1) {
-        const direction = orderByClause[0]!.direction
-        return direction === `desc` ? descComparator(a, b) : ascComparator(a, b)
+        const clause = orderByClause[0]!
+        const direction = clause.direction
+        const nulls = clause.nulls
+        return direction === `desc`
+          ? descComparator(a, b, nulls)
+          : ascComparator(a, b, nulls)
       }
 
-      return ascComparator(a, b)
+      return ascComparator(a, b, `first`)
     }
   }
 

--- a/packages/db/src/query/compiler/order-by.ts
+++ b/packages/db/src/query/compiler/order-by.ts
@@ -1,5 +1,5 @@
 import { orderByWithFractionalIndex } from "@tanstack/db-ivm"
-import { ascComparator, descComparator } from "../../utils/comparison.js"
+import { defaultComparator, makeComparator } from "../../utils/comparison.js"
 import { compileExpression } from "./evaluators.js"
 import type { OrderByClause } from "../ir.js"
 import type { NamespacedAndKeyedStream, NamespacedRow } from "../../types.js"
@@ -19,8 +19,7 @@ export function processOrderBy(
   // Pre-compile all order by expressions
   const compiledOrderBy = orderByClause.map((clause) => ({
     compiledExpression: compileExpression(clause.expression),
-    direction: clause.direction,
-    nulls: clause.nulls,
+    compareOptions: clause.compareOptions,
   }))
 
   // Create a value extractor function for the orderBy operator
@@ -54,41 +53,31 @@ export function processOrderBy(
   }
 
   // Create a multi-property comparator that respects the order and direction of each property
-  const makeComparator = () => {
-    return (a: unknown, b: unknown) => {
-      // If we're comparing arrays (multiple properties), compare each property in order
-      if (orderByClause.length > 1) {
-        const arrayA = a as Array<unknown>
-        const arrayB = b as Array<unknown>
-        for (let i = 0; i < orderByClause.length; i++) {
-          const clause = orderByClause[i]!
-          const direction = clause.direction
-          const nulls = clause.nulls
-          const compareFn =
-            direction === `desc` ? descComparator : ascComparator
-          const result = compareFn(arrayA[i], arrayB[i], nulls)
-          if (result !== 0) {
-            return result
-          }
+  const comparator = (a: unknown, b: unknown) => {
+    // If we're comparing arrays (multiple properties), compare each property in order
+    if (orderByClause.length > 1) {
+      const arrayA = a as Array<unknown>
+      const arrayB = b as Array<unknown>
+      for (let i = 0; i < orderByClause.length; i++) {
+        const clause = orderByClause[i]!
+        const compareFn = makeComparator(clause.compareOptions)
+        const result = compareFn(arrayA[i], arrayB[i])
+        if (result !== 0) {
+          return result
         }
-        return arrayA.length - arrayB.length
       }
-
-      // Single property comparison
-      if (orderByClause.length === 1) {
-        const clause = orderByClause[0]!
-        const direction = clause.direction
-        const nulls = clause.nulls
-        return direction === `desc`
-          ? descComparator(a, b, nulls)
-          : ascComparator(a, b, nulls)
-      }
-
-      return ascComparator(a, b, `first`)
+      return arrayA.length - arrayB.length
     }
-  }
 
-  const comparator = makeComparator()
+    // Single property comparison
+    if (orderByClause.length === 1) {
+      const clause = orderByClause[0]!
+      const compareFn = makeComparator(clause.compareOptions)
+      return compareFn(a, b)
+    }
+
+    return defaultComparator(a, b)
+  }
 
   // Use fractional indexing and return the tuple [value, index]
   return pipeline.pipe(

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -2,6 +2,7 @@
 This is the intermediate representation of the query.
 */
 
+import type { CompareOptions } from "./builder/types"
 import type { CollectionImpl } from "../collection"
 import type { NamespacedRow } from "../types"
 
@@ -48,8 +49,7 @@ export type OrderBy = Array<OrderByClause>
 
 export type OrderByClause = {
   expression: BasicExpression
-  direction: OrderByDirection
-  nulls: `first` | `last`
+  compareOptions: CompareOptions
 }
 
 export type OrderByDirection = `asc` | `desc`

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -49,6 +49,7 @@ export type OrderBy = Array<OrderByClause>
 export type OrderByClause = {
   expression: BasicExpression
   direction: OrderByDirection
+  nulls: `first` | `last`
 }
 
 export type OrderByDirection = `asc` | `desc`

--- a/packages/db/src/utils/comparison.ts
+++ b/packages/db/src/utils/comparison.ts
@@ -19,11 +19,15 @@ function getObjectId(obj: object): number {
  * Handles null/undefined, strings, arrays, dates, objects, and primitives
  * Always sorts null/undefined values first
  */
-export const ascComparator = (a: any, b: any): number => {
+export const ascComparator = (
+  a: any,
+  b: any,
+  nulls: `first` | `last` = `first`
+): number => {
   // Handle null/undefined
   if (a == null && b == null) return 0
-  if (a == null) return -1
-  if (b == null) return 1
+  if (a == null) return nulls === `first` ? -1 : 1
+  if (b == null) return nulls === `first` ? 1 : -1
 
   // if a and b are both strings, compare them based on locale
   if (typeof a === `string` && typeof b === `string`) {
@@ -33,7 +37,7 @@ export const ascComparator = (a: any, b: any): number => {
   // if a and b are both arrays, compare them element by element
   if (Array.isArray(a) && Array.isArray(b)) {
     for (let i = 0; i < Math.min(a.length, b.length); i++) {
-      const result = ascComparator(a[i], b[i])
+      const result = ascComparator(a[i], b[i], nulls)
       if (result !== 0) {
         return result
       }
@@ -74,6 +78,10 @@ export const ascComparator = (a: any, b: any): number => {
  * Descending comparator function for ordering values
  * Handles null/undefined as largest values (opposite of ascending)
  */
-export const descComparator = (a: unknown, b: unknown): number => {
-  return ascComparator(b, a)
+export const descComparator = (
+  a: unknown,
+  b: unknown,
+  nulls: `first` | `last` = `first`
+): number => {
+  return ascComparator(b, a, nulls === `first` ? `last` : `first`)
 }

--- a/packages/db/src/utils/comparison.ts
+++ b/packages/db/src/utils/comparison.ts
@@ -1,3 +1,5 @@
+import type { CompareOptions } from "../query/builder/types"
+
 // WeakMap to store stable IDs for objects
 const objectIds = new WeakMap<object, number>()
 let nextObjectId = 1
@@ -19,11 +21,9 @@ function getObjectId(obj: object): number {
  * Handles null/undefined, strings, arrays, dates, objects, and primitives
  * Always sorts null/undefined values first
  */
-export const ascComparator = (
-  a: any,
-  b: any,
-  nulls: `first` | `last` = `first`
-): number => {
+export const ascComparator = (a: any, b: any, opts: CompareOptions): number => {
+  const { nulls } = opts
+
   // Handle null/undefined
   if (a == null && b == null) return 0
   if (a == null) return nulls === `first` ? -1 : 1
@@ -31,13 +31,16 @@ export const ascComparator = (
 
   // if a and b are both strings, compare them based on locale
   if (typeof a === `string` && typeof b === `string`) {
-    return a.localeCompare(b)
+    if (opts.stringSort === `locale`) {
+      return a.localeCompare(b, opts.locale, opts.localeOptions)
+    }
+    // For lexical sort we rely on direct comparison for primitive values
   }
 
   // if a and b are both arrays, compare them element by element
   if (Array.isArray(a) && Array.isArray(b)) {
     for (let i = 0; i < Math.min(a.length, b.length); i++) {
-      const result = ascComparator(a[i], b[i], nulls)
+      const result = ascComparator(a[i], b[i], opts)
       if (result !== 0) {
         return result
       }
@@ -81,7 +84,29 @@ export const ascComparator = (
 export const descComparator = (
   a: unknown,
   b: unknown,
-  nulls: `first` | `last` = `first`
+  opts: CompareOptions
 ): number => {
-  return ascComparator(b, a, nulls === `first` ? `last` : `first`)
+  return ascComparator(b, a, {
+    ...opts,
+    nulls: opts.nulls === `first` ? `last` : `first`,
+  })
 }
+
+export function makeComparator(
+  opts: CompareOptions
+): (a: any, b: any) => number {
+  return (a, b) => {
+    if (opts.direction === `asc`) {
+      return ascComparator(a, b, opts)
+    } else {
+      return descComparator(a, b, opts)
+    }
+  }
+}
+
+/** Default comparator orders values in ascending order with nulls first and locale string comparison. */
+export const defaultComparator = makeComparator({
+  direction: `asc`,
+  nulls: `first`,
+  stringSort: `locale`,
+})

--- a/packages/db/tests/query/builder/order-by.test.ts
+++ b/packages/db/tests/query/builder/order-by.test.ts
@@ -20,7 +20,7 @@ const employeesCollection = new CollectionImpl<Employee>({
 })
 
 describe(`QueryBuilder.orderBy`, () => {
-  it(`sets the order by clause correctly with default ascending`, () => {
+  it(`sets the order by clause correctly with default options`, () => {
     const builder = new Query()
     const query = builder
       .from({ employees: employeesCollection })
@@ -38,7 +38,9 @@ describe(`QueryBuilder.orderBy`, () => {
       `employees`,
       `name`,
     ])
-    expect(builtQuery.orderBy![0]!.direction).toBe(`asc`)
+    expect(builtQuery.orderBy![0]!.compareOptions.direction).toBe(`asc`)
+    expect(builtQuery.orderBy![0]!.compareOptions.nulls).toBe(`first`)
+    expect(builtQuery.orderBy![0]!.compareOptions.stringSort).toBe(`locale`)
   })
 
   it(`supports descending order`, () => {
@@ -58,7 +60,9 @@ describe(`QueryBuilder.orderBy`, () => {
       `employees`,
       `salary`,
     ])
-    expect(builtQuery.orderBy![0]!.direction).toBe(`desc`)
+    expect(builtQuery.orderBy![0]!.compareOptions.direction).toBe(`desc`)
+    expect(builtQuery.orderBy![0]!.compareOptions.nulls).toBe(`first`)
+    expect(builtQuery.orderBy![0]!.compareOptions.stringSort).toBe(`locale`)
   })
 
   it(`supports ascending order explicitly`, () => {
@@ -70,6 +74,98 @@ describe(`QueryBuilder.orderBy`, () => {
     const builtQuery = getQueryIR(query)
     expect(builtQuery.orderBy).toBeDefined()
     expect(builtQuery.orderBy).toHaveLength(1)
+  })
+
+  it(`supports nulls first/last`, () => {
+    const builder = new Query()
+    const query = builder
+      .from({ employees: employeesCollection })
+      .orderBy(({ employees }) => employees.hire_date, {
+        direction: `asc`,
+        nulls: `last`,
+      })
+      .select(({ employees }) => ({
+        id: employees.id,
+        hire_date: employees.hire_date,
+      }))
+
+    const builtQuery = getQueryIR(query)
+    expect(builtQuery.orderBy).toBeDefined()
+    expect(builtQuery.orderBy).toHaveLength(1)
+    expect(builtQuery.orderBy![0]!.compareOptions.direction).toBe(`asc`)
+    expect(builtQuery.orderBy![0]!.compareOptions.nulls).toBe(`last`)
+    expect(builtQuery.orderBy![0]!.compareOptions.stringSort).toBe(`locale`)
+  })
+
+  it(`supports stringSort`, () => {
+    const builder = new Query()
+    const query = builder
+      .from({ employees: employeesCollection })
+      .orderBy(({ employees }) => employees.name, {
+        direction: `asc`,
+        stringSort: `lexical`,
+      })
+      .select(({ employees }) => ({
+        id: employees.id,
+        name: employees.name,
+      }))
+
+    const builtQuery = getQueryIR(query)
+    expect(builtQuery.orderBy).toBeDefined()
+    expect(builtQuery.orderBy).toHaveLength(1)
+    expect(builtQuery.orderBy![0]!.compareOptions.stringSort).toBe(`lexical`)
+    expect(builtQuery.orderBy![0]!.compareOptions.nulls).toBe(`first`)
+    expect(builtQuery.orderBy![0]!.compareOptions.direction).toBe(`asc`)
+  })
+
+  it(`supports locale`, () => {
+    const builder = new Query()
+    const query = builder
+      .from({ employees: employeesCollection })
+      .orderBy(({ employees }) => employees.name, {
+        direction: `asc`,
+        stringSort: `locale`,
+        locale: `de-DE`,
+      })
+      .select(({ employees }) => ({
+        id: employees.id,
+        name: employees.name,
+      }))
+
+    const builtQuery = getQueryIR(query)
+    expect(builtQuery.orderBy).toBeDefined()
+    expect(builtQuery.orderBy).toHaveLength(1)
+    expect(builtQuery.orderBy![0]!.compareOptions.stringSort).toBe(`locale`)
+    expect(builtQuery.orderBy![0]!.compareOptions.locale).toBe(`de-DE`)
+    expect(builtQuery.orderBy![0]!.compareOptions.nulls).toBe(`first`)
+    expect(builtQuery.orderBy![0]!.compareOptions.direction).toBe(`asc`)
+  })
+
+  it(`supports locale options`, () => {
+    const builder = new Query()
+    const query = builder
+      .from({ employees: employeesCollection })
+      .orderBy(({ employees }) => employees.name, {
+        direction: `asc`,
+        stringSort: `locale`,
+        locale: `de-DE`,
+        localeOptions: { sensitivity: `base` },
+      })
+      .select(({ employees }) => ({
+        id: employees.id,
+        name: employees.name,
+      }))
+
+    const builtQuery = getQueryIR(query)
+    expect(builtQuery.orderBy).toBeDefined()
+    expect(builtQuery.orderBy).toHaveLength(1)
+    expect(builtQuery.orderBy![0]!.compareOptions.stringSort).toBe(`locale`)
+    expect(builtQuery.orderBy![0]!.compareOptions.locale).toBe(`de-DE`)
+    expect(builtQuery.orderBy![0]!.compareOptions.localeOptions).toEqual({
+      sensitivity: `base`,
+    })
+    expect(builtQuery.orderBy![0]!.compareOptions.nulls).toBe(`first`)
+    expect(builtQuery.orderBy![0]!.compareOptions.direction).toBe(`asc`)
   })
 
   it(`supports simple order by expressions`, () => {
@@ -104,7 +200,9 @@ describe(`QueryBuilder.orderBy`, () => {
     // The function expression gets wrapped, so we check if it contains the function
     const orderByClause = builtQuery.orderBy![0]!
     expect(orderByClause.expression.type).toBeDefined()
-    expect(orderByClause.direction).toBe(`asc`)
+    expect(orderByClause.compareOptions.direction).toBe(`asc`)
+    expect(orderByClause.compareOptions.nulls).toBe(`first`)
+    expect(orderByClause.compareOptions.stringSort).toBe(`locale`)
   })
 
   it(`can be combined with other clauses`, () => {
@@ -141,12 +239,16 @@ describe(`QueryBuilder.orderBy`, () => {
       `employees`,
       `name`,
     ])
-    expect(builtQuery.orderBy![0]!.direction).toBe(`asc`)
+    expect(builtQuery.orderBy![0]!.compareOptions.direction).toBe(`asc`)
+    expect(builtQuery.orderBy![0]!.compareOptions.nulls).toBe(`first`)
+    expect(builtQuery.orderBy![0]!.compareOptions.stringSort).toBe(`locale`)
     expect((builtQuery.orderBy![1]!.expression as any).path).toEqual([
       `employees`,
       `salary`,
     ])
-    expect(builtQuery.orderBy![1]!.direction).toBe(`desc`)
+    expect(builtQuery.orderBy![1]!.compareOptions.direction).toBe(`desc`)
+    expect(builtQuery.orderBy![1]!.compareOptions.nulls).toBe(`first`)
+    expect(builtQuery.orderBy![1]!.compareOptions.stringSort).toBe(`locale`)
   })
 
   it(`supports limit and offset with order by`, () => {

--- a/packages/db/tests/query/optimizer.test.ts
+++ b/packages/db/tests/query/optimizer.test.ts
@@ -366,8 +366,11 @@ describe(`Query Optimizer`, () => {
         orderBy: [
           {
             expression: createPropRef(`u`, `name`),
-            direction: `asc`,
-            nulls: `first`,
+            compareOptions: {
+              direction: `asc`,
+              nulls: `first`,
+              stringSort: `locale`,
+            },
           },
         ],
         limit: 10,
@@ -1158,8 +1161,11 @@ describe(`Query Optimizer`, () => {
         orderBy: [
           {
             expression: createPropRef(`u`, `salary`),
-            direction: `desc`,
-            nulls: `first`,
+            compareOptions: {
+              direction: `desc`,
+              nulls: `first`,
+              stringSort: `locale`,
+            },
           },
         ],
         limit: 10, // Top 10 highest paid users
@@ -1318,8 +1324,11 @@ describe(`Query Optimizer`, () => {
         orderBy: [
           {
             expression: createPropRef(`u`, `name`),
-            direction: `asc`,
-            nulls: `first`,
+            compareOptions: {
+              direction: `asc`,
+              nulls: `first`,
+              stringSort: `locale`,
+            },
           },
         ],
         // No LIMIT or OFFSET - safe to optimize

--- a/packages/db/tests/query/optimizer.test.ts
+++ b/packages/db/tests/query/optimizer.test.ts
@@ -363,7 +363,13 @@ describe(`Query Optimizer`, () => {
             createValue(5)
           ),
         ],
-        orderBy: [{ expression: createPropRef(`u`, `name`), direction: `asc` }],
+        orderBy: [
+          {
+            expression: createPropRef(`u`, `name`),
+            direction: `asc`,
+            nulls: `first`,
+          },
+        ],
         limit: 10,
         offset: 5,
         fnSelect: () => ({ name: `test` }),
@@ -1150,7 +1156,11 @@ describe(`Query Optimizer`, () => {
       const subqueryWithLimitedOrder: QueryIR = {
         from: new CollectionRef(mockCollection, `u`),
         orderBy: [
-          { expression: createPropRef(`u`, `salary`), direction: `desc` },
+          {
+            expression: createPropRef(`u`, `salary`),
+            direction: `desc`,
+            nulls: `first`,
+          },
         ],
         limit: 10, // Top 10 highest paid users
       }
@@ -1305,7 +1315,13 @@ describe(`Query Optimizer`, () => {
     test(`should safely optimize ORDER BY without LIMIT/OFFSET`, () => {
       const subqueryWithOrderOnly: QueryIR = {
         from: new CollectionRef(mockCollection, `u`),
-        orderBy: [{ expression: createPropRef(`u`, `name`), direction: `asc` }],
+        orderBy: [
+          {
+            expression: createPropRef(`u`, `name`),
+            direction: `asc`,
+            nulls: `first`,
+          },
+        ],
         // No LIMIT or OFFSET - safe to optimize
       }
 

--- a/packages/db/tests/query/order-by.test.ts
+++ b/packages/db/tests/query/order-by.test.ts
@@ -705,7 +705,10 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
         const collection = createLiveQueryCollection((q) =>
           q
             .from({ employees: employeesWithNullableCollection })
-            .orderBy(({ employees }) => employees.salary, `asc`, `first`)
+            .orderBy(({ employees }) => employees.salary, {
+              direction: `asc`,
+              nulls: `first`,
+            })
             .select(({ employees }) => ({
               id: employees.id,
               name: employees.name,
@@ -733,7 +736,10 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
         const collection = createLiveQueryCollection((q) =>
           q
             .from({ employees: employeesWithNullableCollection })
-            .orderBy(({ employees }) => employees.salary, `asc`, `last`)
+            .orderBy(({ employees }) => employees.salary, {
+              direction: `asc`,
+              nulls: `last`,
+            })
             .select(({ employees }) => ({
               id: employees.id,
               name: employees.name,
@@ -761,7 +767,10 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
         const collection = createLiveQueryCollection((q) =>
           q
             .from({ employees: employeesWithNullableCollection })
-            .orderBy(({ employees }) => employees.salary, `desc`, `first`)
+            .orderBy(({ employees }) => employees.salary, {
+              direction: `desc`,
+              nulls: `first`,
+            })
             .select(({ employees }) => ({
               id: employees.id,
               name: employees.name,
@@ -789,7 +798,10 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
         const collection = createLiveQueryCollection((q) =>
           q
             .from({ employees: employeesWithNullableCollection })
-            .orderBy(({ employees }) => employees.salary, `desc`, `last`)
+            .orderBy(({ employees }) => employees.salary, {
+              direction: `desc`,
+              nulls: `last`,
+            })
             .select(({ employees }) => ({
               id: employees.id,
               name: employees.name,
@@ -817,8 +829,14 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
         const collection = createLiveQueryCollection((q) =>
           q
             .from({ employees: employeesWithNullableCollection })
-            .orderBy(({ employees }) => employees.department_id, `asc`, `first`)
-            .orderBy(({ employees }) => employees.salary, `desc`, `last`)
+            .orderBy(({ employees }) => employees.department_id, {
+              direction: `asc`,
+              nulls: `first`,
+            })
+            .orderBy(({ employees }) => employees.salary, {
+              direction: `desc`,
+              nulls: `last`,
+            })
             .select(({ employees }) => ({
               id: employees.id,
               name: employees.name,
@@ -852,7 +870,10 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
         const collection = createLiveQueryCollection((q) =>
           q
             .from({ employees: employeesWithNullableCollection })
-            .orderBy(({ employees }) => employees.salary, `asc`, `first`)
+            .orderBy(({ employees }) => employees.salary, {
+              direction: `asc`,
+              nulls: `first`,
+            })
             .select(({ employees }) => ({
               id: employees.id,
               name: employees.name,

--- a/packages/db/tests/query/order-by.test.ts
+++ b/packages/db/tests/query/order-by.test.ts
@@ -55,6 +55,15 @@ interface Department {
   budget: number
 }
 
+// Test schema for nullable fields
+interface EmployeeWithNullableFields {
+  id: number
+  name: string
+  department_id: number | null
+  salary: number | null
+  hire_date: string
+}
+
 // Test data
 const employeeData: Array<Employee> = [
   {
@@ -99,6 +108,52 @@ const departmentData: Array<Department> = [
   { id: 2, name: `Sales`, budget: 300000 },
 ]
 
+// Test data with nullable fields
+const employeeWithNullableData: Array<EmployeeWithNullableFields> = [
+  {
+    id: 1,
+    name: `Alice`,
+    department_id: 1,
+    salary: 50000,
+    hire_date: `2020-01-15`,
+  },
+  {
+    id: 2,
+    name: `Bob`,
+    department_id: 2,
+    salary: null,
+    hire_date: `2019-03-20`,
+  },
+  {
+    id: 3,
+    name: `Charlie`,
+    department_id: null,
+    salary: 55000,
+    hire_date: `2021-06-10`,
+  },
+  {
+    id: 4,
+    name: `Diana`,
+    department_id: 2,
+    salary: 65000,
+    hire_date: `2018-11-05`,
+  },
+  {
+    id: 5,
+    name: `Eve`,
+    department_id: 1,
+    salary: 52000,
+    hire_date: `2022-02-28`,
+  },
+  {
+    id: 6,
+    name: `Frank`,
+    department_id: null,
+    salary: null,
+    hire_date: `2023-01-01`,
+  },
+]
+
 function createEmployeesCollection(autoIndex: `off` | `eager` = `eager`) {
   return createCollection(
     mockSyncCollectionOptions<Employee>({
@@ -116,6 +171,19 @@ function createDepartmentsCollection(autoIndex: `off` | `eager` = `eager`) {
       id: `test-departments`,
       getKey: (department) => department.id,
       initialData: departmentData,
+      autoIndex,
+    })
+  )
+}
+
+function createEmployeesWithNullableCollection(
+  autoIndex: `off` | `eager` = `eager`
+) {
+  return createCollection(
+    mockSyncCollectionOptions<EmployeeWithNullableFields>({
+      id: `test-employees-nullable`,
+      getKey: (employee) => employee.id,
+      initialData: employeeWithNullableData,
       autoIndex,
     })
   )
@@ -620,6 +688,220 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
 
         const results = Array.from(collection.values())
         expect(results).toHaveLength(0)
+      })
+    })
+
+    describe(`Nullable Column OrderBy`, () => {
+      let employeesWithNullableCollection: ReturnType<
+        typeof createEmployeesWithNullableCollection
+      >
+
+      beforeEach(() => {
+        employeesWithNullableCollection =
+          createEmployeesWithNullableCollection(autoIndex)
+      })
+
+      it(`orders by nullable column ascending with nulls first`, async () => {
+        const collection = createLiveQueryCollection((q) =>
+          q
+            .from({ employees: employeesWithNullableCollection })
+            .orderBy(({ employees }) => employees.salary, `asc`, `first`)
+            .select(({ employees }) => ({
+              id: employees.id,
+              name: employees.name,
+              salary: employees.salary,
+            }))
+        )
+        await collection.preload()
+
+        const results = Array.from(collection.values())
+
+        expect(results).toHaveLength(6)
+
+        // Should have nulls first, then sorted by salary ascending
+        expect(results.map((r) => r.salary)).toEqual([
+          null, // Frank
+          null, // Bob
+          50000, // Alice
+          52000, // Eve
+          55000, // Charlie
+          65000, // Diana
+        ])
+      })
+
+      it(`orders by nullable column ascending with nulls last`, async () => {
+        const collection = createLiveQueryCollection((q) =>
+          q
+            .from({ employees: employeesWithNullableCollection })
+            .orderBy(({ employees }) => employees.salary, `asc`, `last`)
+            .select(({ employees }) => ({
+              id: employees.id,
+              name: employees.name,
+              salary: employees.salary,
+            }))
+        )
+        await collection.preload()
+
+        const results = Array.from(collection.values())
+
+        expect(results).toHaveLength(6)
+
+        // Should have lowest salaries first, then nulls last
+        expect(results.map((r) => r.salary)).toEqual([
+          50000, // Alice
+          52000, // Eve
+          55000, // Charlie
+          65000, // Diana
+          null, // Bob
+          null, // Frank
+        ])
+      })
+
+      it(`orders by nullable column descending with nulls first`, async () => {
+        const collection = createLiveQueryCollection((q) =>
+          q
+            .from({ employees: employeesWithNullableCollection })
+            .orderBy(({ employees }) => employees.salary, `desc`, `first`)
+            .select(({ employees }) => ({
+              id: employees.id,
+              name: employees.name,
+              salary: employees.salary,
+            }))
+        )
+        await collection.preload()
+
+        const results = Array.from(collection.values())
+
+        expect(results).toHaveLength(6)
+
+        // Should have nulls first, then highest salaries
+        expect(results.map((r) => r.salary)).toEqual([
+          null, // Frank
+          null, // Bob
+          65000, // Diana
+          55000, // Charlie
+          52000, // Eve
+          50000, // Alice
+        ])
+      })
+
+      it(`orders by nullable column descending with nulls last`, async () => {
+        const collection = createLiveQueryCollection((q) =>
+          q
+            .from({ employees: employeesWithNullableCollection })
+            .orderBy(({ employees }) => employees.salary, `desc`, `last`)
+            .select(({ employees }) => ({
+              id: employees.id,
+              name: employees.name,
+              salary: employees.salary,
+            }))
+        )
+        await collection.preload()
+
+        const results = Array.from(collection.values())
+
+        expect(results).toHaveLength(6)
+
+        // Should have highest salaries first, then nulls last
+        expect(results.map((r) => r.salary)).toEqual([
+          65000, // Diana
+          55000, // Charlie
+          52000, // Eve
+          50000, // Alice
+          null, // Bob
+          null, // Frank
+        ])
+      })
+
+      it(`orders by multiple nullable columns`, async () => {
+        const collection = createLiveQueryCollection((q) =>
+          q
+            .from({ employees: employeesWithNullableCollection })
+            .orderBy(({ employees }) => employees.department_id, `asc`, `first`)
+            .orderBy(({ employees }) => employees.salary, `desc`, `last`)
+            .select(({ employees }) => ({
+              id: employees.id,
+              name: employees.name,
+              department_id: employees.department_id,
+              salary: employees.salary,
+            }))
+        )
+        await collection.preload()
+
+        const results = Array.from(collection.values())
+
+        expect(results).toHaveLength(6)
+
+        // Should be ordered by department_id ASC (nulls first), then salary DESC (nulls last)
+        // Department null: Charlie (55000), Frank (null)
+        // Department 1: Alice (50000), Eve (52000)
+        // Department 2: Diana (65000), Bob (null)
+        expect(
+          results.map((r) => ({ dept: r.department_id, salary: r.salary }))
+        ).toEqual([
+          { dept: null, salary: 55000 }, // Charlie
+          { dept: null, salary: null }, // Frank
+          { dept: 1, salary: 52000 }, // Eve
+          { dept: 1, salary: 50000 }, // Alice
+          { dept: 2, salary: 65000 }, // Diana
+          { dept: 2, salary: null }, // Bob
+        ])
+      })
+
+      it(`maintains stable ordering during live updates with nullable fields`, async () => {
+        const collection = createLiveQueryCollection((q) =>
+          q
+            .from({ employees: employeesWithNullableCollection })
+            .orderBy(({ employees }) => employees.salary, `asc`, `first`)
+            .select(({ employees }) => ({
+              id: employees.id,
+              name: employees.name,
+              salary: employees.salary,
+            }))
+        )
+        await collection.preload()
+
+        // Get initial order
+        const initialResults = Array.from(collection.values())
+        expect(initialResults.map((r) => r.salary)).toEqual([
+          null,
+          null,
+          50000,
+          52000,
+          55000,
+          65000,
+        ])
+
+        // Add a new employee with null salary
+        const newEmployee = {
+          id: 7,
+          name: `Grace`,
+          department_id: 1,
+          salary: null,
+          hire_date: `2023-01-01`,
+        }
+        employeesWithNullableCollection.utils.begin()
+        employeesWithNullableCollection.utils.write({
+          type: `insert`,
+          value: newEmployee,
+        })
+        employeesWithNullableCollection.utils.commit()
+
+        // Check that ordering is maintained with new null item
+        const updatedResults = Array.from(collection.values())
+        expect(updatedResults.map((r) => r.salary)).toEqual([
+          null,
+          null,
+          null,
+          50000,
+          52000,
+          55000,
+          65000,
+        ])
+
+        // Verify the new item is in the correct position
+        const graceIndex = updatedResults.findIndex((r) => r.name === `Grace`)
+        expect(graceIndex).toBeLessThan(3) // Should be among the nulls
       })
     })
   })


### PR DESCRIPTION
Fixes https://github.com/TanStack/db/issues/212 and fixes https://github.com/TanStack/db/issues/229 by adding a configuration argument to `orderBy`:
```ts
orderBy(
  callback: OrderByCallback<TContext>,
  options: OrderByDirection | OrderByOptions = `asc`
)

type OrderByOptions = {
  direction?: OrderByDirection
  nulls?: `first` | `last`
} & StringSortOpts

type StringSortOpts =
  | {
      stringSort?: `lexical`
    }
  | {
      stringSort?: `locale`
      locale?: string
      localeOptions?: object
    }
```