### PR TITLE
ensure that react useLiveQuery returns a stable ref when there are no changes

### DIFF
--- a/.changeset/ready-poems-fail.md
+++ b/.changeset/ready-poems-fail.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/react-db": patch
+---
+
+ensure that useLiveQuery returns a stable ref when there are no changes

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -114,6 +114,48 @@ describe(`Query Collections`, () => {
     })
   })
 
+  it(`should keep stable ref`, async () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `test-persons`,
+        getKey: (person: Person) => person.id,
+        initialData: initialPersons,
+      })
+    )
+
+    const { result, rerender } = renderHook(() => {
+      return useLiveQuery((q) =>
+        q
+          .from({ persons: collection })
+          .where(({ persons }) => gt(persons.age, 30))
+          .select(({ persons }) => ({
+            id: persons.id,
+            name: persons.name,
+            age: persons.age,
+          }))
+      )
+    })
+
+    // Wait for collection to sync and state to update
+    await waitFor(() => {
+      expect(result.current.state.size).toBe(1) // Only John Smith (age 35)
+    })
+
+    const data1 = result.current.data
+    expect(result.current.data).toHaveLength(1)
+
+    rerender()
+
+    const data2 = result.current.data
+
+    // Passes cause the underlying objects are stable
+    expect(data1).toEqual(data2)
+    expect(data1[0]).toBe(data2[0])
+
+    // Fails cause array isn't
+    expect(data1).toBe(data2)
+  })
+
   it(`should be able to query a collection with live updates`, async () => {
     const collection = createCollection(
       mockSyncCollectionOptions<Person>({


### PR DESCRIPTION
incorporates the test from #349 and fixes the issue.