### PR TITLE
Refactor select improving spread (`...obj`) and enabling nested projection.

### DIFF
--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -1,5 +1,13 @@
 import { CollectionImpl } from "../../collection.js"
-import { CollectionRef, QueryRef, Aggregate as AggregateExpr, Func as FuncExpr, PropRef, Value as ValueExpr } from "../ir.js"
+import {
+  Aggregate as AggregateExpr,
+  CollectionRef,
+  Func as FuncExpr,
+  PropRef,
+  QueryRef,
+  Value as ValueExpr,
+  isExpressionLike,
+} from "../ir.js"
 import {
   InvalidSourceError,
   JoinConditionMustBeEqualityError,
@@ -438,8 +446,8 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
       return (
         value !== null &&
         typeof value === `object` &&
-        !(`type` in value) &&
-        !(value as any).__refProxy
+        !isExpressionLike(value) &&
+        !value.__refProxy
       )
     }
 
@@ -461,7 +469,7 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
 
     return new BaseQueryBuilder({
       ...this.query,
-      select: select as any,
+      select: select,
       fnSelect: undefined, // remove the fnSelect clause if it exists
     }) as any
   }

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -26,7 +26,6 @@ import type {
   OrderByDirection,
   QueryIR,
 } from "../ir.js"
-// import { PropRef } from "../ir.js"
 import type {
   CompareOptions,
   Context,

--- a/packages/db/src/query/builder/ref-proxy.ts
+++ b/packages/db/src/query/builder/ref-proxy.ts
@@ -101,8 +101,7 @@ export function createRefProxy<T extends Record<string, any>>(
         if (typeof prop === `symbol`) return Reflect.get(target, prop, receiver)
 
         const newPath = [...path, String(prop)]
-        const child = createProxy(newPath)
-        return child
+        return createProxy(newPath)
       },
 
       has(target, prop) {
@@ -112,29 +111,14 @@ export function createRefProxy<T extends Record<string, any>>(
       },
 
       ownKeys(target) {
-        // If this is a table-level proxy (path length 1), inject a table spread sentinel
-        if (path.length === 1) {
-          const aliasName = path[0]!
-          const id = ++accessId
-          const sentinelKey = `__SPREAD_SENTINEL__${aliasName}__${id}`
-          if (!Object.prototype.hasOwnProperty.call(target, sentinelKey)) {
-            Object.defineProperty(target, sentinelKey, {
-              enumerable: true,
-              configurable: true,
-              value: true,
-            })
-          }
-        } else if (path.length > 1) {
-          // Nested spread: inject a unified spread sentinel using dotted path
-          const id = ++accessId
-          const sentinelKey = `__SPREAD_SENTINEL__${path.join(`.`)}__${id}`
-          if (!Object.prototype.hasOwnProperty.call(target, sentinelKey)) {
-            Object.defineProperty(target, sentinelKey, {
-              enumerable: true,
-              configurable: true,
-              value: true,
-            })
-          }
+        const id = ++accessId
+        const sentinelKey = `__SPREAD_SENTINEL__${path.join(`.`)}__${id}`
+        if (!Object.prototype.hasOwnProperty.call(target, sentinelKey)) {
+          Object.defineProperty(target, sentinelKey, {
+            enumerable: true,
+            configurable: true,
+            value: true,
+          })
         }
         return Reflect.ownKeys(target)
       },

--- a/packages/db/src/query/builder/ref-proxy.ts
+++ b/packages/db/src/query/builder/ref-proxy.ts
@@ -177,11 +177,7 @@ export function createRefProxy<T extends Record<string, any>>(
     },
 
     has(target, prop) {
-      if (
-        prop === `__refProxy` ||
-        prop === `__path` ||
-        prop === `__type`
-      )
+      if (prop === `__refProxy` || prop === `__path` || prop === `__type`)
         return true
       if (typeof prop === `string` && aliases.includes(prop)) return true
       return Reflect.has(target, prop)
@@ -192,11 +188,7 @@ export function createRefProxy<T extends Record<string, any>>(
     },
 
     getOwnPropertyDescriptor(target, prop) {
-      if (
-        prop === `__refProxy` ||
-        prop === `__path` ||
-        prop === `__type`
-      ) {
+      if (prop === `__refProxy` || prop === `__path` || prop === `__type`) {
         return { enumerable: false, configurable: true }
       }
       if (typeof prop === `string` && aliases.includes(prop)) {

--- a/packages/db/src/query/builder/ref-proxy.ts
+++ b/packages/db/src/query/builder/ref-proxy.ts
@@ -125,9 +125,9 @@ export function createRefProxy<T extends Record<string, any>>(
             })
           }
         } else if (path.length > 1) {
-          // Nested spread: inject a nested spread sentinel using dotted path
+          // Nested spread: inject a unified spread sentinel using dotted path
           const id = ++accessId
-          const sentinelKey = `__NESTED_SPREAD__${path.join(`.`)}__${id}`
+          const sentinelKey = `__SPREAD_SENTINEL__${path.join(`.`)}__${id}`
           if (!Object.prototype.hasOwnProperty.call(target, sentinelKey)) {
             Object.defineProperty(target, sentinelKey, {
               enumerable: true,

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -179,6 +179,9 @@ type SelectValue =
   | SpreadableRefProxy<any> // For spread operations without internal properties
   | Array<Ref<any>>
 
+// Recursive shape for select objects allowing nested projections
+type SelectShape = { [key: string]: SelectValue | SelectShape }
+
 /**
  * SelectObject - Wrapper type for select clause objects
  *
@@ -187,7 +190,7 @@ type SelectValue =
  * messages when invalid selections are attempted.
  */
 export type SelectObject<
-  T extends Record<string, SelectValue> = Record<string, SelectValue>,
+  T extends SelectShape = SelectShape,
 > = T
 
 /**

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -230,46 +230,61 @@ export type SelectObject<
  * ```
  */
 export type ResultTypeFromSelect<TSelectObject> = {
-  [K in keyof TSelectObject]: TSelectObject[K] extends RefProxy<infer T>
+  [K in keyof StripInternalKeys<TSelectObject>]: StripInternalKeys<TSelectObject>[K] extends RefProxy<
+    infer T
+  >
     ? T
-    : TSelectObject[K] extends Ref<infer T>
+    : StripInternalKeys<TSelectObject>[K] extends Ref<infer T>
       ? T
-      : TSelectObject[K] extends Ref<infer T> | undefined
+      : StripInternalKeys<TSelectObject>[K] extends Ref<infer T> | undefined
         ? T | undefined
-        : TSelectObject[K] extends Ref<infer T> | null
+        : StripInternalKeys<TSelectObject>[K] extends Ref<infer T> | null
           ? T | null
-          : TSelectObject[K] extends RefProxy<infer T> | undefined
+          : StripInternalKeys<TSelectObject>[K] extends
+                | RefProxy<infer T>
+                | undefined
             ? T | undefined
-            : TSelectObject[K] extends RefProxy<infer T> | null
+            : StripInternalKeys<TSelectObject>[K] extends RefProxy<
+                  infer T
+                > | null
               ? T | null
-              : TSelectObject[K] extends BasicExpression<infer T>
+              : StripInternalKeys<TSelectObject>[K] extends BasicExpression<
+                    infer T
+                  >
                 ? T
-                : TSelectObject[K] extends Aggregate<infer T>
+                : StripInternalKeys<TSelectObject>[K] extends Aggregate<infer T>
                   ? T
-                  : TSelectObject[K] extends RefProxyFor<infer T>
-                    ? T
-                    : TSelectObject[K] extends SpreadableRefProxy<infer T>
-                      ? ResultTypeFromSelect<SpreadableRefProxy<T>>
-                      : TSelectObject[K] extends string
-                        ? string
-                        : TSelectObject[K] extends number
-                          ? number
-                          : TSelectObject[K] extends boolean
-                            ? boolean
-                            : TSelectObject[K] extends null
-                              ? null
-                              : TSelectObject[K] extends undefined
-                                ? undefined
-                                : TSelectObject[K] extends { __type: infer U }
-                                  ? U
-                                  : TSelectObject[K] extends Record<string, any>
-                                    ? TSelectObject[K] extends {
-                                        __refProxy: true
-                                      }
-                                      ? never // This is a RefProxy, handled above
-                                      : ResultTypeFromSelect<TSelectObject[K]> // Recursive for nested objects
-                                    : never
+                  : StripInternalKeys<TSelectObject>[K] extends string
+                    ? string
+                    : StripInternalKeys<TSelectObject>[K] extends number
+                      ? number
+                      : StripInternalKeys<TSelectObject>[K] extends boolean
+                        ? boolean
+                        : StripInternalKeys<TSelectObject>[K] extends null
+                          ? null
+                          : StripInternalKeys<TSelectObject>[K] extends undefined
+                            ? undefined
+                            : StripInternalKeys<TSelectObject>[K] extends {
+                                  __type: infer U
+                                }
+                              ? U
+                              : StripInternalKeys<TSelectObject>[K] extends Record<
+                                    string,
+                                    any
+                                  >
+                                ? ResultTypeFromSelect<
+                                    StripInternalKeys<
+                                      StripInternalKeys<TSelectObject>[K]
+                                    >
+                                  >
+                                : never
 }
+
+// Helper to strip internal RefProxy keys from any object type
+type StripInternalKeys<T> =
+  T extends Record<string, any>
+    ? Omit<T, `__refProxy` | `__path` | `__type`>
+    : T
 
 /**
  * OrderByCallback - Type for orderBy clause callback functions

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -189,9 +189,7 @@ type SelectShape = { [key: string]: SelectValue | SelectShape }
  * for all their properties. It's a simple wrapper that provides better error
  * messages when invalid selections are attempted.
  */
-export type SelectObject<
-  T extends SelectShape = SelectShape,
-> = T
+export type SelectObject<T extends SelectShape = SelectShape> = T
 
 /**
  * ResultTypeFromSelect - Infers the result type from a select object

--- a/packages/db/src/query/compiler/index.ts
+++ b/packages/db/src/query/compiler/index.ts
@@ -7,12 +7,12 @@ import {
   LimitOffsetRequireOrderByError,
   UnsupportedFromTypeError,
 } from "../../errors.js"
+import { Value as ValClass } from "../ir.js"
 import { compileExpression } from "./evaluators.js"
 import { processJoins } from "./joins.js"
 import { processGroupBy } from "./group-by.js"
 import { processOrderBy } from "./order-by.js"
 import { processSelectToResults } from "./select.js"
-import { Value as ValClass } from "../ir.js"
 import type {
   BasicExpression,
   CollectionRef,
@@ -246,8 +246,11 @@ export function compileQuery(
         const finalResults =
           raw instanceof ValClass
             ? raw.value
-            : raw && typeof raw === `object` && `type` in raw && (raw as any).type === `val`
-              ? (raw as any).value
+            : raw &&
+                typeof raw === `object` &&
+                `type` in raw &&
+                raw.type === `val`
+              ? raw.value
               : raw
         return [key, [finalResults, orderByIndex]] as [unknown, [any, string]]
       })
@@ -275,8 +278,11 @@ export function compileQuery(
       const finalResults =
         raw instanceof ValClass
           ? raw.value
-          : raw && typeof raw === `object` && `type` in raw && (raw as any).type === `val`
-            ? (raw as any).value
+          : raw &&
+              typeof raw === `object` &&
+              `type` in raw &&
+              raw.type === `val`
+            ? raw.value
             : raw
       return [key, [finalResults, undefined]] as [
         unknown,
@@ -335,8 +341,11 @@ function processFrom(
           const [key, [value, _orderByIndex]] = data
           // Unwrap Value expressions that might have leaked through as the entire row
           const unwrapped =
-            value && typeof value === `object` && `type` in value && value.type === `val`
-              ? (value as any).value
+            value &&
+            typeof value === `object` &&
+            `type` in value &&
+            value.type === `val`
+              ? value.value
               : value
           return [key, unwrapped] as [unknown, any]
         })

--- a/packages/db/src/query/compiler/select.ts
+++ b/packages/db/src/query/compiler/select.ts
@@ -1,7 +1,7 @@
 import { map } from "@tanstack/db-ivm"
+import { PropRef, Value as ValClass, isExpressionLike } from "../ir.js"
 import { compileExpression } from "./evaluators.js"
 import type { Aggregate, BasicExpression, Select } from "../ir.js"
-import { Aggregate as AggClass, Func as FuncClass, PropRef, Value as ValClass } from "../ir.js"
 import type {
   KeyedStream,
   NamespacedAndKeyedStream,
@@ -19,19 +19,14 @@ export function processSelectToResults(
 ): NamespacedAndKeyedStream {
   // Build ordered operations to preserve authoring order (spreads and fields)
   type Op =
-    | { kind: `merge`; targetPath: Array<string>; source: (row: NamespacedRow) => any }
+    | {
+        kind: `merge`
+        targetPath: Array<string>
+        source: (row: NamespacedRow) => any
+      }
     | { kind: `field`; alias: string; compiled: (row: NamespacedRow) => any }
 
   const ops: Array<Op> = []
-
-  function isExpressionLike(expr: any): boolean {
-    return (
-      expr instanceof AggClass ||
-      expr instanceof FuncClass ||
-      expr instanceof PropRef ||
-      expr instanceof ValClass
-    )
-  }
 
   function addFromObject(prefixPath: Array<string>, obj: any) {
     for (const [key, value] of Object.entries(obj)) {
@@ -210,21 +205,13 @@ export function processSelect(
   _allInputs: Record<string, KeyedStream>
 ): KeyedStream {
   type Op =
-    | { kind: `merge`; targetPath: Array<string>; source: (row: NamespacedRow) => any }
+    | {
+        kind: `merge`
+        targetPath: Array<string>
+        source: (row: NamespacedRow) => any
+      }
     | { kind: `field`; alias: string; compiled: (row: NamespacedRow) => any }
   const ops: Array<Op> = []
-
-  function isExpressionLike(expr: any): boolean {
-    return (
-      !!expr &&
-      typeof expr === `object` &&
-      `type` in (expr as any) &&
-      ((expr as any).type === `agg` ||
-        (expr as any).type === `func` ||
-        (expr as any).type === `ref` ||
-        (expr as any).type === `val`)
-    )
-  }
 
   function addFromObject(prefixPath: Array<string>, obj: any) {
     for (const [key, value] of Object.entries(obj)) {

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -128,3 +128,16 @@ export class Aggregate<T = any> extends BaseExpression<T> {
     super()
   }
 }
+
+/**
+ * Runtime helper to detect IR expression-like objects.
+ * Prefer this over ad-hoc local implementations to keep behavior consistent.
+ */
+export function isExpressionLike(value: any): boolean {
+  return (
+    value instanceof Aggregate ||
+    value instanceof Func ||
+    value instanceof PropRef ||
+    value instanceof Value
+  )
+}

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -27,7 +27,7 @@ export interface QueryIR {
 export type From = CollectionRef | QueryRef
 
 export type Select = {
-  [alias: string]: BasicExpression | Aggregate
+  [alias: string]: BasicExpression | Aggregate | Select
 }
 
 export type Join = Array<JoinClause>

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -220,10 +220,6 @@ export function liveQueryCollectionOptions<
 
           begin()
           messages
-            .map((o) => {
-              console.log(`message`, JSON.stringify(o, null, 2))
-              return o
-            })
             .reduce((acc, [[key, tupleData], multiplicity]) => {
               // All queries now consistently return [value, orderByIndex] format
               // where orderByIndex is undefined for queries without ORDER BY
@@ -253,7 +249,6 @@ export function liveQueryCollectionOptions<
 
               // Store the key of the result so that we can retrieve it in the
               // getKey function
-              console.log(`setting resultKeys`, value, rawKey)
               resultKeys.set(value as unknown as object, rawKey)
 
               // Store the orderBy index if it exists
@@ -380,12 +375,7 @@ export function liveQueryCollectionOptions<
     id,
     getKey:
       config.getKey ||
-      ((item) =>
-        resultKeys.get(
-          (item !== null && (typeof item === 'object' || typeof item === 'function'))
-            ? (item as object)
-            : ({ __wrapped: item } as unknown as object)
-        ) as string | number),
+      ((item) => resultKeys.get(item as unknown as object) as string | number),
     sync,
     compare,
     gcTime: config.gcTime || 5000, // 5 seconds by default for live queries

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -220,6 +220,10 @@ export function liveQueryCollectionOptions<
 
           begin()
           messages
+            .map((o) => {
+              console.log(`message`, JSON.stringify(o, null, 2))
+              return o
+            })
             .reduce((acc, [[key, tupleData], multiplicity]) => {
               // All queries now consistently return [value, orderByIndex] format
               // where orderByIndex is undefined for queries without ORDER BY
@@ -249,11 +253,12 @@ export function liveQueryCollectionOptions<
 
               // Store the key of the result so that we can retrieve it in the
               // getKey function
-              resultKeys.set(value, rawKey)
+              console.log(`setting resultKeys`, value, rawKey)
+              resultKeys.set(value as unknown as object, rawKey)
 
               // Store the orderBy index if it exists
               if (orderByIndex !== undefined) {
-                orderByIndices.set(value, orderByIndex)
+                orderByIndices.set(value as unknown as object, orderByIndex)
               }
 
               // Simple singular insert.
@@ -374,7 +379,13 @@ export function liveQueryCollectionOptions<
   return {
     id,
     getKey:
-      config.getKey || ((item) => resultKeys.get(item) as string | number),
+      config.getKey ||
+      ((item) =>
+        resultKeys.get(
+          (item !== null && (typeof item === 'object' || typeof item === 'function'))
+            ? (item as object)
+            : ({ __wrapped: item } as unknown as object)
+        ) as string | number),
     sync,
     compare,
     gcTime: config.gcTime || 5000, // 5 seconds by default for live queries

--- a/packages/db/tests/query/builder/ref-proxy.test.ts
+++ b/packages/db/tests/query/builder/ref-proxy.test.ts
@@ -61,7 +61,7 @@ describe(`ref-proxy`, () => {
       expect(`__refProxy` in proxy).toBe(true)
       expect(`__path` in proxy).toBe(true)
       expect(`__type` in proxy).toBe(true)
-      expect(`__spreadSentinels` in proxy).toBe(true)
+      expect(`__events` in proxy).toBe(true)
       expect(`users` in proxy).toBe(true)
       expect(`nonexistent` in proxy).toBe(false)
     })
@@ -78,7 +78,7 @@ describe(`ref-proxy`, () => {
       expect(keys).toContain(`__refProxy`)
       expect(keys).toContain(`__path`)
       expect(keys).toContain(`__type`)
-      expect(keys).toContain(`__spreadSentinels`)
+      expect(keys).toContain(`__events`)
     })
 
     it(`handles getOwnPropertyDescriptor correctly`, () => {
@@ -115,8 +115,14 @@ describe(`ref-proxy`, () => {
       // Access ownKeys on table-level proxy (should mark as spread)
       Object.getOwnPropertyNames(proxy.users)
 
-      const spreadSentinels = (proxy as any).__spreadSentinels
-      expect(spreadSentinels.has(`users`)).toBe(true)
+      const events = (proxy as any).__events as Array<{
+        type: `spread`
+        alias: string
+        id: number
+      }>
+      expect(
+        events.some((e) => e.type === `spread` && e.alias === `users`)
+      ).toBe(true)
     })
 
     it(`handles accessing undefined alias`, () => {

--- a/packages/db/tests/query/builder/ref-proxy.test.ts
+++ b/packages/db/tests/query/builder/ref-proxy.test.ts
@@ -61,7 +61,6 @@ describe(`ref-proxy`, () => {
       expect(`__refProxy` in proxy).toBe(true)
       expect(`__path` in proxy).toBe(true)
       expect(`__type` in proxy).toBe(true)
-      expect(`__events` in proxy).toBe(true)
       expect(`users` in proxy).toBe(true)
       expect(`nonexistent` in proxy).toBe(false)
     })
@@ -78,7 +77,6 @@ describe(`ref-proxy`, () => {
       expect(keys).toContain(`__refProxy`)
       expect(keys).toContain(`__path`)
       expect(keys).toContain(`__type`)
-      expect(keys).toContain(`__events`)
     })
 
     it(`handles getOwnPropertyDescriptor correctly`, () => {
@@ -113,16 +111,11 @@ describe(`ref-proxy`, () => {
       ])
 
       // Access ownKeys on table-level proxy (should mark as spread)
-      Object.getOwnPropertyNames(proxy.users)
-
-      const events = (proxy as any).__events as Array<{
-        type: `spread`
-        alias: string
-        id: number
-      }>
-      expect(
-        events.some((e) => e.type === `spread` && e.alias === `users`)
-      ).toBe(true)
+      const keys = Object.getOwnPropertyNames((proxy as any).users)
+      // table spread sentinel should exist on table proxy
+      expect(keys.some((k) => k.startsWith(`__SPREAD_SENTINEL__users__`))).toBe(
+        true
+      )
     })
 
     it(`handles accessing undefined alias`, () => {

--- a/packages/db/tests/query/select-spread.test-d.ts
+++ b/packages/db/tests/query/select-spread.test-d.ts
@@ -1,0 +1,86 @@
+import { describe, expectTypeOf, test } from "vitest"
+import { createCollection } from "../../src/collection.js"
+import { createLiveQueryCollection } from "../../src/query/index.js"
+import { mockSyncCollectionOptions } from "../utls.js"
+import { add, upper } from "../../src/query/builder/functions.js"
+
+// Base type used in bug report
+type Message = {
+  id: number
+  text: string
+  user: string
+}
+
+const initialMessages: Array<Message> = [
+  { id: 1, text: `hello`, user: `sam` },
+  { id: 2, text: `world`, user: `kim` },
+]
+
+function createMessagesCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<Message>({
+      id: `messages`,
+      getKey: (m) => m.id,
+      initialData: initialMessages,
+    })
+  )
+}
+
+describe(`Select spread typing`, () => {
+  test(`spreading the source alias projects the full row type`, () => {
+    const messagesCollection = createMessagesCollection()
+
+    const collection = createLiveQueryCollection({
+      startSync: true,
+      query: (q) =>
+        q.from({ message: messagesCollection }).select(({ message }) => ({
+          ...message,
+        })),
+    })
+
+    const results = collection.toArray
+    expectTypeOf(results).toEqualTypeOf<Array<Message>>()
+
+    // Accessors should also be correctly typed
+    const first = collection.get(1)
+    expectTypeOf(first).toEqualTypeOf<Message | undefined>()
+  })
+
+  test(`spreading and adding computed fields merges types`, () => {
+    const messagesCollection = createMessagesCollection()
+
+    const collection = createLiveQueryCollection({
+      startSync: true,
+      query: (q) =>
+        q.from({ message: messagesCollection }).select(({ message }) => ({
+          ...message,
+          idPlusOne: add(message.id, 1),
+          upperText: upper(message.text),
+        })),
+    })
+
+    const results = collection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<Message & { idPlusOne: number; upperText: string }>
+    >(undefined as any)
+  })
+
+  test(`explicit property wins over spread and preserves type`, () => {
+    const messagesCollection = createMessagesCollection()
+
+    const collection = createLiveQueryCollection({
+      startSync: true,
+      query: (q) =>
+        q.from({ message: messagesCollection }).select(({ message }) => ({
+          ...message,
+          // override user with computed value
+          user: upper(message.user),
+        })),
+    })
+
+    const results = collection.toArray
+    expectTypeOf(results).toEqualTypeOf<
+      Array<Omit<Message, `user`> & { user: string }>
+    >(undefined as any)
+  })
+})

--- a/packages/db/tests/query/select-spread.test.ts
+++ b/packages/db/tests/query/select-spread.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { createCollection } from "../../src/collection.js"
+import { createLiveQueryCollection } from "../../src/query/index.js"
+import { mockSyncCollectionOptions } from "../utls.js"
+import { add, eq, upper } from "../../src/query/builder/functions.js"
+
+// Base type used in bug report
+interface Message {
+  id: number
+  text: string
+  user: string
+}
+
+const initialMessages: Array<Message> = [
+  { id: 1, text: `hello`, user: `sam` },
+  { id: 2, text: `world`, user: `kim` },
+]
+
+function createMessagesCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<Message>({
+      id: `messages-select-spread`,
+      getKey: (m) => m.id,
+      initialData: initialMessages,
+    })
+  )
+}
+
+// Nested message shape for deeper spread tests
+interface MessageWithMeta extends Message {
+  meta: {
+    tags: Array<string>
+    author: {
+      name: string
+      rating: number
+    }
+  }
+}
+
+const nestedMessages: Array<MessageWithMeta> = [
+  {
+    id: 1,
+    text: `hello`,
+    user: `sam`,
+    meta: { tags: [`a`, `b`], author: { name: `sam`, rating: 5 } },
+  },
+  {
+    id: 2,
+    text: `world`,
+    user: `kim`,
+    meta: { tags: [`x`], author: { name: `kim`, rating: 3 } },
+  },
+]
+
+function createMessagesWithMetaCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<MessageWithMeta>({
+      id: `messages-select-spread-nested`,
+      getKey: (m) => m.id,
+      initialData: nestedMessages,
+    })
+  )
+}
+
+// A second collection to verify spreading across multiple aliases (join)
+interface UserRow {
+  id: number
+  alias: string
+}
+
+const usersData: Array<UserRow> = [
+  { id: 1, alias: `sammy` },
+  { id: 2, alias: `kimmy` },
+]
+
+function createUsersCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<UserRow>({
+      id: `users-select-spread`,
+      getKey: (u) => u.id,
+      initialData: usersData,
+    })
+  )
+}
+
+describe(`select spreads (runtime)`, () => {
+  let messagesCollection: ReturnType<typeof createMessagesCollection>
+
+  beforeEach(() => {
+    messagesCollection = createMessagesCollection()
+  })
+
+  it(`spreading the source alias projects the full row`, async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ message: messagesCollection }).select(({ message }) => ({
+        ...message,
+      }))
+    )
+    await collection.preload()
+
+    const results = Array.from(collection.values())
+    expect(results).toHaveLength(2)
+    // Should match initial data exactly
+    expect(results).toEqual(initialMessages)
+    // Index access by key
+    expect(collection.get(1)).toEqual(initialMessages[0])
+  })
+
+  it(`spread + computed fields merges fields with correct values`, async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ message: messagesCollection }).select(({ message }) => ({
+        ...message,
+        idPlusOne: add(message.id, 1),
+        upperText: upper(message.text),
+      }))
+    )
+    await collection.preload()
+
+    const results = Array.from(collection.values())
+    expect(results).toHaveLength(2)
+
+    const r1 = results.find((m) => m.id === 1)!
+    expect(r1).toMatchObject({ id: 1, text: `hello`, user: `sam` })
+    expect(r1.idPlusOne).toBe(2)
+    expect(r1.upperText).toBe(`HELLO`)
+
+    const r2 = results.find((m) => m.id === 2)!
+    expect(r2.idPlusOne).toBe(3)
+    expect(r2.upperText).toBe(`WORLD`)
+  })
+
+  it(`explicit property wins over spread (override after spread)`, async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ message: messagesCollection }).select(({ message }) => ({
+        ...message,
+        user: upper(message.user),
+      }))
+    )
+    await collection.preload()
+
+    const results = Array.from(collection.values())
+    const r1 = results.find((m) => m.id === 1)!
+    expect(r1.user).toBe(`SAM`)
+  })
+
+  it(`spread after explicit property restores original (last spread wins)`, async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ message: messagesCollection }).select(({ message }) => ({
+        // @ts-expect-error - user is overridden by spread
+        user: upper(message.user),
+        ...message,
+      }))
+    )
+    await collection.preload()
+
+    const results = Array.from(collection.values())
+    const r1 = results.find((m) => m.id === 1)!
+    // Because the later spread should overwrite earlier user override
+    expect(r1.user).toBe(`sam`)
+  })
+
+  it(`live updates maintain spread semantics`, async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ message: messagesCollection }).select(({ message }) => ({
+        ...message,
+      }))
+    )
+    await collection.preload()
+
+    // Insert new message
+    messagesCollection.utils.begin()
+    messagesCollection.utils.write({
+      type: `insert`,
+      value: { id: 3, text: `test`, user: `alex` },
+    })
+    messagesCollection.utils.commit()
+
+    const results = Array.from(collection.values())
+    expect(results).toHaveLength(3)
+    expect(collection.get(3)).toEqual({ id: 3, text: `test`, user: `alex` })
+  })
+
+  it(`spreading preserves nested object fields intact`, async () => {
+    const messagesNested = createMessagesWithMetaCollection()
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ m: messagesNested }).select(({ m }) => ({
+        ...m,
+      }))
+    )
+    await collection.preload()
+
+    const results = Array.from(collection.values())
+    expect(results).toEqual(nestedMessages)
+
+    const r1 = results.find((r) => r.id === 1) as MessageWithMeta
+    expect(r1.meta.author.name).toBe(`sam`)
+    expect(r1.meta.tags).toEqual([`a`, `b`])
+  })
+
+  it(`repeating the same alias spread multiple times uses last-wins for all fields`, async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ message: messagesCollection }).select(({ message }) => ({
+        ...message,
+        // @ts-expect-error - user is overridden by spread
+        user: upper(message.user),
+        // later spread should restore original values for all overlapping keys
+        ...message,
+        // and a final override wins over the last spread
+        text: upper(message.text),
+      }))
+    )
+    await collection.preload()
+
+    const r1 = Array.from(collection.values()).find((m) => m.id === 1)!
+    // user restored by second spread
+    expect(r1.user).toBe(`sam`)
+    // text overridden after the second spread
+    expect(r1.text).toBe(`HELLO`)
+  })
+
+  it(`spreading across multiple aliases merges both rows (no collisions)`, async () => {
+    const users = createUsersCollection()
+    const collection = createLiveQueryCollection((q) =>
+      q
+        .from({ m: messagesCollection })
+        .join({ u: users }, ({ m, u }) => eq(m.id, u.id), `inner`)
+        .select(({ m, u }) => ({
+          ...m,
+          ...u,
+        }))
+    )
+    await collection.preload()
+
+    const r1 = Array.from(collection.values()).find((row) => row.id === 1)!
+    // id comes from last spread (users), but here both ids are equal anyway
+    expect(r1.alias).toBe(`sammy`)
+    expect(r1.text).toBe(`hello`)
+  })
+
+  // TODO: Nested spread into a sub-object is not yet supported by the runtime
+  // These tests document desired semantics without enforcing them now
+  it.skip(`nested object property supports spreading another object under that key`, async () => {
+    const messagesNested = createMessagesWithMetaCollection()
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ m: messagesNested }).select(({ m }) => ({
+        id: m.id,
+        user: m.user,
+        meta: {
+          extra: 1,
+          // desired: spread meta fields under meta key
+          ...m.meta,
+        },
+      }))
+    )
+    await collection.preload()
+
+    const r1 = Array.from(collection.values()).find((r) => r.id === 1) as any
+    expect(r1.meta.extra).toBe(1)
+    expect(r1.meta.tags).toEqual([`a`, `b`]) // from spread
+    expect(r1.meta.author).toEqual({ name: `sam`, rating: 5 })
+  })
+
+  it.skip(`nested spread respects last-wins within the nested object`, async () => {
+    const messagesNested = createMessagesWithMetaCollection()
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ m: messagesNested }).select(({ m }) => ({
+        id: m.id,
+        meta: {
+          // override first
+          author: { name: upper(m.user), rating: 0 },
+          // last spread restores original author
+          ...m.meta,
+        },
+      }))
+    )
+    await collection.preload()
+
+    const r1 = Array.from(collection.values()).find((r) => r.id === 1) as any
+    expect(r1.meta.author).toEqual({ name: `sam`, rating: 5 })
+  })
+})

