### PR TITLE
fix handling of electric must-refetch

### DIFF
--- a/.changeset/eleven-towns-carry.md
+++ b/.changeset/eleven-towns-carry.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/electric-db-collection": patch
+---
+
+fix the handling of an electric must-refetch message so that the truncate is handled in the same transaction as the next up-to-date, ensuring you don't get a momentary empty collection.

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -540,9 +540,8 @@ function createElectricSync<T extends Row<unknown>>(
 
             truncate()
 
-            // Commit the truncate transaction immediately
-            commit()
-            transactionStarted = false
+            // Reset hasUpToDate so we continue accumulating changes until next up-to-date
+            hasUpToDate = false
           }
         }
 

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -483,6 +483,9 @@ function createElectricSync<T extends Row<unknown>>(
         onError: (errorParams) => {
           // Just immediately mark ready if there's an error to avoid blocking
           // apps waiting for `.preload()` to finish.
+          // Note that Electric sends a 409 error on a `must-refetch` message, but the
+          // ShapeStream handled this and it will not reach this handler, therefor
+          // this markReady will not be triggers by a `must-refetch`.
           markReady()
 
           if (shapeOptions.onError) {

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -476,7 +476,7 @@ function createElectricSync<T extends Row<unknown>>(
 
   return {
     sync: (params: Parameters<SyncConfig<T>[`sync`]>[0]) => {
-      const { begin, write, commit, markReady, truncate } = params
+      const { begin, write, commit, markReady, truncate, collection } = params
       const stream = new ShapeStream({
         ...shapeOptions,
         signal: abortController.signal,
@@ -487,6 +487,13 @@ function createElectricSync<T extends Row<unknown>>(
 
           if (shapeOptions.onError) {
             return shapeOptions.onError(errorParams)
+          } else {
+            console.error(
+              `An error occurred while syncing collection: ${collection.id}, \n` +
+                `it has been marked as ready to avoid blocking apps waiting for '.preload()' to finish. \n` +
+                `You can provide an 'onError' handler on the shapeOptions to handle this error, and this message will not be logged.`,
+              errorParams
+            )
           }
 
           return

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -254,8 +254,10 @@ describe(`Electric Integration`, () => {
       },
     ])
 
-    // The collection should be cleared but remain in ready state
-    expect(collection.state.size).toBe(0)
+    // The collection should still have old data because truncate is in pending
+    // transaction. This is the intended behavior of the collection, you should have
+    // the old data until the next up-to-date message.
+    expect(collection.state.size).toBe(2)
     expect(collection.status).toBe(`ready`)
 
     // Send new data after must-refetch


### PR DESCRIPTION
I tried to add a test to validate that a 409 didn't reach the onError handler, but it would require very complex mocking, and time is limited...