### PR TITLE
feat: improve writeBatch API to use callback pattern

### DIFF
--- a/.changeset/dirty-birds-accept.md
+++ b/.changeset/dirty-birds-accept.md
@@ -1,0 +1,10 @@
+---
+"@tanstack/query-db-collection": patch
+---
+
+Improve writeBatch API to use callback pattern
+
+- Changed `writeBatch` from accepting an array of operations to accepting a callback function
+- Write operations called within the callback are automatically batched together
+- This provides a more intuitive API similar to database transactions
+- Added comprehensive documentation for Query Collections including direct writes feature

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -1,0 +1,311 @@
+---
+title: Query Collection
+---
+
+# Query Collection
+
+Query collections provide seamless integration between TanStack DB and TanStack Query, enabling automatic synchronization between your local database and remote data sources.
+
+## Overview
+
+The `@tanstack/query-db-collection` package allows you to create collections that:
+- Automatically sync with remote data via TanStack Query
+- Support optimistic updates with automatic rollback on errors
+- Handle persistence through customizable mutation handlers
+- Provide direct write capabilities as an escape hatch for advanced scenarios
+
+## Installation
+
+```bash
+npm install @tanstack/query-db-collection @tanstack/query-core @tanstack/db
+```
+
+## Basic Usage
+
+```typescript
+import { QueryClient } from '@tanstack/query-core'
+import { createCollection } from '@tanstack/db'
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
+
+const queryClient = new QueryClient()
+
+const todosCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos'],
+    queryFn: async () => {
+      const response = await fetch('/api/todos')
+      return response.json()
+    },
+    queryClient,
+    getKey: (item) => item.id,
+  })
+)
+```
+
+### Using Meta for Additional Context
+
+The `meta` option allows you to pass additional context to your query function:
+
+```typescript
+const todosCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos', userId],
+    queryFn: async (context) => {
+      // Access meta from the context
+      const { meta, queryKey } = context
+      const headers = meta?.authToken 
+        ? { Authorization: `Bearer ${meta.authToken}` }
+        : {}
+      
+      const response = await fetch(`/api/users/${queryKey[1]}/todos`, { headers })
+      return response.json()
+    },
+    queryClient,
+    getKey: (item) => item.id,
+    // Pass metadata that will be available in queryFn
+    meta: {
+      authToken: getAuthToken(),
+      apiVersion: 'v2',
+    }
+  })
+)
+```
+
+## Configuration Options
+
+The `queryCollectionOptions` function accepts the following options:
+
+### Required Options
+
+- `queryKey`: The query key for TanStack Query
+- `queryFn`: Function that fetches data from the server
+- `queryClient`: TanStack Query client instance
+- `getKey`: Function to extract the unique key from an item
+
+### Query Options
+
+- `enabled`: Whether the query should automatically run (default: `true`)
+- `refetchInterval`: Refetch interval in milliseconds
+- `retry`: Retry configuration for failed queries
+- `retryDelay`: Delay between retries
+- `staleTime`: How long data is considered fresh
+- `meta`: Optional metadata that will be passed to the query function context
+
+### Collection Options
+
+- `id`: Unique identifier for the collection
+- `schema`: Schema for validating items
+- `sync`: Custom sync configuration
+- `startSync`: Whether to start syncing immediately (default: `true`)
+
+### Persistence Handlers
+
+- `onInsert`: Handler called before insert operations
+- `onUpdate`: Handler called before update operations
+- `onDelete`: Handler called before delete operations
+
+## Persistence Handlers
+
+You can define handlers that are called when mutations occur. These handlers can persist changes to your backend and control whether the query should refetch after the operation:
+
+```typescript
+const todosCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos'],
+    queryFn: fetchTodos,
+    queryClient,
+    getKey: (item) => item.id,
+    
+    onInsert: async ({ transaction }) => {
+      const newItems = transaction.mutations.map(m => m.modified)
+      await api.createTodos(newItems)
+      // Returning nothing or { refetch: true } will trigger a refetch
+      // Return { refetch: false } to skip automatic refetch
+    },
+    
+    onUpdate: async ({ transaction }) => {
+      const updates = transaction.mutations.map(m => ({
+        id: m.key,
+        changes: m.changes
+      }))
+      await api.updateTodos(updates)
+    },
+    
+    onDelete: async ({ transaction }) => {
+      const ids = transaction.mutations.map(m => m.key)
+      await api.deleteTodos(ids)
+    }
+  })
+)
+```
+
+### Controlling Refetch Behavior
+
+By default, after any persistence handler (`onInsert`, `onUpdate`, or `onDelete`) completes successfully, the query will automatically refetch to ensure the local state matches the server state.
+
+You can control this behavior by returning an object with a `refetch` property:
+
+```typescript
+onInsert: async ({ transaction }) => {
+  await api.createTodos(transaction.mutations.map(m => m.modified))
+  
+  // Skip the automatic refetch
+  return { refetch: false }
+}
+```
+
+This is useful when:
+- You're confident the server state matches what you sent
+- You want to avoid unnecessary network requests
+- You're handling state updates through other mechanisms (like WebSockets)
+
+## Utility Methods
+
+The collection provides these utility methods via `collection.utils`:
+
+- `refetch()`: Manually trigger a refetch of the query
+
+## Direct Writes (Advanced)
+
+Direct writes are an escape hatch for scenarios where the normal query/mutation flow doesn't fit your needs. They allow you to manually sync data from alternative sources like WebSockets, server-sent events, or when dealing with large datasets where full refetches are inefficient.
+
+### When to Use Direct Writes
+
+Direct writes should be used when:
+- You need to sync real-time updates from WebSockets or server-sent events
+- You're dealing with large datasets where refetching everything is too expensive
+- You receive incremental updates or server-computed field updates
+- You need to implement complex pagination or partial data loading scenarios
+
+### Individual Write Operations
+
+```typescript
+// Insert a new item
+todosCollection.utils.writeInsert({ id: '1', text: 'Buy milk', completed: false })
+
+// Update an existing item
+todosCollection.utils.writeUpdate({ id: '1', completed: true })
+
+// Delete an item
+todosCollection.utils.writeDelete('1')
+
+// Upsert (insert or update)
+todosCollection.utils.writeUpsert({ id: '1', text: 'Buy milk', completed: false })
+```
+
+### Batch Operations
+
+The `writeBatch` method allows you to perform multiple operations atomically. Any write operations called within the callback will be collected and executed as a single transaction:
+
+```typescript
+todosCollection.utils.writeBatch(() => {
+  todosCollection.utils.writeInsert({ id: '1', text: 'Buy milk' })
+  todosCollection.utils.writeInsert({ id: '2', text: 'Walk dog' })
+  todosCollection.utils.writeUpdate({ id: '3', completed: true })
+  todosCollection.utils.writeDelete('4')
+})
+```
+
+### Real-World Example: WebSocket Integration
+
+```typescript
+// Handle real-time updates from WebSocket without triggering full refetches
+ws.on('todos:update', (changes) => {
+  todosCollection.utils.writeBatch(() => {
+    changes.forEach(change => {
+      switch (change.type) {
+        case 'insert':
+          todosCollection.utils.writeInsert(change.data)
+          break
+        case 'update':
+          todosCollection.utils.writeUpdate(change.data)
+          break
+        case 'delete':
+          todosCollection.utils.writeDelete(change.id)
+          break
+      }
+    })
+  })
+})
+```
+
+### Example: Incremental Updates
+
+```typescript
+// Handle server responses after mutations without full refetch
+const createTodo = async (todo) => {
+  // Optimistically add the todo
+  const tempId = crypto.randomUUID()
+  todosCollection.insert({ ...todo, id: tempId })
+  
+  try {
+    // Send to server
+    const serverTodo = await api.createTodo(todo)
+    
+    // Sync the server response (with server-generated ID and timestamps)
+    // without triggering a full collection refetch
+    todosCollection.utils.writeBatch(() => {
+      todosCollection.utils.writeDelete(tempId)
+      todosCollection.utils.writeInsert(serverTodo)
+    })
+  } catch (error) {
+    // Rollback happens automatically
+    throw error
+  }
+}
+```
+
+### Example: Large Dataset Pagination
+
+```typescript
+// Load additional pages without refetching existing data
+const loadMoreTodos = async (page) => {
+  const newTodos = await api.getTodos({ page, limit: 50 })
+  
+  // Add new items without affecting existing ones
+  todosCollection.utils.writeBatch(() => {
+    newTodos.forEach(todo => {
+      todosCollection.utils.writeInsert(todo)
+    })
+  })
+}
+```
+
+## Important Behaviors
+
+### Full State Sync
+
+The query collection treats the `queryFn` result as the **complete state** of the collection. This means:
+
+- Items present in the collection but not in the query result will be deleted
+- Items in the query result but not in the collection will be inserted
+- Items present in both will be updated if they differ
+
+### Empty Array Behavior
+
+When `queryFn` returns an empty array, **all items in the collection will be deleted**. This is because the collection interprets an empty array as "the server has no items".
+
+```typescript
+// This will delete all items in the collection
+queryFn: async () => []
+```
+
+### Direct Writes and Query Sync
+
+Direct writes update the collection immediately and also update the TanStack Query cache. However, they do not prevent the normal query sync behavior. If your `queryFn` returns data that conflicts with your direct writes, the query data will take precedence.
+
+To handle this properly:
+1. Use `{ refetch: false }` in your persistence handlers when using direct writes
+2. Set appropriate `staleTime` to prevent unnecessary refetches
+3. Design your `queryFn` to be aware of incremental updates (e.g., only fetch new data)
+
+## Complete Direct Write API Reference
+
+All direct write methods are available on `collection.utils`:
+
+- `writeInsert(data)`: Insert one or more items directly
+- `writeUpdate(data)`: Update one or more items directly
+- `writeDelete(keys)`: Delete one or more items directly
+- `writeUpsert(data)`: Insert or update one or more items directly
+- `writeBatch(callback)`: Perform multiple operations atomically
+- `refetch()`: Manually trigger a refetch of the query

