### PR TITLE
Fix race condition where initial data does not trigger live query

### DIFF
--- a/.changeset/poor-vans-design.md
+++ b/.changeset/poor-vans-design.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/react-db": minor
+---
+
+Fixed a bug where a race condition could cause initial results not to be rendered when using `useLiveQuery`.

--- a/.changeset/poor-vans-design.md
+++ b/.changeset/poor-vans-design.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/react-db": minor
+"@tanstack/react-db": patch
 ---
 
 Fixed a bug where a race condition could cause initial results not to be rendered when using `useLiveQuery`.

--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -252,6 +252,11 @@ export function useLiveQuery(
         versionRef.current += 1
         onStoreChange()
       })
+      // Collection may be ready and will not receive initial `subscribeChanges()`
+      if (collectionRef.current!.status === `ready`) {
+        versionRef.current += 1
+        onStoreChange()
+      }
       return () => {
         unsubscribe()
       }


### PR DESCRIPTION
There is a race condition where data may be loaded into a collection before the `subscribeChanges(() => {})` is called, so `useLiveQuery` does not emit the initial data. This change checks if the collection is ready and will immediately call `onStoreChanges()`, so that the initial data is rendered.

Example:
```ts
export const vehicleDocumentCollection = createCollection({
  getKey: (item) => item.id,
  schema: vehicleDocumentSchema,
  sync: {
    sync: async ({ begin, commit, write, markReady }) => {
      begin()
      for (const doc of docResponse.documents) {
        write({ type: 'insert', value: doc })
      }

      // Initial data is not displayed, `isLoading` is stuck at true, `isReady` is stuck at false 
      await new Promise((resolve) => setTimeout(resolve, 0))
     // Initial data is displayed, `isLoading: false, isReady: true`
     // await new Promise((resolve) => setTimeout(resolve, 1000))

      commit()

      markReady()
    }
  }
})
```

I believe this will resolve https://github.com/TanStack/db/issues/483 and https://github.com/TanStack/db/issues/437.