### PR TITLE
keep residual where clause in join predicate pushdown

### DIFF
--- a/.changeset/slimy-lizards-kiss.md
+++ b/.changeset/slimy-lizards-kiss.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Fix query optimizer to preserve outer join semantics by keeping residual WHERE clauses when pushing predicates to subqueries.

--- a/packages/db/src/query/compiler/group-by.ts
+++ b/packages/db/src/query/compiler/group-by.ts
@@ -1,5 +1,5 @@
 import { filter, groupBy, groupByOperators, map } from "@tanstack/db-ivm"
-import { Func, PropRef } from "../ir.js"
+import { Func, PropRef, getHavingExpression } from "../ir.js"
 import {
   AggregateFunctionNotInSelectError,
   NonAggregateExpressionNotInGroupByError,
@@ -129,8 +129,9 @@ export function processGroupBy(
     // Apply HAVING clauses if present
     if (havingClauses && havingClauses.length > 0) {
       for (const havingClause of havingClauses) {
+        const havingExpression = getHavingExpression(havingClause)
         const transformedHavingClause = transformHavingClause(
-          havingClause,
+          havingExpression,
           selectClause || {}
         )
         const compiledHaving = compileExpression(transformedHavingClause)
@@ -263,8 +264,9 @@ export function processGroupBy(
   // Apply HAVING clauses if present
   if (havingClauses && havingClauses.length > 0) {
     for (const havingClause of havingClauses) {
+      const havingExpression = getHavingExpression(havingClause)
       const transformedHavingClause = transformHavingClause(
-        havingClause,
+        havingExpression,
         selectClause || {}
       )
       const compiledHaving = compileExpression(transformedHavingClause)

--- a/packages/db/src/query/compiler/index.ts
+++ b/packages/db/src/query/compiler/index.ts
@@ -7,7 +7,7 @@ import {
   LimitOffsetRequireOrderByError,
   UnsupportedFromTypeError,
 } from "../../errors.js"
-import { PropRef } from "../ir.js"
+import { PropRef, getWhereExpression } from "../ir.js"
 import { compileExpression } from "./evaluators.js"
 import { processJoins } from "./joins.js"
 import { processGroupBy } from "./group-by.js"
@@ -131,7 +131,8 @@ export function compileQuery(
   if (query.where && query.where.length > 0) {
     // Apply each WHERE condition as a filter (they are ANDed together)
     for (const where of query.where) {
-      const compiledWhere = compileExpression(where)
+      const whereExpression = getWhereExpression(where)
+      const compiledWhere = compileExpression(whereExpression)
       pipeline = pipeline.pipe(
         filter(([_key, namespacedRow]) => {
           return compiledWhere(namespacedRow)

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -39,7 +39,9 @@ export interface JoinClause {
   right: BasicExpression
 }
 
-export type Where = BasicExpression<boolean>
+export type Where =
+  | BasicExpression<boolean>
+  | { expression: BasicExpression<boolean>; residual?: boolean }
 
 export type GroupBy = Array<BasicExpression>
 
@@ -127,4 +129,49 @@ export class Aggregate<T = any> extends BaseExpression<T> {
   ) {
     super()
   }
+}
+
+/**
+ * Helper functions for working with Where clauses
+ */
+
+/**
+ * Extract the expression from a Where clause
+ */
+export function getWhereExpression(where: Where): BasicExpression<boolean> {
+  return typeof where === `object` && `expression` in where
+    ? where.expression
+    : where
+}
+
+/**
+ * Extract the expression from a HAVING clause
+ * HAVING clauses can contain aggregates, unlike regular WHERE clauses
+ */
+export function getHavingExpression(
+  having: Where
+): BasicExpression | Aggregate {
+  return typeof having === `object` && `expression` in having
+    ? having.expression
+    : having
+}
+
+/**
+ * Check if a Where clause is marked as residual
+ */
+export function isResidualWhere(where: Where): boolean {
+  return (
+    typeof where === `object` &&
+    `expression` in where &&
+    where.residual === true
+  )
+}
+
+/**
+ * Create a residual Where clause from an expression
+ */
+export function createResidualWhere(
+  expression: BasicExpression<boolean>
+): Where {
+  return { expression, residual: true }
 }

--- a/packages/db/src/query/optimizer.ts
+++ b/packages/db/src/query/optimizer.ts
@@ -45,6 +45,11 @@
  * - **Ordering + Limits**: ORDER BY combined with LIMIT/OFFSET (would change result set)
  * - **Functional Operations**: fnSelect, fnWhere, fnHaving (potential side effects)
  *
+ * ### Residual WHERE Clauses
+ * For outer joins (LEFT, RIGHT, FULL), WHERE clauses are copied to subqueries for optimization
+ * but also kept as "residual" clauses in the main query to preserve semantics. This ensures
+ * that NULL values from outer joins are properly filtered according to SQL standards.
+ *
  * The optimizer tracks which clauses were actually optimized and only removes those from the
  * main query. Subquery reuse is handled safely through immutable query copies.
  *
@@ -121,9 +126,12 @@ import {
   CollectionRef as CollectionRefClass,
   Func,
   QueryRef as QueryRefClass,
+  createResidualWhere,
+  getWhereExpression,
+  isResidualWhere,
 } from "./ir.js"
 import { isConvertibleToCollectionFilter } from "./compiler/expressions.js"
-import type { BasicExpression, From, QueryIR } from "./ir.js"
+import type { BasicExpression, From, QueryIR, Where } from "./ir.js"
 
 /**
  * Represents a WHERE clause after source analysis
@@ -424,6 +432,36 @@ function isRedundantSubquery(query: QueryIR): boolean {
  * ```
  */
 function splitAndClauses(
+  whereClauses: Array<Where>
+): Array<BasicExpression<boolean>> {
+  const result: Array<BasicExpression<boolean>> = []
+
+  for (const whereClause of whereClauses) {
+    // Skip residual WHERE clauses to prevent them from being pushed down again
+    if (isResidualWhere(whereClause)) {
+      const clause = getWhereExpression(whereClause)
+      result.push(clause)
+      continue
+    }
+
+    const clause = getWhereExpression(whereClause)
+    if (clause.type === `func` && clause.name === `and`) {
+      // Recursively split nested AND clauses to handle complex expressions
+      const splitArgs = splitAndClausesBasic(
+        clause.args as Array<BasicExpression<boolean>>
+      )
+      result.push(...splitArgs)
+    } else {
+      // Preserve non-AND clauses as-is (including OR clauses)
+      result.push(clause)
+    }
+  }
+
+  return result
+}
+
+// Helper function for recursive splitting of BasicExpression arrays
+function splitAndClausesBasic(
   whereClauses: Array<BasicExpression<boolean>>
 ): Array<BasicExpression<boolean>> {
   const result: Array<BasicExpression<boolean>> = []
@@ -431,7 +469,7 @@ function splitAndClauses(
   for (const clause of whereClauses) {
     if (clause.type === `func` && clause.name === `and`) {
       // Recursively split nested AND clauses to handle complex expressions
-      const splitArgs = splitAndClauses(
+      const splitArgs = splitAndClausesBasic(
         clause.args as Array<BasicExpression<boolean>>
       )
       result.push(...splitArgs)
@@ -588,19 +626,32 @@ function applyOptimizations(
       }))
     : undefined
 
-  // Build the remaining WHERE clauses: multi-source + any single-source that weren't optimized
-  const remainingWhereClauses: Array<BasicExpression<boolean>> = []
+  // Build the remaining WHERE clauses: multi-source + residual single-source clauses
+  const remainingWhereClauses: Array<Where> = []
 
   // Add multi-source clauses
   if (groupedClauses.multiSource) {
     remainingWhereClauses.push(groupedClauses.multiSource)
   }
 
-  // Add single-source clauses that weren't actually optimized
+  // Determine if we need residual clauses (when query has outer JOINs)
+  const hasOuterJoins =
+    query.join &&
+    query.join.some(
+      (join) =>
+        join.type === `left` || join.type === `right` || join.type === `full`
+    )
+
+  // Add single-source clauses
   for (const [source, clause] of groupedClauses.singleSource) {
     if (!actuallyOptimized.has(source)) {
+      // Wasn't optimized at all - keep as regular WHERE clause
       remainingWhereClauses.push(clause)
+    } else if (hasOuterJoins) {
+      // Was optimized AND query has outer JOINs - keep as residual WHERE clause
+      remainingWhereClauses.push(createResidualWhere(clause))
     }
+    // If optimized and no outer JOINs - don't keep (original behavior)
   }
 
   // Create a completely new query object to ensure immutability

--- a/packages/db/tests/query/indexes.test.ts
+++ b/packages/db/tests/query/indexes.test.ts
@@ -631,7 +631,7 @@ describe(`Query Index Optimization`, () => {
             write({
               type: `insert`,
               value: {
-                id: `other1`,
+                id: `1`, // Matches Alice from main collection
                 name: `Other Active Item`,
                 age: 40,
                 status: `active`,
@@ -641,7 +641,7 @@ describe(`Query Index Optimization`, () => {
             write({
               type: `insert`,
               value: {
-                id: `other2`,
+                id: `2`, // Matches Bob from main collection
                 name: `Other Inactive Item`,
                 age: 35,
                 status: `inactive`,
@@ -970,11 +970,11 @@ describe(`Query Index Optimization`, () => {
 
         await liveQuery.stateWhenReady()
 
-        // Should include all results from the first collection
+        // Should only include results where both sides match the WHERE condition
+        // Charlie and Eve are filtered out because they have no matching 'other' records
+        // and the WHERE clause requires other.status = 'active' (can't be NULL)
         expect(liveQuery.toArray).toEqual([
           { id: `1`, name: `Alice`, otherName: `Other Active Item` },
-          { id: `3`, name: `Charlie` },
-          { id: `5`, name: `Eve` },
         ])
 
         // Combine stats from both collections
@@ -1100,11 +1100,11 @@ describe(`Query Index Optimization`, () => {
 
         await liveQuery.stateWhenReady()
 
-        // Should have found results where both items are active
+        // Should only include results where both sides match the WHERE condition
+        // Charlie and Eve are filtered out because they have no matching 'other' records
+        // and the WHERE clause requires other.status = 'active' (can't be NULL)
         expect(liveQuery.toArray).toEqual([
           { id: `1`, name: `Alice`, otherName: `Other Active Item` },
-          { id: `3`, name: `Charlie` },
-          { id: `5`, name: `Eve` },
         ])
 
         // We should have done an index lookup on the left collection to find active items

--- a/packages/db/tests/query/optimizer.test.ts
+++ b/packages/db/tests/query/optimizer.test.ts
@@ -1455,9 +1455,13 @@ describe(`Query Optimizer`, () => {
       // The WHERE clause should remain in the main query to preserve LEFT JOIN semantics
       // It should NOT be completely moved to the subquery
       expect(optimizedQuery.where).toHaveLength(1)
-      expect(optimizedQuery.where![0]).toEqual(
-        createEq(createPropRef(`teamMember`, `user_id`), createValue(100))
-      )
+      expect(optimizedQuery.where![0]).toEqual({
+        expression: createEq(
+          createPropRef(`teamMember`, `user_id`),
+          createValue(100)
+        ),
+        residual: true,
+      })
 
       // If the optimizer creates a subquery for teamMember, the WHERE clause should also be copied there
       // but a residual copy must remain in the main query
@@ -1469,9 +1473,13 @@ describe(`Query Optimizer`, () => {
         // The subquery may have the WHERE clause for optimization
         if (teamMemberSubquery.where && teamMemberSubquery.where.length > 0) {
           // But the main query MUST still have it to preserve semantics
-          expect(optimizedQuery.where).toContainEqual(
-            createEq(createPropRef(`teamMember`, `user_id`), createValue(100))
-          )
+          expect(optimizedQuery.where).toContainEqual({
+            expression: createEq(
+              createPropRef(`teamMember`, `user_id`),
+              createValue(100)
+            ),
+            residual: true,
+          })
         }
       }
     })
@@ -1513,9 +1521,13 @@ describe(`Query Optimizer`, () => {
       // The WHERE clause should remain in the main query to preserve RIGHT JOIN semantics
       // It should NOT be completely moved to the subquery
       expect(optimizedQuery.where).toHaveLength(1)
-      expect(optimizedQuery.where![0]).toEqual(
-        createEq(createPropRef(`user`, `department_id`), createValue(1))
-      )
+      expect(optimizedQuery.where![0]).toEqual({
+        expression: createEq(
+          createPropRef(`user`, `department_id`),
+          createValue(1)
+        ),
+        residual: true,
+      })
 
       // If the optimizer creates a subquery for users, the WHERE clause should also be copied there
       // but a residual copy must remain in the main query
@@ -1524,9 +1536,13 @@ describe(`Query Optimizer`, () => {
         // The subquery may have the WHERE clause for optimization
         if (userSubquery.where && userSubquery.where.length > 0) {
           // But the main query MUST still have it to preserve semantics
-          expect(optimizedQuery.where).toContainEqual(
-            createEq(createPropRef(`user`, `department_id`), createValue(1))
-          )
+          expect(optimizedQuery.where).toContainEqual({
+            expression: createEq(
+              createPropRef(`user`, `department_id`),
+              createValue(1)
+            ),
+            residual: true,
+          })
         }
       }
     })
@@ -1568,9 +1584,13 @@ describe(`Query Optimizer`, () => {
       // The WHERE clause should remain in the main query to preserve FULL JOIN semantics
       // It should NOT be completely moved to the subquery
       expect(optimizedQuery.where).toHaveLength(1)
-      expect(optimizedQuery.where![0]).toEqual(
-        createGt(createPropRef(`payment`, `amount`), createValue(100))
-      )
+      expect(optimizedQuery.where![0]).toEqual({
+        expression: createGt(
+          createPropRef(`payment`, `amount`),
+          createValue(100)
+        ),
+        residual: true,
+      })
 
       // If the optimizer creates a subquery for payments, the WHERE clause should also be copied there
       // but a residual copy must remain in the main query
@@ -1582,9 +1602,13 @@ describe(`Query Optimizer`, () => {
         // The subquery may have the WHERE clause for optimization
         if (paymentSubquery.where && paymentSubquery.where.length > 0) {
           // But the main query MUST still have it to preserve semantics
-          expect(optimizedQuery.where).toContainEqual(
-            createGt(createPropRef(`payment`, `amount`), createValue(100))
-          )
+          expect(optimizedQuery.where).toContainEqual({
+            expression: createGt(
+              createPropRef(`payment`, `amount`),
+              createValue(100)
+            ),
+            residual: true,
+          })
         }
       }
     })
@@ -1621,8 +1645,7 @@ describe(`Query Optimizer`, () => {
       const { optimizedQuery } = optimizeQuery(query)
 
       // For INNER JOIN, the WHERE clause CAN be completely moved to the subquery
-      // This is safe because INNER JOIN doesn't produce NULL values
-      // The main query where array might be empty or have the clause - either is semantically correct
+      // This is safe because INNER JOIN doesn't produce NULL values that need residual filtering
       expect(optimizedQuery.where).toHaveLength(0)
 
       // The WHERE clause should be pushed into the department subquery for optimization

--- a/packages/db/tests/query/optimizer.test.ts
+++ b/packages/db/tests/query/optimizer.test.ts
@@ -1420,4 +1420,221 @@ describe(`Query Optimizer`, () => {
       }
     })
   })
+
+  describe(`JOIN semantics preservation`, () => {
+    test(`should preserve WHERE clause semantics when pushing down to LEFT JOIN`, () => {
+      // This test reproduces the bug where pushing WHERE clauses into LEFT JOIN subqueries
+      // changes the semantics by filtering out null values that should remain
+
+      const teamsCollection = { id: `teams` } as any
+      const teamMembersCollection = { id: `team-members` } as any
+
+      // Original query: LEFT JOIN with WHERE clause that should filter final results
+      const query: QueryIR = {
+        from: new CollectionRef(teamsCollection, `team`),
+        join: [
+          {
+            type: `left`,
+            from: new CollectionRef(teamMembersCollection, `teamMember`),
+            left: createPropRef(`team`, `id`),
+            right: createPropRef(`teamMember`, `team_id`),
+          },
+        ],
+        where: [
+          // This WHERE clause should filter the final result, not pre-filter the teamMember collection
+          createEq(createPropRef(`teamMember`, `user_id`), createValue(100)),
+        ],
+        select: {
+          id: createPropRef(`team`, `id`),
+          name: createPropRef(`team`, `name`),
+        },
+      }
+
+      const { optimizedQuery } = optimizeQuery(query)
+
+      // The WHERE clause should remain in the main query to preserve LEFT JOIN semantics
+      // It should NOT be completely moved to the subquery
+      expect(optimizedQuery.where).toHaveLength(1)
+      expect(optimizedQuery.where![0]).toEqual(
+        createEq(createPropRef(`teamMember`, `user_id`), createValue(100))
+      )
+
+      // If the optimizer creates a subquery for teamMember, the WHERE clause should also be copied there
+      // but a residual copy must remain in the main query
+      if (
+        optimizedQuery.join &&
+        optimizedQuery.join[0]?.from.type === `queryRef`
+      ) {
+        const teamMemberSubquery = optimizedQuery.join[0].from.query
+        // The subquery may have the WHERE clause for optimization
+        if (teamMemberSubquery.where && teamMemberSubquery.where.length > 0) {
+          // But the main query MUST still have it to preserve semantics
+          expect(optimizedQuery.where).toContainEqual(
+            createEq(createPropRef(`teamMember`, `user_id`), createValue(100))
+          )
+        }
+      }
+    })
+
+    test(`should preserve WHERE clause semantics when pushing down to RIGHT JOIN`, () => {
+      // This test reproduces the bug where pushing WHERE clauses into RIGHT JOIN subqueries
+      // changes the semantics by filtering out null values that should remain
+
+      const usersCollection = { id: `users` } as any
+      const profilesCollection = { id: `profiles` } as any
+
+      // Original query: RIGHT JOIN with WHERE clause that should filter final results
+      // This should include all profiles, but only those where user.department_id = 1 OR user is null
+      const query: QueryIR = {
+        from: new CollectionRef(usersCollection, `user`),
+        join: [
+          {
+            type: `right`,
+            from: new CollectionRef(profilesCollection, `profile`),
+            left: createPropRef(`user`, `id`),
+            right: createPropRef(`profile`, `user_id`),
+          },
+        ],
+        where: [
+          // This WHERE clause should filter the final result, not pre-filter the users collection
+          // In a RIGHT JOIN, this should keep profiles where either:
+          // 1. user.department_id = 1, OR
+          // 2. user is null (profile has no matching user)
+          createEq(createPropRef(`user`, `department_id`), createValue(1)),
+        ],
+        select: {
+          profile_id: createPropRef(`profile`, `id`),
+          user_name: createPropRef(`user`, `name`),
+        },
+      }
+
+      const { optimizedQuery } = optimizeQuery(query)
+
+      // The WHERE clause should remain in the main query to preserve RIGHT JOIN semantics
+      // It should NOT be completely moved to the subquery
+      expect(optimizedQuery.where).toHaveLength(1)
+      expect(optimizedQuery.where![0]).toEqual(
+        createEq(createPropRef(`user`, `department_id`), createValue(1))
+      )
+
+      // If the optimizer creates a subquery for users, the WHERE clause should also be copied there
+      // but a residual copy must remain in the main query
+      if (optimizedQuery.from.type === `queryRef`) {
+        const userSubquery = optimizedQuery.from.query
+        // The subquery may have the WHERE clause for optimization
+        if (userSubquery.where && userSubquery.where.length > 0) {
+          // But the main query MUST still have it to preserve semantics
+          expect(optimizedQuery.where).toContainEqual(
+            createEq(createPropRef(`user`, `department_id`), createValue(1))
+          )
+        }
+      }
+    })
+
+    test(`should preserve WHERE clause semantics when pushing down to FULL JOIN`, () => {
+      // This test reproduces the bug where pushing WHERE clauses into FULL JOIN subqueries
+      // changes the semantics by filtering out null values that should remain
+
+      const ordersCollection = { id: `orders` } as any
+      const paymentsCollection = { id: `payments` } as any
+
+      // Original query: FULL JOIN with WHERE clause that should filter final results
+      // This should include:
+      // 1. Orders with payments where payment.amount > 100
+      // 2. Orders without payments (WHERE would be false for null payment.amount, so filtered out)
+      // 3. Payments without orders where payment.amount > 100
+      const query: QueryIR = {
+        from: new CollectionRef(ordersCollection, `order`),
+        join: [
+          {
+            type: `full`,
+            from: new CollectionRef(paymentsCollection, `payment`),
+            left: createPropRef(`order`, `id`),
+            right: createPropRef(`payment`, `order_id`),
+          },
+        ],
+        where: [
+          // This WHERE clause should filter the final result, not pre-filter either collection
+          createGt(createPropRef(`payment`, `amount`), createValue(100)),
+        ],
+        select: {
+          order_id: createPropRef(`order`, `id`),
+          payment_amount: createPropRef(`payment`, `amount`),
+        },
+      }
+
+      const { optimizedQuery } = optimizeQuery(query)
+
+      // The WHERE clause should remain in the main query to preserve FULL JOIN semantics
+      // It should NOT be completely moved to the subquery
+      expect(optimizedQuery.where).toHaveLength(1)
+      expect(optimizedQuery.where![0]).toEqual(
+        createGt(createPropRef(`payment`, `amount`), createValue(100))
+      )
+
+      // If the optimizer creates a subquery for payments, the WHERE clause should also be copied there
+      // but a residual copy must remain in the main query
+      if (
+        optimizedQuery.join &&
+        optimizedQuery.join[0]?.from.type === `queryRef`
+      ) {
+        const paymentSubquery = optimizedQuery.join[0].from.query
+        // The subquery may have the WHERE clause for optimization
+        if (paymentSubquery.where && paymentSubquery.where.length > 0) {
+          // But the main query MUST still have it to preserve semantics
+          expect(optimizedQuery.where).toContainEqual(
+            createGt(createPropRef(`payment`, `amount`), createValue(100))
+          )
+        }
+      }
+    })
+
+    test(`should allow WHERE clause pushdown for INNER JOIN (semantics preserved)`, () => {
+      // This test confirms that INNER JOIN optimization is still safe
+      // Because INNER JOINs don't produce NULL values, moving WHERE clauses to subqueries
+      // doesn't change the semantics
+
+      const usersCollection = { id: `users` } as any
+      const departmentsCollection = { id: `departments` } as any
+
+      // Original query: INNER JOIN with WHERE clause - optimization should be allowed
+      const query: QueryIR = {
+        from: new CollectionRef(usersCollection, `user`),
+        join: [
+          {
+            type: `inner`,
+            from: new CollectionRef(departmentsCollection, `dept`),
+            left: createPropRef(`user`, `department_id`),
+            right: createPropRef(`dept`, `id`),
+          },
+        ],
+        where: [
+          // This WHERE clause CAN be moved to subquery for INNER JOIN without changing semantics
+          createEq(createPropRef(`dept`, `budget`), createValue(100000)),
+        ],
+        select: {
+          user_name: createPropRef(`user`, `name`),
+          dept_name: createPropRef(`dept`, `name`),
+        },
+      }
+
+      const { optimizedQuery } = optimizeQuery(query)
+
+      // For INNER JOIN, the WHERE clause CAN be completely moved to the subquery
+      // This is safe because INNER JOIN doesn't produce NULL values
+      // The main query where array might be empty or have the clause - either is semantically correct
+      expect(optimizedQuery.where).toHaveLength(0)
+
+      // The WHERE clause should be pushed into the department subquery for optimization
+      expect(optimizedQuery.join).toHaveLength(1)
+      expect(optimizedQuery.join![0]?.from.type).toBe(`queryRef`)
+
+      if (optimizedQuery.join![0]?.from.type === `queryRef`) {
+        const deptSubquery = optimizedQuery.join![0].from.query
+        expect(deptSubquery.where).toContainEqual(
+          createEq(createPropRef(`dept`, `budget`), createValue(100000))
+        )
+      }
+    })
+  })
 })


### PR DESCRIPTION
This modifies the optimiser to keep a residual copy of the where clause in place when pushing a predicate down into a left/right/full join ensuring that the semantics of the query are maintained.

The residual where close is marked as such in the IR so that it is not repeatedly pushed down during the recursive optimisation.