--- a/docs/config.json
+++ b/docs/config.json
@@ -79,6 +79,15 @@
       ]
     },
     {
+      "label": "Collections",
+      "children": [
+        {
+          "label": "Query Collection",
+          "to": "collections/query-collection"
+        }
+      ]
+    },
+    {
       "label": "API Reference",
       "children": [
         {

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -6,7 +6,6 @@ import {
   QueryKeyRequiredError,
 } from "./errors"
 import { createWriteUtils } from "./manual-sync"
-import type { SyncOperation } from "./manual-sync"
 import type {
   QueryClient,
   QueryFunctionContext,
@@ -241,9 +240,7 @@ export interface QueryCollectionUtils<
   writeUpdate: (updates: Partial<TItem> | Array<Partial<TItem>>) => void
   writeDelete: (keys: TKey | Array<TKey>) => void
   writeUpsert: (data: Partial<TItem> | Array<Partial<TItem>>) => void
-  writeBatch: (
-    operations: Array<SyncOperation<TItem, TKey, TInsertInput>>
-  ) => void
+  writeBatch: (callback: () => void) => void
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR improves the writeBatch API in @tanstack/query-db-collection by changing it from accepting an array of operations to accepting a callback function. This provides a more intuitive API similar to database transactions.

## Changes

### API Improvement
- Changed `writeBatch` to accept a callback function instead of an array of operations
- Write operations called within the callback are automatically batched together
- This follows the same pattern as `getActiveTransaction()` in the core DB package

### Before
```typescript
collection.utils.writeBatch([
  { type: 'insert', data: { id: '1', name: 'Item 1' } },
  { type: 'update', data: { id: '2', name: 'Updated' } }
])
```

### After
```typescript
collection.utils.writeBatch(() => {
  collection.utils.writeInsert({ id: '1', name: 'Item 1' })
  collection.utils.writeUpdate({ id: '2', name: 'Updated' })
})
```

### Documentation
- Added comprehensive documentation for Query Collections in a new "Collections" section
- Documented direct writes as an advanced/escape hatch API
- Included documentation for the meta support feature from #363
- Explained important behaviors like empty array handling and full state sync

## Related Issues
- Addresses feedback from #303
- Documents behavior discussed in #294

🤖 Generated with [Claude Code](https://claude.ai/code)