### PR TITLE
fix: improve InvalidSourceError message clarity

### DIFF
--- a/packages/db/src/errors.ts
+++ b/packages/db/src/errors.ts
@@ -302,8 +302,10 @@ export class SubQueryMustHaveFromClauseError extends QueryBuilderError {
 }
 
 export class InvalidSourceError extends QueryBuilderError {
-  constructor() {
-    super(`Invalid source`)
+  constructor(alias: string) {
+    super(
+      `Invalid source for live query: The value provided for alias "${alias}" is not a Collection. Live queries only accept Collection instances. Please ensure you're passing a valid Collection object, not a plain array or other data type.`
+    )
   }
 }
 

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -70,7 +70,7 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
       }
       ref = new QueryRef(subQuery, alias)
     } else {
-      throw new InvalidSourceError()
+      throw new InvalidSourceError(alias)
     }
 
     return [alias, ref]


### PR DESCRIPTION
## Summary
- Improves the `InvalidSourceError` message to be more descriptive and actionable
- Adds the alias name to help identify which source is causing the problem  
- Provides clear guidance on what should be passed instead (Collection instances)
- Changes from generic "Invalid source" to specific error about non-Collection values

## Test plan
- [x] All existing tests pass (1,281 tests across packages)
- [x] Build completes successfully
- [x] Linting passes
- [x] Error message now includes helpful debugging information

## Error message before/after

**Before:**
```
Invalid source
```

**After:**
```
Invalid source for live query: The value provided for alias "myAlias" is not a Collection. Live queries only accept Collection instances. Please ensure you're passing a valid Collection object, not a plain array or other data type.
```

🤖 Generated with [Claude Code](https://claude.ai/code)