### PR TITLE
fix a bug where a pending sync transaction could be committed early

### DIFF
--- a/.changeset/eighty-hoops-report.md
+++ b/.changeset/eighty-hoops-report.md
@@ -2,4 +2,4 @@
 "@tanstack/db": patch
 ---
 
-fixed a bug where a pending sync transaction could be applied early when an optimistic mutation was resolved to rolled back
+fixed a bug where a pending sync transaction could be applied early when an optimistic mutation was resolved or rolled back

--- a/.changeset/eighty-hoops-report.md
+++ b/.changeset/eighty-hoops-report.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fixed a bug where a pending sync transaction could be applied early when an optimistic mutation was resolved to rolled back

--- a/packages/db/tests/collection-auto-index.test.ts
+++ b/packages/db/tests/collection-auto-index.test.ts
@@ -15,7 +15,7 @@ import {
   createIndexUsageTracker,
   expectIndexUsage,
   withIndexTracking,
-} from "./utls"
+} from "./utils"
 
 // Global row proxy for expressions
 const row = createSingleRowRefProxy<TestItem>()

--- a/packages/db/tests/collection-indexes.test.ts
+++ b/packages/db/tests/collection-indexes.test.ts
@@ -13,7 +13,7 @@ import {
   lte,
   or,
 } from "../src/query/builder/functions"
-import { expectIndexUsage, withIndexTracking } from "./utls"
+import { expectIndexUsage, withIndexTracking } from "./utils"
 import type { Collection } from "../src/collection"
 import type { MutationFn, PendingMutation } from "../src/types"
 

