### PR TITLE
fix stuck empty remounted live query that uses joins bug

### DIFF
--- a/.changeset/deep-bushes-sell.md
+++ b/.changeset/deep-bushes-sell.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fix an bug where a live query that used joins could become stuck empty when its remounted/resubscribed

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -49,15 +49,11 @@ export class CollectionConfigBuilder<
     | undefined
 
   // Map of collection IDs to functions that load keys for that lazy collection
-  readonly lazyCollectionsCallbacks: Record<string, LazyCollectionCallbacks> =
-    {}
+  lazyCollectionsCallbacks: Record<string, LazyCollectionCallbacks> = {}
   // Set of collection IDs that are lazy collections
   readonly lazyCollections = new Set<string>()
   // Set of collection IDs that include an optimizable ORDER BY clause
-  readonly optimizableOrderByCollections: Record<
-    string,
-    OrderByOptimizationInfo
-  > = {}
+  optimizableOrderByCollections: Record<string, OrderByOptimizationInfo> = {}
 
   constructor(
     private readonly config: LiveQueryCollectionConfig<TContext, TResult>
@@ -168,6 +164,11 @@ export class CollectionConfigBuilder<
       this.inputsCache = undefined
       this.pipelineCache = undefined
       this.collectionWhereClausesCache = undefined
+
+      // Reset lazy collection state
+      this.lazyCollections.clear()
+      this.optimizableOrderByCollections = {}
+      this.lazyCollectionsCallbacks = {}
     }
   }
 

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import { act, renderHook, waitFor } from "@testing-library/react"
 import {
   Query,
@@ -1007,106 +1007,6 @@ describe(`Query Collections`, () => {
       name: `John Smith`,
       age: 35,
     })
-  })
-
-  it(`nested live query should not go blank after GC and resubscribe`, async () => {
-    type Thread = { id: string; last_email_id: string; last_sent_at: number }
-    type LabelByEmail = { email_id: string; label: string }
-
-    const threads = createCollection(
-      mockSyncCollectionOptions<Thread>({
-        id: `threads-for-nested-gc-repro`,
-        getKey: (t) => t.id,
-        initialData: [
-          { id: `t1`, last_email_id: `e1`, last_sent_at: 3 },
-          { id: `t2`, last_email_id: `e2`, last_sent_at: 2 },
-        ],
-      })
-    )
-
-    const labelsByEmail = createCollection(
-      mockSyncCollectionOptions<LabelByEmail>({
-        id: `labels-for-nested-gc-repro`,
-        getKey: (l) => l.email_id,
-        initialData: [
-          { email_id: `e1`, label: `inbox` },
-          { email_id: `e2`, label: `work` },
-        ],
-      })
-    )
-
-    // Source live query (pre-created)
-    const sourceLQ = createLiveQueryCollection({
-      query: (q: any) =>
-        q
-          .from({ thread: threads })
-          .orderBy(({ thread }: any) => thread.last_sent_at, {
-            direction: `desc`,
-          }),
-      startSync: true,
-      gcTime: 5,
-    })
-
-    // Nested live query built from the source live query
-    const nestedLQ = createLiveQueryCollection({
-      query: (q: any) =>
-        q
-          .from({ thread: sourceLQ })
-          .join(
-            { label: labelsByEmail },
-            ({ thread, label }: any) =>
-              eq(thread.last_email_id, label.email_id),
-            `inner`
-          )
-          .orderBy(({ thread }: any) => thread.last_sent_at, {
-            direction: `desc`,
-          }),
-      startSync: true,
-      gcTime: 5,
-    })
-
-    // First mount
-    const { result, unmount } = renderHook(() => useLiveQuery(nestedLQ))
-    await waitFor(() => {
-      expect(result.current.state.size).toBe(2)
-    })
-    unmount()
-    await new Promise((r) => setTimeout(r, 20))
-
-    // Try multiple resubscribe cycles to increase chance of reproduction
-    for (let i = 0; i < 3; i++) {
-      const { result: r2, unmount: u2 } = renderHook(() =>
-        useLiveQuery(nestedLQ)
-      )
-
-      // Immediate read simulating UI
-      const immediateJoinedSize = r2.current.state.size
-      const sourceThreadsSize = threads.size
-      const sourceLabelsSize = labelsByEmail.size
-
-      if (
-        sourceThreadsSize > 0 &&
-        sourceLabelsSize > 0 &&
-        immediateJoinedSize === 0
-      ) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `Reproduced blank nested joined state after GC/resubscribe`,
-          {
-            cycle: i,
-            immediateJoinedSize,
-            sourceThreadsSize,
-            sourceLabelsSize,
-          }
-        )
-      }
-
-      await waitFor(() => {
-        expect(r2.current.state.size).toBe(2)
-      })
-      u2()
-      await new Promise((r) => setTimeout(r, 20))
-    }
   })
 
   describe(`isLoaded property`, () => {


### PR DESCRIPTION
We were not fully clearing the state of the subscriptions when a live query was cleaned up, this resulted in it trying to resubscribe to its source collection without the initial state.

Failed test run showing the repro before fixing: https://github.com/TanStack/db/actions/runs/17427389243/job/49477526316?pr=484