### PR TITLE
fix race condition in loading joined collections into live query

### DIFF
--- a/.changeset/new-swans-heal.md
+++ b/.changeset/new-swans-heal.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fix a race condition that could result in the initial state of a joined collection being sent to the live query pipeline twice, this would result in incorrect join results.

--- a/packages/db/src/query/live/collection-subscriber.ts
+++ b/packages/db/src/query/live/collection-subscriber.ts
@@ -168,9 +168,11 @@ export class CollectionSubscriber<
     const sendVisibleChanges = (
       changes: Array<ChangeMessage<any, string | number>>
     ) => {
-      // We are filtering the changes out when `sendChanges` is false, but still sending
-      // an empty array to the pipeline. This is needed to ensure that the pipeline
-      // receives the status update that the collection is now ready.
+      // We filter out changes when sendChanges is false to ensure that we don't send
+      // any changes from the live subscription until the join operator requests either
+      // the initial state or its first key. This is needed otherwise it could receive
+      // changes which are then later subsumed by the initial state (and that would
+      // lead to weird bugs due to the data being received twice).
       this.sendVisibleChangesToPipeline(
         sendChanges ? changes : [],
         loadedInitialState


### PR DESCRIPTION
Fixes #438

The issue was that the subscription to the live changes could start emitting results before we had first done any join processing. The join called either `loadKeys` or `loadInitialState` depending on if there was an index it could use. These now set a flag to indicate that we now actually want to start tailing the live changes, until then they are filtered out. We still have to send an empty array of changes when there are any before then so that the query is notified of any collection status change.

Failed test run with repo before it's then fixed: https://github.com/TanStack/db/actions/runs/17233860827/job/48894002331?pr=451