### PR TITLE
Modify topK and orderBy to track by key instead of by object reference

### DIFF
--- a/packages/db-ivm/tests/operators/orderByWithFractionalIndex.test.ts
+++ b/packages/db-ivm/tests/operators/orderByWithFractionalIndex.test.ts
@@ -10,6 +10,15 @@ import { loadBTree } from "../../src/operators/topKWithFractionalIndexBTree.js"
 import { MessageTracker } from "../test-utils.js"
 import type { KeyValue } from "../../src/types.js"
 
+const compareFractionalIndex = (
+  r1: [string, [{ id: number; value: string }, string]],
+  r2: [string, [{ id: number; value: string }, string]]
+) => {
+  const [_key1, [_value1, index1]] = r1
+  const [_key2, [_value2, index2]] = r2
+  return index1 < index2 ? -1 : index1 > index2 ? 1 : 0
+}
+
 const stripFractionalIndex = ([[key, [value, _index]], multiplicity]: any) => [
   key,
   value,
@@ -357,10 +366,12 @@ describe(`Operators`, () => {
 
       graph.finalize()
 
+      const value1 = { id: 1, value: `a` }
+
       // Initial data
       input.sendData(
         new MultiSet([
-          [[`key1`, { id: 1, value: `a` }], 1],
+          [[`key1`, value1], 1],
           [[`key3`, { id: 3, value: `c` }], 1],
           [[`key2`, { id: 2, value: `b` }], 1],
           [[`key4`, { id: 4, value: `d` }], 1],
@@ -368,32 +379,40 @@ describe(`Operators`, () => {
       )
       graph.run()
 
-      const initialResult = tracker.getResult()
+      const initialResult = tracker.getResult(compareFractionalIndex)
       // Should have the top 3 items by value
       expect(initialResult.sortedResults.length).toBe(3)
       expect(initialResult.messageCount).toBeLessThanOrEqual(4) // Should be efficient
+
+      expect(
+        initialResult.sortedResults.map(stripFractionalIndexWithoutMultiplicity)
+      ).toEqual([
+        [`key1`, { id: 1, value: `a` }],
+        [`key2`, { id: 2, value: `b` }],
+        [`key3`, { id: 3, value: `c` }],
+      ])
 
       tracker.reset()
 
       // Remove a row that was in the top 3
       input.sendData(
         new MultiSet([
-          [[`key1`, { id: 1, value: `a` }], -1], // Remove the first item
+          [[`key1`, value1], -1], // Remove the first item
         ])
       )
       graph.run()
 
-      const updateResult = tracker.getResult()
-      // Should have efficient incremental update
-      expect(updateResult.messageCount).toBeLessThanOrEqual(4) // Should be incremental
-      expect(updateResult.messageCount).toBeGreaterThan(0) // Should have changes
+      const updateResult = tracker.getResult(compareFractionalIndex)
 
-      expect(
-        initialResult.sortedResults.map(stripFractionalIndexWithoutMultiplicity)
-      ).toEqual([
-        [`key2`, { id: 2, value: `b` }],
-        [`key3`, { id: 3, value: `c` }],
-        [`key4`, { id: 4, value: `d` }],
+      // The incremental messages should tell us that key1 is no longer in the top K
+      // and that key4 entered the top K
+      expect(updateResult.messages.length).toBe(2)
+      const sortedKeysAndMultiplicities = updateResult.messages
+        .map(([[key, _v], multiplicity]) => [key, multiplicity])
+        .sort((a, b) => (a[0]! < b[0]! ? -1 : a[0]! > b[0]! ? 1 : 0))
+      expect(sortedKeysAndMultiplicities).toEqual([
+        [`key1`, -1],
+        [`key4`, 1],
       ])
     })
 
@@ -421,19 +440,21 @@ describe(`Operators`, () => {
 
       graph.finalize()
 
+      const value2 = { id: 2, value: `c` }
+
       // Initial data
       input.sendData(
         new MultiSet([
           [[`key1`, { id: 1, value: `a` }], 1],
-          [[`key2`, { id: 2, value: `c` }], 1],
+          [[`key2`, value2], 1],
           [[`key3`, { id: 3, value: `b` }], 1],
           [[`key4`, { id: 4, value: `d` }], 1],
         ])
       )
       graph.run()
 
-      const initialResult = tracker.getResult()
       // Should have the top 3 items by value
+      const initialResult = tracker.getResult(compareFractionalIndex)
       expect(
         initialResult.sortedResults.map(stripFractionalIndexWithoutMultiplicity)
       ).toEqual([
@@ -448,23 +469,26 @@ describe(`Operators`, () => {
       // Modify an existing row by removing it and adding a new version
       input.sendData(
         new MultiSet([
-          [[`key2`, { id: 2, value: `c` }], -1], // Remove old version
+          [[`key2`, value2], -1], // Remove old version
           [[`key2`, { id: 2, value: `z` }], 1], // Add new version with different value
         ])
       )
       graph.run()
 
-      const updateResult = tracker.getResult()
+      const updateResult = tracker.getResult(compareFractionalIndex)
       // Should have efficient incremental update
       expect(updateResult.messageCount).toBeLessThanOrEqual(6) // Should be incremental (modify operation)
       expect(updateResult.messageCount).toBeGreaterThan(0) // Should have changes
 
-      expect(
-        updateResult.sortedResults.map(stripFractionalIndexWithoutMultiplicity)
-      ).toEqual([
-        [`key1`, { id: 1, value: `a` }],
-        [`key3`, { id: 3, value: `b` }],
-        [`key4`, { id: 4, value: `d` }],
+      // The incremental messages should tell us that key2 is no longer in the top K
+      // and that key4 entered the top K
+      expect(updateResult.messages.length).toBe(2)
+      const sortedKeysAndMultiplicities = updateResult.messages
+        .map(([[key, _v], multiplicity]) => [key, multiplicity])
+        .sort((a, b) => (a[0]! < b[0]! ? -1 : a[0]! > b[0]! ? 1 : 0))
+      expect(sortedKeysAndMultiplicities).toEqual([
+        [`key2`, -1],
+        [`key4`, 1],
       ])
     })
   })

--- a/packages/db-ivm/tests/test-utils.ts
+++ b/packages/db-ivm/tests/test-utils.ts
@@ -78,11 +78,17 @@ export function materializeKeyedResults<K, V>(
 /**
  * Convert a Map back to a sorted array for comparison
  */
-export function mapToSortedArray<T>(map: Map<string, T>): Array<T> {
-  return Array.from(map.values()).sort((a, b) => {
-    // Sort by JSON string representation for consistent ordering
-    return JSON.stringify(a).localeCompare(JSON.stringify(b))
-  })
+export function mapToSortedArray<T>(
+  map: Map<string, T>,
+  compare?: (a: T, b: T) => number
+): Array<T> {
+  const compareFn =
+    compare ??
+    ((a: T, b: T) => {
+      // Sort by JSON string representation for consistent ordering
+      return JSON.stringify(a).localeCompare(JSON.stringify(b))
+    })
+  return Array.from(map.values()).sort(compareFn)
 }
 
 /**
@@ -121,9 +127,9 @@ export class MessageTracker<T> {
     this.messages.push(...message.getInner())
   }
 
-  getResult(): TestResult<T> {
+  getResult(compare?: (a: T, b: T) => number): TestResult<T> {
     const materializedResults = materializeResults(this.messages)
-    const sortedResults = mapToSortedArray(materializedResults)
+    const sortedResults = mapToSortedArray(materializedResults, compare)
 
     return {
       messages: this.messages,

--- a/packages/db/tests/query/order-by.test.ts
+++ b/packages/db/tests/query/order-by.test.ts
@@ -603,12 +603,14 @@ function createOrderByTests(autoIndex: `off` | `eager`): void {
         // as a result, Eve with salary 52k should move into the top 2 with offset 1
         const bobData = employeeData.find((e) => e.id === 2)!
 
+        console.log(`gonna delete bob`)
         employeesCollection.utils.begin()
         employeesCollection.utils.write({
           type: `delete`,
           value: bobData,
         })
         employeesCollection.utils.commit()
+        console.log(`deleted bob`)
 
         const newResults = Array.from(collection.values())
 


### PR DESCRIPTION
This PR modifies the topK and orderBy operators. Previoiusly, the topK was computing a topK per key and it tracked multiplicities for each value associated to that key. We were always keying by `null` in ts/db and the values were entire rows, i.e. objects. However, the objects are always different objects (even for the same row) so they were always treated as a new value.

As reported by community members, this led to a bug where the results of an `orderBy` query with e.g. `limit: 10` would end up with just a single item in the result. This would happen in the following case:
- initial query run, results in 10 rows (because of the limit)
- update to a row in that top 10: ts/db splits it into a delete of the old row and an insert of the new row
- topK operator sees the delete for the old row, but the object reference is different from the object reference of the old row it has seen before, so instead of finding the multiplicity for the old row (which is 1), it doesn't find it and thinks it hasn't seen it before so multiplicity is 0. It decrements it by 1, yielding -1. It concludes that since it was 0 before, this row was not visible and is still not visible. Nothing happens. The row is in fact never deleted. 
- topK operator sees the insert for the new (updated) row. It stores this new row with multiplicity 1.
- Now the old row is in the top 10 and the new row is in the top 10. But ts/db materializes the query results by key so you will only see it once (with the new value) in the results. However, since internally it's twice in the top K it kicked out another row, so there are only 9 distinct rows in the query result. If you repeat this update 8 more times, you end up with a single row in the query results

To solve this problem i modified the `topK` operator such that it takes a keyed stream, i.e. a stream of tuples: `[Key, Value]`. It computes the topK across all keys (i.e. not per key as it did before) and uses the key to identify values. As such, when a row is received we lookup its multiplicity based on the key instead of the object reference.