### PR TITLE
Fix error example which doesn't compile

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -101,7 +101,7 @@ const todoCollection = createCollection({
 
 // Usage - optimistic update will be rolled back if the mutation fails
 try {
-  const tx = await todoCollection.insert({
+  const tx = todoCollection.insert({
     id: "1",
     text: "New todo",
     completed: false,


### PR DESCRIPTION
I removed the await to fix the compile error in this PR.

Also, not fixed in this PR, but FYI - the `createCollection` call above also throws a TS error.