--- a/packages/db/tests/query/basic.test-d.ts
+++ b/packages/db/tests/query/basic.test-d.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 import { type } from "arktype"
 import { createLiveQueryCollection, eq, gt } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample user type for tests
 type User = {

--- a/packages/db/tests/query/basic.test.ts
+++ b/packages/db/tests/query/basic.test.ts
@@ -6,7 +6,7 @@ import {
   upper,
 } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample user type for tests
 type User = {

--- a/packages/db/tests/query/builder/callback-types.test-d.ts
+++ b/packages/db/tests/query/builder/callback-types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, test } from "vitest"
 import { createCollection } from "../../../src/collection.js"
-import { mockSyncCollectionOptions } from "../../utls.js"
+import { mockSyncCollectionOptions } from "../../utils.js"
 import { Query } from "../../../src/query/builder/index.js"
 import {
   add,

--- a/packages/db/tests/query/composables.test.ts
+++ b/packages/db/tests/query/composables.test.ts
@@ -11,7 +11,7 @@ import {
   upper,
 } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 import type { Ref } from "../../src/query/index.js"
 
 // Sample user type for tests

--- a/packages/db/tests/query/distinct.test.ts
+++ b/packages/db/tests/query/distinct.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { concat, createLiveQueryCollection } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 import { DistinctRequiresSelectError } from "../../src/errors"
 
 // Sample data types for comprehensive DISTINCT testing

--- a/packages/db/tests/query/functional-variants.test-d.ts
+++ b/packages/db/tests/query/functional-variants.test-d.ts
@@ -6,7 +6,7 @@ import {
   gt,
 } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample user type for tests
 type User = {

--- a/packages/db/tests/query/functional-variants.test.ts
+++ b/packages/db/tests/query/functional-variants.test.ts
@@ -6,7 +6,7 @@ import {
   gt,
 } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample user type for tests
 type User = {

--- a/packages/db/tests/query/group-by.test-d.ts
+++ b/packages/db/tests/query/group-by.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest"
 import { createLiveQueryCollection } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 import {
   and,
   avg,

--- a/packages/db/tests/query/group-by.test.ts
+++ b/packages/db/tests/query/group-by.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { createLiveQueryCollection } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 import {
   and,
   avg,

--- a/packages/db/tests/query/indexes.test.ts
+++ b/packages/db/tests/query/indexes.test.ts
@@ -12,7 +12,7 @@ import {
   length,
   or,
 } from "../../src/query/builder/functions"
-import { mockSyncCollectionOptions } from "../utls"
+import { mockSyncCollectionOptions } from "../utils"
 
 interface TestItem {
   id: string

--- a/packages/db/tests/query/join-subquery.test-d.ts
+++ b/packages/db/tests/query/join-subquery.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest"
 import { createLiveQueryCollection, eq, gt } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample data types for join-subquery testing
 type Issue = {

--- a/packages/db/tests/query/join-subquery.test.ts
+++ b/packages/db/tests/query/join-subquery.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { createLiveQueryCollection, eq, gt } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample data types for join-subquery testing
 type Issue = {

--- a/packages/db/tests/query/join.test-d.ts
+++ b/packages/db/tests/query/join.test-d.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 import { type } from "arktype"
 import { createLiveQueryCollection, eq } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample data types for join type testing
 type User = {

--- a/packages/db/tests/query/join.test.ts
+++ b/packages/db/tests/query/join.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { createLiveQueryCollection, eq } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample data types for join testing
 type User = {

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -6,7 +6,7 @@ import { Query } from "../../src/query/builder/index.js"
 import {
   mockSyncCollectionOptions,
   mockSyncCollectionOptionsNoInitialState,
-} from "../utls.js"
+} from "../utils.js"
 import type { ChangeMessage } from "../../src/types.js"
 
 // Sample user type for tests

--- a/packages/db/tests/query/optional-fields-negative.test-d.ts
+++ b/packages/db/tests/query/optional-fields-negative.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest"
 import { createLiveQueryCollection, eq, gt } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Test types with optional fields
 type UserWithOptional = {

--- a/packages/db/tests/query/optional-fields-runtime.test.ts
+++ b/packages/db/tests/query/optional-fields-runtime.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { createLiveQueryCollection, eq } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Test types with optional fields
 type UserWithOptional = {

--- a/packages/db/tests/query/order-by.test.ts
+++ b/packages/db/tests/query/order-by.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 import { createLiveQueryCollection } from "../../src/query/live-query-collection.js"
 import { eq, gt } from "../../src/query/builder/functions.js"
 

--- a/packages/db/tests/query/subquery.test-d.ts
+++ b/packages/db/tests/query/subquery.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest"
 import { createLiveQueryCollection, eq, gt } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample types for subquery testing
 type Issue = {

--- a/packages/db/tests/query/subquery.test.ts
+++ b/packages/db/tests/query/subquery.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { createLiveQueryCollection, eq, gt } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 
 // Sample types for subquery testing
 type Issue = {

--- a/packages/db/tests/query/where.test.ts
+++ b/packages/db/tests/query/where.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { createLiveQueryCollection } from "../../src/query/index.js"
 import { createCollection } from "../../src/collection.js"
-import { mockSyncCollectionOptions } from "../utls.js"
+import { mockSyncCollectionOptions } from "../utils.js"
 import {
   add,
   and,

--- a/packages/db/tests/utils.ts
+++ b/packages/db/tests/utils.ts
@@ -337,3 +337,88 @@ export function mockSyncCollectionOptionsNoInitialState<
 
   return options
 }
+
+// Utility to flush microtasks and promises
+export const flushPromises = () =>
+  new Promise((resolve) => setTimeout(resolve, 0))
+
+/**
+ * Utility to suppress expected unhandled rejections in tests.
+ *
+ * This function temporarily removes the vitest unhandled rejection handler and
+ * sets up a custom handler that catches rejections with the expected message.
+ * It's useful for testing scenarios where you expect a rejection to happen
+ * asynchronously (e.g., in microtasks) that would otherwise cause vitest to
+ * report an unhandled error.
+ *
+ * In tanstack db we rethrow errors in optimistic mutations inside a microtask, and so
+ * this bubbles up as an unhandled rejection. This utility can be used to suppress
+ * these rejections within a test.
+ *
+ * @param expectedMessage - The error message to expect and suppress
+ * @param testFn - The test function that will trigger the expected rejection
+ * @returns A promise that resolves when the test completes and the rejection is caught
+ *
+ * @example
+ * ```typescript
+ * await withExpectedRejection('expected error message', () => {
+ *   // Your test code that triggers the rejection
+ *   someAsyncOperation()
+ *   return flushPromises()
+ * })
+ * ```
+ */
+export function withExpectedRejection<T>(
+  expectedMessage: string,
+  testFn: () => T | Promise<T>
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    // Find and temporarily remove the vitest unhandled rejection handler
+    const originalUnhandledRejection = process
+      .listeners(`unhandledRejection`)
+      .find((listener) => listener.name === `vitestUnhandledRejectionHandler`)
+
+    let expectedRejectionCaught = false
+    const handleRejection = (reason: any) => {
+      if (reason?.message === expectedMessage) {
+        expectedRejectionCaught = true
+        return // Don't re-throw, this is expected
+      }
+      // Re-throw other rejections
+      reject(reason)
+    }
+
+    if (originalUnhandledRejection) {
+      process.removeListener(`unhandledRejection`, originalUnhandledRejection)
+    }
+    process.on(`unhandledRejection`, handleRejection)
+
+    // Execute the test function and handle the result
+    Promise.resolve(testFn())
+      .then(async (value) => {
+        // Wait for microtasks and then check if the rejection was caught
+        await flushPromises()
+
+        if (!expectedRejectionCaught) {
+          reject(
+            new Error(
+              `Expected rejection with message "${expectedMessage}" was not caught`
+            )
+          )
+          return
+        }
+
+        resolve(value)
+      })
+      .catch((error) => {
+        reject(error)
+      })
+      .finally(() => {
+        // Clean up the error handler
+        process.removeListener(`unhandledRejection`, handleRejection)
+        if (originalUnhandledRejection) {
+          process.addListener(`unhandledRejection`, originalUnhandledRejection)
+        }
+      })
+  })
+}

--- a/packages/db/tests/utls.ts
+++ b/packages/db/tests/utls.ts
@@ -271,6 +271,7 @@ export function mockSyncCollectionOptionsNoInitialState<
   let write: Parameters<SyncConfig<T>[`sync`]>[0][`write`]
   let commit: () => void
   let markReady: () => void
+  let truncate: () => void
 
   let syncPendingPromise: Promise<void> | undefined
   let syncPendingResolve: (() => void) | undefined
@@ -297,6 +298,7 @@ export function mockSyncCollectionOptionsNoInitialState<
     write: ((value) => write!(value)) as typeof write,
     commit: () => commit!(),
     markReady: () => markReady!(),
+    truncate: () => truncate!(),
     resolveSync: () => {
       syncPendingResolve!()
     },
@@ -312,6 +314,7 @@ export function mockSyncCollectionOptionsNoInitialState<
         write = params.write
         commit = params.commit
         markReady = params.markReady
+        truncate = params.truncate
       },
     },
     startSync: false,

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "@tanstack/db"
 import { useEffect } from "react"
 import { useLiveQuery } from "../src/useLiveQuery"
-import { mockSyncCollectionOptions } from "../../db/tests/utls"
+import { mockSyncCollectionOptions } from "../../db/tests/utils"
 
 type Person = {
   id: string

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "@tanstack/db"
 import { createComputed, createRoot, createSignal } from "solid-js"
 import { useLiveQuery } from "../src/useLiveQuery"
-import { mockSyncCollectionOptions } from "../../db/tests/utls"
+import { mockSyncCollectionOptions } from "../../db/tests/utils"
 import type { Accessor } from "solid-js"
 
 type Person = {

--- a/packages/svelte-db/tests/useLiveQuery.svelte.test.ts
+++ b/packages/svelte-db/tests/useLiveQuery.svelte.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@tanstack/db"
 import { flushSync } from "svelte"
 import { useLiveQuery } from "../src/useLiveQuery.svelte.js"
-import { mockSyncCollectionOptions } from "../../db/tests/utls"
+import { mockSyncCollectionOptions } from "../../db/tests/utils"
 
 type Person = {
   id: string

--- a/packages/vue-db/tests/useLiveQuery.test.ts
+++ b/packages/vue-db/tests/useLiveQuery.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/db"
 import { nextTick, ref, watchEffect } from "vue"
 import { useLiveQuery } from "../src/useLiveQuery"
-import { mockSyncCollectionOptions } from "../../db/tests/utls"
+import { mockSyncCollectionOptions } from "../../db/tests/utils"
 
 type Person = {
   id: string


### PR DESCRIPTION
This resolves a bug where a local optimistic change that is "resolved" would trigger all pending sync transactions to be applied to the collection, even if they haven't been "committed" themselves.

This could be seen if for example an electric collection received a `must-refetch` which would trigger a `truncate`, that transaction is then left open which the data is refetched. If a local mutation was resolved or rejected, that pending sync transaction was applied.

The root cause was that `commitPendingTransactions` would apply to *all* pending sync transactions, both uncommitted and committed - this is wrong. This fixes it by filtering out only committed transactions and applying them.

Failed test run from before fix committed: https://github.com/TanStack/db/actions/runs/17399754657/job/49389905839?pr=482