### PR TITLE
Support ordering grouped results based on aggregates

### DIFF
--- a/.changeset/lemon-queens-pump.md
+++ b/.changeset/lemon-queens-pump.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Add support for queries to order results based on aggregated values

--- a/packages/db/src/query/compiler/group-by.ts
+++ b/packages/db/src/query/compiler/group-by.ts
@@ -130,7 +130,7 @@ export function processGroupBy(
     if (havingClauses && havingClauses.length > 0) {
       for (const havingClause of havingClauses) {
         const havingExpression = getHavingExpression(havingClause)
-        const transformedHavingClause = transformHavingClause(
+        const transformedHavingClause = replaceAggregatesByRefs(
           havingExpression,
           selectClause || {}
         )
@@ -265,7 +265,7 @@ export function processGroupBy(
   if (havingClauses && havingClauses.length > 0) {
     for (const havingClause of havingClauses) {
       const havingExpression = getHavingExpression(havingClause)
-      const transformedHavingClause = transformHavingClause(
+      const transformedHavingClause = replaceAggregatesByRefs(
         havingExpression,
         selectClause || {}
       )
@@ -367,11 +367,12 @@ function getAggregateFunction(aggExpr: Aggregate) {
 }
 
 /**
- * Transforms a HAVING clause to replace Agg expressions with references to computed values
+ * Transforms basic expressions and aggregates to replace Agg expressions with references to computed values
  */
-function transformHavingClause(
+export function replaceAggregatesByRefs(
   havingExpr: BasicExpression | Aggregate,
-  selectClause: Select
+  selectClause: Select,
+  resultAlias: string = `result`
 ): BasicExpression {
   switch (havingExpr.type) {
     case `agg`: {
@@ -380,7 +381,7 @@ function transformHavingClause(
       for (const [alias, selectExpr] of Object.entries(selectClause)) {
         if (selectExpr.type === `agg` && aggregatesEqual(aggExpr, selectExpr)) {
           // Replace with a reference to the computed aggregate
-          return new PropRef([`result`, alias])
+          return new PropRef([resultAlias, alias])
         }
       }
       // If no matching aggregate found in SELECT, throw error
@@ -392,7 +393,7 @@ function transformHavingClause(
       // Transform function arguments recursively
       const transformedArgs = funcExpr.args.map(
         (arg: BasicExpression | Aggregate) =>
-          transformHavingClause(arg, selectClause)
+          replaceAggregatesByRefs(arg, selectClause)
       )
       return new Func(funcExpr.name, transformedArgs)
     }
@@ -404,7 +405,7 @@ function transformHavingClause(
         const alias = refExpr.path[0]!
         if (selectClause[alias]) {
           // This is a reference to a SELECT alias, convert to result.alias
-          return new PropRef([`result`, alias])
+          return new PropRef([resultAlias, alias])
         }
       }
       // Return as-is for other refs

--- a/packages/db/src/query/compiler/index.ts
+++ b/packages/db/src/query/compiler/index.ts
@@ -259,6 +259,7 @@ export function compileQuery(
       rawQuery,
       pipeline,
       query.orderBy,
+      query.select || {},
       collections[mainCollectionId]!,
       optimizableOrderByCollections,
       query.limit,


### PR DESCRIPTION
Fixes https://github.com/TanStack/db/issues/466 such that queries can order grouped results based on aggregates. This means we support queries like this one:
```ts
q
  .from({ vehicleDocuments: vehicleDocumentCollection })
  .groupBy((q) => q.vehicleDocuments.vin)
  .orderBy(
    (q) => max(q.vehicleDocuments.updatedAt), // couldn't do this before
    "desc"
  )
  .select((q) => ({
    vin: q.vehicleDocuments.vin,
    updatedAt: max(q.vehicleDocuments.updatedAt),
  }))
```