--- a/packages/db/tests/query/select-spread.test.ts
+++ b/packages/db/tests/query/select-spread.test.ts
@@ -237,9 +237,7 @@ describe(`select spreads (runtime)`, () => {
     expect(r1.text).toBe(`hello`)
   })
 
-  // TODO: Nested spread into a sub-object is not yet supported by the runtime
-  // These tests document desired semantics without enforcing them now
-  it.skip(`nested object property supports spreading another object under that key`, async () => {
+  it(`nested object property supports spreading another object under that key`, async () => {
     const messagesNested = createMessagesWithMetaCollection()
     const collection = createLiveQueryCollection((q) =>
       q.from({ m: messagesNested }).select(({ m }) => ({
@@ -260,13 +258,14 @@ describe(`select spreads (runtime)`, () => {
     expect(r1.meta.author).toEqual({ name: `sam`, rating: 5 })
   })
 
-  it.skip(`nested spread respects last-wins within the nested object`, async () => {
+  it(`nested spread respects last-wins within the nested object`, async () => {
     const messagesNested = createMessagesWithMetaCollection()
     const collection = createLiveQueryCollection((q) =>
       q.from({ m: messagesNested }).select(({ m }) => ({
         id: m.id,
         meta: {
           // override first
+          // @ts-expect-error - user is overridden by spread
           author: { name: upper(m.user), rating: 0 },
           // last spread restores original author
           ...m.meta,

--- a/packages/db/tests/query/select.test-d.ts
+++ b/packages/db/tests/query/select.test-d.ts
@@ -26,15 +26,15 @@ type User = {
 function createUsers() {
   return createCollection(
     mockSyncCollectionOptions<User>({
-      id: "nested-select-users-type",
+      id: `nested-select-users-type`,
       getKey: (u) => u.id,
       initialData: [],
     })
   )
 }
 
-describe("nested select types", () => {
-  test("nested object selection infers nested result type", () => {
+describe(`nested select types`, () => {
+  test(`nested object selection infers nested result type`, () => {
     const users = createUsers()
     const col = createLiveQueryCollection((q) =>
       q.from({ u: users }).select(({ u }) => ({
@@ -57,7 +57,7 @@ describe("nested select types", () => {
     expectTypeOf(col.toArray).toEqualTypeOf<Expected>()
   })
 
-  test("nested spread preserves object structure types", () => {
+  test(`nested spread preserves object structure types`, () => {
     const users = createUsers()
     const col = createLiveQueryCollection((q) =>
       q.from({ u: users }).select(({ u }) => ({
@@ -83,5 +83,3 @@ describe("nested select types", () => {
     expectTypeOf(col.toArray).toEqualTypeOf<Expected>()
   })
 })
-
-

--- a/packages/db/tests/query/select.test-d.ts
+++ b/packages/db/tests/query/select.test-d.ts
@@ -1,0 +1,87 @@
+import { describe, expectTypeOf, test } from "vitest"
+import { createCollection } from "../../src/collection.js"
+import { createLiveQueryCollection } from "../../src/query/index.js"
+import { mockSyncCollectionOptions } from "../utls.js"
+import { upper } from "../../src/query/builder/functions.js"
+
+type User = {
+  id: number
+  name: string
+  profile: {
+    bio: string
+    preferences: {
+      notifications: boolean
+      theme: `light` | `dark`
+    }
+  }
+  address?: {
+    city: string
+    coordinates: {
+      lat: number
+      lng: number
+    }
+  }
+}
+
+function createUsers() {
+  return createCollection(
+    mockSyncCollectionOptions<User>({
+      id: "nested-select-users-type",
+      getKey: (u) => u.id,
+      initialData: [],
+    })
+  )
+}
+
+describe("nested select types", () => {
+  test("nested object selection infers nested result type", () => {
+    const users = createUsers()
+    const col = createLiveQueryCollection((q) =>
+      q.from({ u: users }).select(({ u }) => ({
+        id: u.id,
+        meta: {
+          city: u.address?.city,
+          coords: u.address?.coordinates,
+        },
+      }))
+    )
+
+    type Expected = Array<{
+      id: number
+      meta: {
+        city: string | undefined
+        coords: { lat: number; lng: number } | undefined
+      }
+    }>
+
+    expectTypeOf(col.toArray).toEqualTypeOf<Expected>()
+  })
+
+  test("nested spread preserves object structure types", () => {
+    const users = createUsers()
+    const col = createLiveQueryCollection((q) =>
+      q.from({ u: users }).select(({ u }) => ({
+        user: {
+          id: u.id,
+          nameUpper: upper(u.name),
+          profile: { ...u.profile },
+        },
+      }))
+    )
+
+    type Expected = Array<{
+      user: {
+        id: number
+        nameUpper: string
+        profile: {
+          bio: string
+          preferences: { notifications: boolean; theme: `light` | `dark` }
+        }
+      }
+    }>
+
+    expectTypeOf(col.toArray).toEqualTypeOf<Expected>()
+  })
+})
+
+

--- a/packages/db/tests/query/select.test.ts
+++ b/packages/db/tests/query/select.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { createCollection } from "../../src/collection.js"
+import { createLiveQueryCollection } from "../../src/query/index.js"
+import { mockSyncCollectionOptions } from "../utls.js"
+import { upper } from "../../src/query/builder/functions.js"
+
+type User = {
+  id: number
+  name: string
+  profile: {
+    bio: string
+    preferences: {
+      notifications: boolean
+      theme: `light` | `dark`
+    }
+  }
+  address?: {
+    city: string
+    coordinates: {
+      lat: number
+      lng: number
+    }
+  }
+}
+
+const data: Array<User> = [
+  {
+    id: 1,
+    name: "Alice",
+    profile: {
+      bio: "Engineer",
+      preferences: { notifications: true, theme: "dark" },
+    },
+    address: { city: "NYC", coordinates: { lat: 40.7, lng: -74.0 } },
+  },
+  {
+    id: 2,
+    name: "Bob",
+    profile: {
+      bio: "Dev",
+      preferences: { notifications: false, theme: "light" },
+    },
+  },
+]
+
+function createUsers() {
+  return createCollection(
+    mockSyncCollectionOptions<User>({
+      id: "nested-select-users",
+      getKey: (u) => u.id,
+      initialData: data,
+    })
+  )
+}
+
+describe("nested select projections", () => {
+  let users: ReturnType<typeof createUsers>
+
+  beforeEach(() => {
+    users = createUsers()
+  })
+
+  it("selects nested object structure", async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ u: users }).select(({ u }) => ({
+        id: u.id,
+        meta: {
+          city: u.address?.city,
+          coords: u.address?.coordinates,
+        },
+      }))
+    )
+
+    await collection.preload()
+
+    const r1 = collection.get(1) as any
+    expect(r1).toMatchObject({
+      id: 1,
+      meta: { city: "NYC", coords: { lat: 40.7, lng: -74.0 } },
+    })
+
+    const r2 = collection.get(2) as any
+    expect(r2).toMatchObject({ id: 2 })
+    expect(r2.meta?.city).toBeUndefined()
+    expect(r2.meta?.coords).toBeUndefined()
+  })
+
+  it("supports nested spread of object refs under a key", async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ u: users }).select(({ u }) => ({
+        id: u.id,
+        preferences: {
+          // spread all preference fields under preferences
+          ...u.profile.preferences,
+        },
+      }))
+    )
+
+    await collection.preload()
+
+    const r1 = collection.get(1) as any
+    expect(r1.preferences).toEqual({ notifications: true, theme: "dark" })
+
+    const r2 = collection.get(2) as any
+    expect(r2.preferences).toEqual({ notifications: false, theme: "light" })
+  })
+
+  it("allows mixing nested spreads and computed fields", async () => {
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ u: users }).select(({ u }) => ({
+        user: {
+          id: u.id,
+          nameUpper: upper(u.name),
+          profile: {
+            ...u.profile,
+          },
+        },
+      }))
+    )
+
+    await collection.preload()
+
+    const r1 = collection.get(1) as any
+    expect(r1.user.id).toBe(1)
+    expect(r1.user.nameUpper).toBe("ALICE")
+    expect(r1.user.profile).toEqual({
+      bio: "Engineer",
+      preferences: { notifications: true, theme: "dark" },
+    })
+  })
+})
+
+

--- a/packages/db/tests/query/select.test.ts
+++ b/packages/db/tests/query/select.test.ts
@@ -26,19 +26,19 @@ type User = {
 const data: Array<User> = [
   {
     id: 1,
-    name: "Alice",
+    name: `Alice`,
     profile: {
-      bio: "Engineer",
-      preferences: { notifications: true, theme: "dark" },
+      bio: `Engineer`,
+      preferences: { notifications: true, theme: `dark` },
     },
-    address: { city: "NYC", coordinates: { lat: 40.7, lng: -74.0 } },
+    address: { city: `NYC`, coordinates: { lat: 40.7, lng: -74.0 } },
   },
   {
     id: 2,
-    name: "Bob",
+    name: `Bob`,
     profile: {
-      bio: "Dev",
-      preferences: { notifications: false, theme: "light" },
+      bio: `Dev`,
+      preferences: { notifications: false, theme: `light` },
     },
   },
 ]
@@ -46,21 +46,21 @@ const data: Array<User> = [
 function createUsers() {
   return createCollection(
     mockSyncCollectionOptions<User>({
-      id: "nested-select-users",
+      id: `nested-select-users`,
       getKey: (u) => u.id,
       initialData: data,
     })
   )
 }
 
-describe("nested select projections", () => {
+describe(`nested select projections`, () => {
   let users: ReturnType<typeof createUsers>
 
   beforeEach(() => {
     users = createUsers()
   })
 
-  it("selects nested object structure", async () => {
+  it(`selects nested object structure`, async () => {
     const collection = createLiveQueryCollection((q) =>
       q.from({ u: users }).select(({ u }) => ({
         id: u.id,
@@ -76,7 +76,7 @@ describe("nested select projections", () => {
     const r1 = collection.get(1) as any
     expect(r1).toMatchObject({
       id: 1,
-      meta: { city: "NYC", coords: { lat: 40.7, lng: -74.0 } },
+      meta: { city: `NYC`, coords: { lat: 40.7, lng: -74.0 } },
     })
 
     const r2 = collection.get(2) as any
@@ -85,7 +85,7 @@ describe("nested select projections", () => {
     expect(r2.meta?.coords).toBeUndefined()
   })
 
-  it("supports nested spread of object refs under a key", async () => {
+  it(`supports nested spread of object refs under a key`, async () => {
     const collection = createLiveQueryCollection((q) =>
       q.from({ u: users }).select(({ u }) => ({
         id: u.id,
@@ -99,13 +99,13 @@ describe("nested select projections", () => {
     await collection.preload()
 
     const r1 = collection.get(1) as any
-    expect(r1.preferences).toEqual({ notifications: true, theme: "dark" })
+    expect(r1.preferences).toEqual({ notifications: true, theme: `dark` })
 
     const r2 = collection.get(2) as any
-    expect(r2.preferences).toEqual({ notifications: false, theme: "light" })
+    expect(r2.preferences).toEqual({ notifications: false, theme: `light` })
   })
 
-  it("allows mixing nested spreads and computed fields", async () => {
+  it(`allows mixing nested spreads and computed fields`, async () => {
     const collection = createLiveQueryCollection((q) =>
       q.from({ u: users }).select(({ u }) => ({
         user: {
@@ -122,12 +122,10 @@ describe("nested select projections", () => {
 
     const r1 = collection.get(1) as any
     expect(r1.user.id).toBe(1)
-    expect(r1.user.nameUpper).toBe("ALICE")
+    expect(r1.user.nameUpper).toBe(`ALICE`)
     expect(r1.user.profile).toEqual({
-      bio: "Engineer",
-      preferences: { notifications: true, theme: "dark" },
+      bio: `Engineer`,
+      preferences: { notifications: true, theme: `dark` },
     })
   })
 })
-
-


### PR DESCRIPTION
This branch started as a fix for the broken types when using a spread in a select (#385), but identified a couple of problems:

- we didn't have any way to track the order of spreads within an object, so multiple spreads could result in incorrect overwriting of properties. This is now fixed by tracking the order of operations (ref proxy access and spreads) within the select:

```ts
.select({ user }) => ({
  ...user, // <-- spread first
  name: upper(user.name) // <-- override name
})
```

- select didn't have proper support for nested projection, you can now do this:

```ts
select({ user }) => ({
  ...user,
  meta: {  // <= nested object within the select
    email: user.email
  }
})
```