### PR TITLE
Replace JSON.stringify based hashing by structural hashing

### DIFF
--- a/.changeset/tame-times-create.md
+++ b/.changeset/tame-times-create.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db-ivm": patch
+---
+
+Replace JSON.stringify based hash function by structural hashing function.

--- a/packages/db-ivm/package.json
+++ b/packages/db-ivm/package.json
@@ -4,12 +4,10 @@
   "version": "0.1.2",
   "dependencies": {
     "fractional-indexing": "^3.2.0",
-    "murmurhash-js": "^1.0.0",
     "sorted-btree": "^1.8.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
-    "@types/murmurhash-js": "^1.0.6",
     "@vitest/coverage-istanbul": "^3.0.9"
   },
   "exports": {

--- a/packages/db-ivm/src/hashIndex.ts
+++ b/packages/db-ivm/src/hashIndex.ts
@@ -1,4 +1,6 @@
-import { DefaultMap, hash } from "./utils.js"
+import { DefaultMap } from "./utils.js"
+import { hash } from "./hashing/index.js"
+import type { Hash } from "./hashing/index.js"
 
 /**
  * A map from a difference collection trace's keys -> (value, multiplicities) that changed.
@@ -6,12 +8,11 @@ import { DefaultMap, hash } from "./utils.js"
  * exploit the key-value structure of the data to run efficiently.
  */
 export class HashIndex<K, V> {
-  #inner: DefaultMap<K, DefaultMap<string, [V, number]>>
+  #inner: DefaultMap<K, DefaultMap<Hash, [V, number]>>
 
   constructor() {
-    this.#inner = new DefaultMap<K, DefaultMap<string, [V, number]>>(
-      () =>
-        new DefaultMap<string, [V, number]>(() => [undefined as any as V, 0])
+    this.#inner = new DefaultMap<K, DefaultMap<Hash, [V, number]>>(
+      () => new DefaultMap<Hash, [V, number]>(() => [undefined as any as V, 0])
     )
     // #inner is as map of:
     // {

--- a/packages/db-ivm/src/hashing/hash.ts
+++ b/packages/db-ivm/src/hashing/hash.ts
@@ -1,0 +1,157 @@
+import { MurmurHashStream, randomHash } from "./murmur.js"
+import type { Hasher } from "./murmur.js"
+
+/*
+ * Implementation of structural hashing based on the Composites polyfill implementation:
+ * https://github.com/tc39/proposal-composites
+ */
+
+const TRUE = randomHash()
+const FALSE = randomHash()
+const NULL = randomHash()
+const UNDEFINED = randomHash()
+const KEY = randomHash()
+const FUNCTIONS = randomHash()
+const DATE_MARKER = randomHash()
+const OBJECT_MARKER = randomHash()
+const ARRAY_MARKER = randomHash()
+const MAP_MARKER = randomHash()
+const SET_MARKER = randomHash()
+
+const hashCache = new WeakMap<object, number>()
+
+export function hash(input: any): number {
+  const hasher = new MurmurHashStream()
+  updateHasher(hasher, input)
+  return hasher.digest()
+}
+
+function hashObject(input: object): number {
+  const cachedHash = hashCache.get(input)
+  if (cachedHash !== undefined) {
+    return cachedHash
+  }
+
+  let valueHash: number | undefined
+  if (input instanceof Date) {
+    valueHash = hashDate(input)
+  } else {
+    let plainObjectInput = input
+    let marker = OBJECT_MARKER
+
+    if (input instanceof Array) {
+      marker = ARRAY_MARKER
+    }
+
+    if (input instanceof Map) {
+      marker = MAP_MARKER
+      plainObjectInput = [...input.entries()]
+    }
+
+    if (input instanceof Set) {
+      marker = SET_MARKER
+      plainObjectInput = [...input.entries()]
+    }
+
+    if (
+      input instanceof Buffer ||
+      input instanceof Uint8Array ||
+      input instanceof File
+    ) {
+      // Deeply hashing these objects would be too costly
+      // but we also don't want to ignore them
+      // so we track them by reference and cache them in a weak map
+      return cachedReferenceHash(input)
+    }
+
+    valueHash = hashPlainObject(plainObjectInput, marker)
+  }
+
+  hashCache.set(input, valueHash)
+  return valueHash
+}
+
+function hashDate(input: Date): number {
+  const hasher = new MurmurHashStream()
+  hasher.update(DATE_MARKER)
+  hasher.update(input.getTime())
+  return hasher.digest()
+}
+
+function hashPlainObject(input: object, marker: number): number {
+  const hasher = new MurmurHashStream()
+
+  // Mark the type of the input
+  hasher.update(marker)
+  const keys = Object.keys(input)
+  keys.sort(keySort)
+  for (const key of keys) {
+    hasher.update(KEY)
+    hasher.update(key)
+    updateHasher(hasher, input[key as keyof typeof input])
+  }
+
+  return hasher.digest()
+}
+
+function updateHasher(hasher: Hasher, input: unknown): void {
+  if (input === null) {
+    hasher.update(NULL)
+    return
+  }
+  switch (typeof input) {
+    case `undefined`:
+      hasher.update(UNDEFINED)
+      return
+    case `boolean`:
+      hasher.update(input ? TRUE : FALSE)
+      return
+    case `number`:
+      // Normalize NaNs and -0
+      hasher.update(isNaN(input) ? NaN : input === 0 ? 0 : input)
+      return
+    case `bigint`:
+    case `string`:
+    case `symbol`:
+      hasher.update(input)
+      return
+    case `object`:
+      hasher.update(getCachedHash(input))
+      return
+    case `function`:
+      // Functions are assigned a globally unique ID
+      // and that ID is cached in the weak map
+      hasher.update(cachedReferenceHash(input))
+      return
+    default:
+      console.warn(
+        `Ignored input during hashing because it is of type ${typeof input} which is not supported`
+      )
+  }
+}
+
+function getCachedHash(input: object): number {
+  let valueHash = hashCache.get(input)
+  if (valueHash === undefined) {
+    valueHash = hashObject(input)
+  }
+  return valueHash
+}
+
+let nextRefId = 1
+function cachedReferenceHash(fn: object): number {
+  let valueHash = hashCache.get(fn)
+  if (valueHash === undefined) {
+    valueHash = nextRefId ^ FUNCTIONS
+    nextRefId++
+    hashCache.set(fn, valueHash)
+  }
+  return valueHash
+}
+
+/**
+ * Strings sorted lexicographically.
+ */
+function keySort(a: string, b: string): number {
+  return a.localeCompare(b)
+}

--- a/packages/db-ivm/src/hashing/index.ts
+++ b/packages/db-ivm/src/hashing/index.ts
@@ -1,0 +1,2 @@
+export { hash } from "./hash.js"
+export type { Hash, Hasher } from "./murmur.js"

--- a/packages/db-ivm/src/hashing/murmur.ts
+++ b/packages/db-ivm/src/hashing/murmur.ts
@@ -1,0 +1,128 @@
+/*
+ * Implementation of murmur hash based on the Composites polyfill implementation:
+ * https://github.com/tc39/proposal-composites
+ */
+
+const RANDOM_SEED = randomHash()
+const STRING_MARKER = randomHash()
+const BIG_INT_MARKER = randomHash()
+const NEG_BIG_INT_MARKER = randomHash()
+const SYMBOL_MARKER = randomHash()
+
+export type Hash = number
+
+export function randomHash() {
+  return (Math.random() * (2 ** 31 - 1)) >>> 0
+}
+
+export interface Hasher {
+  update: (val: symbol | string | number | bigint) => void
+  digest: () => number
+}
+
+/**
+ * This implementation of Murmur hash uses a random initial seed and random markers.
+ * This means that hashes aren't deterministic across app restarts.
+ * This is intentional in the composites polyfill to be resistent to hash-flooding attacks
+ * where malicious users would precompute lots of different objects whose hashes collide with each other.
+ *
+ * Currently, for ts/db-ivm this is fine because we don't persist client state.
+ * However, when we will introduce persistence we will either need to store the seeds or remove the randomness
+ * to ensure deterministic hashes across app restarts.
+ */
+export class MurmurHashStream implements Hasher {
+  private hash: number = RANDOM_SEED
+  private length = 0
+  private carry = 0
+  private carryBytes = 0
+
+  private _mix(k1: number): void {
+    k1 = Math.imul(k1, 0xcc9e2d51)
+    k1 = (k1 << 15) | (k1 >>> 17)
+    k1 = Math.imul(k1, 0x1b873593)
+    this.hash ^= k1
+    this.hash = (this.hash << 13) | (this.hash >>> 19)
+    this.hash = Math.imul(this.hash, 5) + 0xe6546b64
+  }
+
+  private _writeByte(byte: number): void {
+    this.carry |= (byte & 0xff) << (8 * this.carryBytes)
+    this.carryBytes++
+    this.length++
+
+    if (this.carryBytes === 4) {
+      this._mix(this.carry >>> 0)
+      this.carry = 0
+      this.carryBytes = 0
+    }
+  }
+
+  update(chunk: symbol | string | number | bigint): void {
+    switch (typeof chunk) {
+      case `symbol`: {
+        this.update(SYMBOL_MARKER)
+        const description = chunk.description
+        if (!description) {
+          return
+        }
+
+        for (let i = 0; i < description.length; i++) {
+          const code = description.charCodeAt(i)
+          this._writeByte(code & 0xff)
+          this._writeByte((code >>> 8) & 0xff)
+        }
+        return
+      }
+      case `string`:
+        this.update(STRING_MARKER)
+        for (let i = 0; i < chunk.length; i++) {
+          const code = chunk.charCodeAt(i)
+          this._writeByte(code & 0xff)
+          this._writeByte((code >>> 8) & 0xff)
+        }
+        return
+      case `number`:
+        this._writeByte(chunk & 0xff)
+        this._writeByte((chunk >>> 8) & 0xff)
+        this._writeByte((chunk >>> 16) & 0xff)
+        this._writeByte((chunk >>> 24) & 0xff)
+        return
+      case `bigint`: {
+        let value = chunk
+        if (value < 0n) {
+          value = -value
+          this.update(NEG_BIG_INT_MARKER)
+        } else {
+          this.update(BIG_INT_MARKER)
+        }
+        while (value > 0n) {
+          this._writeByte(Number(value & 0xffn))
+          value >>= 8n
+        }
+        if (chunk === 0n) this._writeByte(0)
+        return
+      }
+      default:
+        throw new TypeError(`Unsupported input type: ${typeof chunk}`)
+    }
+  }
+
+  digest(): number {
+    if (this.carryBytes > 0) {
+      let k1 = this.carry >>> 0
+      k1 = Math.imul(k1, 0xcc9e2d51)
+      k1 = (k1 << 15) | (k1 >>> 17)
+      k1 = Math.imul(k1, 0x1b873593)
+      this.hash ^= k1
+    }
+
+    this.hash ^= this.length
+    this.hash ^= this.hash >>> 16
+    this.hash = Math.imul(this.hash, 0x85ebca6b)
+    this.hash ^= this.hash >>> 13
+    this.hash = Math.imul(this.hash, 0xc2b2ae35)
+    this.hash ^= this.hash >>> 16
+
+    return this.hash >>> 0
+  }
+}

--- a/packages/db-ivm/src/multiset.ts
+++ b/packages/db-ivm/src/multiset.ts
@@ -2,8 +2,8 @@ import {
   DefaultMap,
   chunkedArrayPush,
   globalObjectIdGenerator,
-  hash,
 } from "./utils.js"
+import { hash } from "./hashing/index.js"
 
 export type MultiSetArray<T> = Array<[T, number]>
 export type KeyedData<T> = [key: string, value: T]

--- a/packages/db-ivm/src/operators/distinct.ts
+++ b/packages/db-ivm/src/operators/distinct.ts
@@ -1,11 +1,11 @@
 import { DifferenceStreamWriter, UnaryOperator } from "../graph.js"
 import { StreamBuilder } from "../d2.js"
-import { hash } from "../utils.js"
+import { hash } from "../hashing/index.js"
 import { MultiSet } from "../multiset.js"
+import type { Hash } from "../hashing/index.js"
 import type { DifferenceStreamReader } from "../graph.js"
 import type { IStreamBuilder } from "../types.js"
 
-type HashedValue = string
 type Multiplicity = number
 
 /**
@@ -13,7 +13,7 @@ type Multiplicity = number
  */
 export class DistinctOperator<T> extends UnaryOperator<T> {
   #by: (value: T) => any
-  #values: Map<HashedValue, Multiplicity> // keeps track of the number of times each value has been seen
+  #values: Map<Hash, Multiplicity> // keeps track of the number of times each value has been seen
 
   constructor(
     id: number,
@@ -27,7 +27,7 @@ export class DistinctOperator<T> extends UnaryOperator<T> {
   }
 
   run(): void {
-    const updatedValues = new Map<HashedValue, [Multiplicity, T]>()
+    const updatedValues = new Map<Hash, [Multiplicity, T]>()
 
     // Compute the new multiplicity for each value
     for (const message of this.inputMessages()) {

--- a/packages/db-ivm/src/utils.ts
+++ b/packages/db-ivm/src/utils.ts
@@ -1,4 +1,15 @@
-import murmurhash from "murmurhash-js"
+/**
+ * Simple assertion function for runtime checks.
+ * Throws an error if the condition is false.
+ */
+export function assert(
+  condition: unknown,
+  message?: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(message || `Assertion failed`)
+  }
+}
 
 /**
  * A map that returns a default value for keys that are not present.
@@ -46,11 +57,12 @@ export function chunkedArrayPush(array: Array<unknown>, other: Array<unknown>) {
   }
 }
 
-const hashCache = new WeakMap()
+// const hashCache = new WeakMap()
 
 /**
  * Replacer function for JSON.stringify that converts unsupported types to strings
  */
+/*
 function hashReplacer(_key: string, value: any): any {
   if (typeof value === `bigint`) {
     return String(value)
@@ -67,10 +79,12 @@ function hashReplacer(_key: string, value: any): any {
   }
   return value
 }
+  */
 
 /**
  * A hash method that caches the hash of a value in a week map
  */
+/*
 export function hash(data: any): string {
   if (
     data === null ||
@@ -91,6 +105,7 @@ export function hash(data: any): string {
   hashCache.set(data, hashValue)
   return hashValue
 }
+*/
 
 export function binarySearch<T>(
   array: Array<T>,

--- a/packages/db-ivm/src/utils.ts
+++ b/packages/db-ivm/src/utils.ts
@@ -57,56 +57,6 @@ export function chunkedArrayPush(array: Array<unknown>, other: Array<unknown>) {
   }
 }
 
-// const hashCache = new WeakMap()
-
-/**
- * Replacer function for JSON.stringify that converts unsupported types to strings
- */
-/*
-function hashReplacer(_key: string, value: any): any {
-  if (typeof value === `bigint`) {
-    return String(value)
-  } else if (typeof value === `symbol`) {
-    return String(value)
-  } else if (typeof value === `function`) {
-    return String(value)
-  } else if (value === undefined) {
-    return `undefined`
-  } else if (value instanceof Map) {
-    return `Map(${JSON.stringify(Array.from(value.entries()), hashReplacer)})`
-  } else if (value instanceof Set) {
-    return `Set(${JSON.stringify(Array.from(value.values()), hashReplacer)})`
-  }
-  return value
-}
-  */
-
-/**
- * A hash method that caches the hash of a value in a week map
- */
-/*
-export function hash(data: any): string {
-  if (
-    data === null ||
-    data === undefined ||
-    (typeof data !== `object` && typeof data !== `function`)
-  ) {
-    // Can't be cached in the weak map because it's not an object
-    const serialized = JSON.stringify(data, hashReplacer)
-    return murmurhash.murmur3(serialized).toString(16)
-  }
-
-  if (hashCache.has(data)) {
-    return hashCache.get(data)
-  }
-
-  const serialized = JSON.stringify(data, hashReplacer)
-  const hashValue = murmurhash.murmur3(serialized).toString(16)
-  hashCache.set(data, hashValue)
-  return hashValue
-}
-*/
-
 export function binarySearch<T>(
   array: Array<T>,
   value: T,

--- a/packages/db-ivm/src/valueIndex.ts
+++ b/packages/db-ivm/src/valueIndex.ts
@@ -1,4 +1,4 @@
-import { hash } from "./utils.js"
+import { hash } from "./hashing/index.js"
 
 /**
  * A map from a difference collection trace's keys -> (value, multiplicities) that changed.

--- a/packages/db-ivm/tests/utils.test.ts
+++ b/packages/db-ivm/tests/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { DefaultMap, hash } from "../src/utils.js"
+import { DefaultMap } from "../src/utils.js"
+import { hash } from "../src/hashing/index.js"
 
 describe(`DefaultMap`, () => {
   it(`should return default value for missing keys`, () => {
@@ -28,16 +29,17 @@ describe(`DefaultMap`, () => {
   })
 })
 
+const hashType = `number`
 describe(`hash`, () => {
   describe(`primitive types`, () => {
     it(`should hash null`, () => {
       const result = hash(null)
-      expect(typeof result).toBe(`string`)
+      expect(typeof result).toBe(hashType)
     })
 
     it(`should hash undefined`, () => {
       const result = hash(undefined)
-      expect(typeof result).toBe(`string`)
+      expect(typeof result).toBe(hashType)
     })
 
     it(`should hash strings`, () => {
@@ -46,10 +48,10 @@ describe(`hash`, () => {
       const result3 = hash(`test with spaces`)
       const result4 = hash(`special\nchars\t"`)
 
-      expect(typeof result1).toBe(`string`)
-      expect(typeof result2).toBe(`string`)
-      expect(typeof result3).toBe(`string`)
-      expect(typeof result4).toBe(`string`)
+      expect(typeof result1).toBe(hashType)
+      expect(typeof result2).toBe(hashType)
+      expect(typeof result3).toBe(hashType)
+      expect(typeof result4).toBe(hashType)
 
       // Same strings should have same hash
       expect(hash(`hello`)).toBe(result1)
@@ -64,13 +66,13 @@ describe(`hash`, () => {
       const result6 = hash(-Infinity)
       const result7 = hash(NaN)
 
-      expect(typeof result1).toBe(`string`)
-      expect(typeof result2).toBe(`string`)
-      expect(typeof result3).toBe(`string`)
-      expect(typeof result4).toBe(`string`)
-      expect(typeof result5).toBe(`string`)
-      expect(typeof result6).toBe(`string`)
-      expect(typeof result7).toBe(`string`)
+      expect(typeof result1).toBe(hashType)
+      expect(typeof result2).toBe(hashType)
+      expect(typeof result3).toBe(hashType)
+      expect(typeof result4).toBe(hashType)
+      expect(typeof result5).toBe(hashType)
+      expect(typeof result6).toBe(hashType)
+      expect(typeof result7).toBe(hashType)
 
       // Same numbers should have same hash
       expect(hash(42)).toBe(result1)
@@ -80,8 +82,8 @@ describe(`hash`, () => {
       const result1 = hash(true)
       const result2 = hash(false)
 
-      expect(typeof result1).toBe(`string`)
-      expect(typeof result2).toBe(`string`)
+      expect(typeof result1).toBe(hashType)
+      expect(typeof result2).toBe(hashType)
       expect(result1).not.toBe(result2)
 
       // Same booleans should have same hash
@@ -94,9 +96,9 @@ describe(`hash`, () => {
       const result2 = hash(456n)
       const result3 = hash(123n)
 
-      expect(typeof result1).toBe(`string`)
-      expect(typeof result2).toBe(`string`)
-      expect(typeof result3).toBe(`string`)
+      expect(typeof result1).toBe(hashType)
+      expect(typeof result2).toBe(hashType)
+      expect(typeof result3).toBe(hashType)
       expect(result1).toBe(result3) // Same bigint should have same hash
       expect(result1).not.toBe(result2) // Different bigints should have different hash
     })
@@ -105,17 +107,23 @@ describe(`hash`, () => {
       const sym1 = Symbol(`test`)
       const sym2 = Symbol(`test`)
       const sym3 = Symbol(`different`)
+      const sym4 = Symbol()
+      const sym5 = Symbol()
 
       const result1 = hash(sym1)
       const result2 = hash(sym2)
       const result3 = hash(sym3)
+      const result4 = hash(sym4)
+      const result5 = hash(sym5)
 
-      expect(typeof result1).toBe(`string`)
-      expect(typeof result2).toBe(`string`)
-      expect(typeof result3).toBe(`string`)
-      // Note: Different symbol instances with same description have same string representation
+      expect(typeof result1).toBe(hashType)
+      expect(typeof result2).toBe(hashType)
+      expect(typeof result3).toBe(hashType)
+      // Note: Different symbol instances with same description have same hash
       expect(result1).toBe(result2)
       expect(result1).not.toBe(result3)
+      expect(result4).toBe(result5)
+      expect(result1).not.toBe(result4)
     })
   })
 
@@ -127,8 +135,8 @@ describe(`hash`, () => {
       const hash1 = hash(obj1)
       const hash2 = hash(obj2)
 
-      expect(typeof hash1).toBe(`string`)
-      expect(typeof hash2).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
+      expect(typeof hash2).toBe(hashType)
       // Note: Different key orders might produce different hashes depending on JSON.stringify behavior
     })
 
@@ -141,7 +149,7 @@ describe(`hash`, () => {
       const hash2 = hash(arr2)
       const hash3 = hash(arr3)
 
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
       expect(hash1).toBe(hash2) // Same content should have same hash
       expect(hash1).not.toBe(hash3) // Different content should have different hash
     })
@@ -155,7 +163,7 @@ describe(`hash`, () => {
       const hash2 = hash(date2)
       const hash3 = hash(date3)
 
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
       expect(hash1).toBe(hash2) // Same date should have same hash
       expect(hash1).not.toBe(hash3) // Different dates should have different hash
     })
@@ -169,9 +177,9 @@ describe(`hash`, () => {
       const hash2 = hash(regex2)
       const hash3 = hash(regex3)
 
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
       expect(hash1).toBe(hash2) // Same regex should have same hash
-      // Note: RegExp objects serialize to empty objects {}, so they all produce the same hash
+      // Note: RegExp don't have enumerable properties so they all produce the same hash
       expect(hash1).toBe(hash3) // All RegExp objects have the same hash
     })
 
@@ -184,7 +192,7 @@ describe(`hash`, () => {
       const hash2 = hash(nested2)
       const hash3 = hash(nested3)
 
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
       expect(hash1).toBe(hash2)
       expect(hash1).not.toBe(hash3)
     })
@@ -204,11 +212,12 @@ describe(`hash`, () => {
       const hash2 = hash(func2)
       const hash3 = hash(func3)
 
-      expect(typeof hash1).toBe(`string`)
-      expect(typeof hash2).toBe(`string`)
-      expect(typeof hash3).toBe(`string`)
-      expect(hash1).toBe(hash2) // Same function definition should have same hash
+      expect(typeof hash1).toBe(hashType)
+      expect(typeof hash2).toBe(hashType)
+      expect(typeof hash3).toBe(hashType)
+      expect(hash1).not.toBe(hash2) // Different function should have different hash
       expect(hash1).not.toBe(hash3) // Different function should have different hash
+      expect(hash1).toBe(hash(func1)) // hashing same function should return same hash
     })
 
     it(`should hash Set objects`, () => {
@@ -220,7 +229,7 @@ describe(`hash`, () => {
       const hash2 = hash(set2)
       const hash3 = hash(set3)
 
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
       expect(hash1).toBe(hash2) // Same content should have same hash
       expect(hash1).not.toBe(hash3) // Different content should have different hash
     })
@@ -244,7 +253,7 @@ describe(`hash`, () => {
       const hash2 = hash(map2)
       const hash3 = hash(map3)
 
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
       expect(hash1).toBe(hash2) // Same content should have same hash
       expect(hash1).not.toBe(hash3) // Different content should have different hash
     })
@@ -268,7 +277,7 @@ describe(`hash`, () => {
       const hash2 = hash(mapWithBigInt2)
       const hash3 = hash(mapWithBigInt3)
 
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
       expect(hash1).toBe(hash2) // Same BigInt content should have same hash
       expect(hash1).not.toBe(hash3) // Different BigInt content should have different hash
 
@@ -283,9 +292,50 @@ describe(`hash`, () => {
       const hash5 = hash(setWithSymbols2)
       const hash6 = hash(setWithSymbols3)
 
-      expect(typeof hash4).toBe(`string`)
+      expect(typeof hash4).toBe(hashType)
       expect(hash4).toBe(hash5) // Same Symbol content should have same hash
       expect(hash4).not.toBe(hash6) // Different Symbol content should have different hash
+    })
+
+    it(`should hash Buffers, Uint8Arrays and File objects by reference`, () => {
+      const buffer1 = Buffer.from([1, 2, 3])
+      const buffer2 = Buffer.from([1, 2, 3])
+      const buffer3 = Buffer.from([1, 2, 3, 4])
+
+      const hash1 = hash(buffer1)
+      const hash2 = hash(buffer2)
+      const hash3 = hash(buffer3)
+
+      expect(typeof hash1).toBe(hashType)
+      expect(hash1).not.toBe(hash2) // Same content but different buffer instances have a different hash because it would be too costly to deeply hash buffers
+      expect(hash1).not.toBe(hash3) // Different Buffer content should have different hash
+      expect(hash1).toBe(hash(buffer1)) // Hashing same buffer should return same hash
+
+      const uint8Array1 = new Uint8Array([1, 2, 3])
+      const uint8Array2 = new Uint8Array([1, 2, 3])
+      const uint8Array3 = new Uint8Array([1, 2, 3, 4])
+
+      const hash4 = hash(uint8Array1)
+      const hash5 = hash(uint8Array2)
+      const hash6 = hash(uint8Array3)
+
+      expect(typeof hash4).toBe(hashType)
+      expect(hash4).not.toBe(hash5) // Same content but different uint8Array instances have a different hash because it would be too costly to deeply hash uint8Arrays
+      expect(hash4).not.toBe(hash6) // Different uint8Array content should have different hash
+      expect(hash4).toBe(hash(uint8Array1)) // Hashing same uint8Array should return same hash
+
+      const file1 = new File([`Hello, world!`], `test.txt`)
+      const file2 = new File([`Hello, world!`], `test.txt`)
+      const file3 = new File([`Hello, world!`], `test.txt`)
+
+      const hash7 = hash(file1)
+      const hash8 = hash(file2)
+      const hash9 = hash(file3)
+
+      expect(typeof hash7).toBe(hashType)
+      expect(hash7).not.toBe(hash8) // Same content but different file instances have a different hash because it would be too costly to deeply hash files
+      expect(hash7).not.toBe(hash9) // Different file content should have different hash
+      expect(hash7).toBe(hash(file1)) // Hashing same file should return same hash
     })
   })
 
@@ -297,7 +347,7 @@ describe(`hash`, () => {
       const hash2 = hash(obj)
 
       expect(hash1).toBe(hash2)
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
     })
 
     it(`should return cached values on subsequent calls`, () => {
@@ -310,7 +360,7 @@ describe(`hash`, () => {
       const hash2 = hash(obj)
 
       expect(hash1).toBe(hash2)
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
     })
 
     it(`should not cache primitive values`, () => {
@@ -319,14 +369,14 @@ describe(`hash`, () => {
       const hash2 = hash(`test`)
 
       expect(hash1).toBe(hash2)
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
     })
   })
 
   describe(`edge cases`, () => {
     it(`should handle empty objects and arrays`, () => {
-      expect(typeof hash({})).toBe(`string`)
-      expect(typeof hash([])).toBe(`string`)
+      expect(typeof hash({})).toBe(hashType)
+      expect(typeof hash([])).toBe(hashType)
       expect(hash({})).not.toBe(hash([]))
     })
 
@@ -338,7 +388,22 @@ describe(`hash`, () => {
       const hash2 = hash(obj2)
 
       expect(hash1).toBe(hash2)
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
+    })
+
+    it(`should distinguish between arrays and maps`, () => {
+      const array = [
+        [1, 2],
+        [3, 4],
+      ] as const
+      const map = new Map(array)
+
+      const hash1 = hash(array)
+      const hash2 = hash(map)
+
+      expect(typeof hash1).toBe(hashType)
+      expect(typeof hash2).toBe(hashType)
+      expect(hash1).not.toBe(hash2)
     })
 
     it(`should handle mixed type arrays`, () => {
@@ -349,7 +414,7 @@ describe(`hash`, () => {
       const hash2 = hash(sameArray)
 
       expect(hash1).toBe(hash2)
-      expect(typeof hash1).toBe(`string`)
+      expect(typeof hash1).toBe(hashType)
     })
 
     it(`should produce consistent hashes for same content`, () => {
@@ -359,6 +424,9 @@ describe(`hash`, () => {
         boolean: true,
         array: [1, 2, 3],
         nested: { inner: `value` },
+        buffer: Buffer.from([1, 2, 3]),
+        uint8Array: new Uint8Array([1, 2, 3]),
+        file: new File([`Hello, world!`], `test.txt`),
       }
 
       // Multiple calls should return the same hash
@@ -366,7 +434,7 @@ describe(`hash`, () => {
       const firstHash = hashes[0]
 
       expect(hashes.every((h) => h === firstHash)).toBe(true)
-      expect(typeof firstHash).toBe(`string`)
+      expect(typeof firstHash).toBe(hashType)
     })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         version: 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.44.4(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/router-plugin':
         specifier: ^1.130.2
-        version: 1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+        version: 1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@trpc/client':
         specifier: ^11.4.3
         version: 11.4.3(@trpc/server@11.4.3(typescript@5.8.3))(typescript@5.8.3)
@@ -260,7 +260,7 @@ importers:
         version: 1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-start':
         specifier: ^1.126.1
-        version: 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+        version: 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/trailbase-db-collection':
         specifier: ^0.1.0
         version: link:../../../packages/trailbase-db-collection
@@ -381,7 +381,7 @@ importers:
         version: 1.130.2(solid-js@1.9.7)
       '@tanstack/solid-start':
         specifier: ^1.126.1
-        version: 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(solid-js@1.9.7)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+        version: 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2)(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(solid-js@1.9.7)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/trailbase-db-collection':
         specifier: ^0.0.3
         version: 0.0.3(typescript@5.8.3)
@@ -495,9 +495,6 @@ importers:
       fractional-indexing:
         specifier: ^3.2.0
         version: 3.2.0
-      murmurhash-js:
-        specifier: ^1.0.0
-        version: 1.0.0
       sorted-btree:
         specifier: ^1.8.1
         version: 1.8.1
@@ -508,9 +505,6 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
-      '@types/murmurhash-js':
-        specifier: ^1.0.6
-        version: 1.0.6
       '@vitest/coverage-istanbul':
         specifier: ^3.0.9
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
@@ -2773,9 +2767,6 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/murmurhash-js@1.0.6':
-    resolution: {integrity: sha512-P2RRwRpevEKO0FrK5xNjxBywg0Br24tEv8K2+iWg56PtcCUNGAkaaOWKBQiUpofA8H/gmgdHXrcvSgp2uXCVAQ==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -9305,9 +9296,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-plugin@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@tanstack/react-start-plugin@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
-      '@tanstack/start-plugin-core': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/start-plugin-core': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitejs/plugin-react': 4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       pathe: 2.0.3
       vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -9395,10 +9386,10 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/react-start@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@tanstack/react-start@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@tanstack/react-start-client': 1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/react-start-plugin': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/react-start-plugin': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/react-start-server': 1.130.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/start-server-functions-client': 1.130.2(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/start-server-functions-server': 1.129.7(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
@@ -9521,7 +9512,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@tanstack/router-plugin@1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
+      '@tanstack/router-core': 1.130.2
+      '@tanstack/router-generator': 1.130.2
+      '@tanstack/router-utils': 1.129.7
+      '@tanstack/virtual-file-routes': 1.129.7
+      babel-dead-code-elimination: 1.0.10
+      chokidar: 3.6.0
+      unplugin: 2.3.5
+      zod: 3.25.76
+    optionalDependencies:
+      '@tanstack/react-router': 1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite-plugin-solid: 2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/router-plugin@1.130.2(@tanstack/react-router@1.130.2)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
@@ -9600,9 +9614,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/solid-start-plugin@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@tanstack/solid-start-plugin@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2)(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
-      '@tanstack/start-plugin-core': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/start-plugin-core': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2)(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
       vite-plugin-solid: 2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       zod: 3.25.76
@@ -9648,10 +9662,10 @@ snapshots:
       isbot: 5.1.29
       solid-js: 1.9.7
 
-  '@tanstack/solid-start@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(solid-js@1.9.7)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@tanstack/solid-start@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2)(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(solid-js@1.9.7)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@tanstack/solid-start-client': 1.130.2(solid-js@1.9.7)
-      '@tanstack/solid-start-plugin': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/solid-start-plugin': 1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2)(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/solid-start-server': 1.130.3(solid-js@1.9.7)
       '@tanstack/start-server-functions-client': 1.130.2(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/start-server-functions-server': 1.129.7(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
@@ -9702,14 +9716,14 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-plugin-core@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@tanstack/start-plugin-core@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.0
       '@babel/types': 7.28.2
       '@tanstack/router-core': 1.130.2
       '@tanstack/router-generator': 1.130.2
-      '@tanstack/router-plugin': 1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/router-plugin': 1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/router-utils': 1.129.7
       '@tanstack/server-functions-plugin': 1.129.7(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/start-server-core': 1.130.3
@@ -9763,7 +9777,7 @@ snapshots:
       '@babel/types': 7.28.2
       '@tanstack/router-core': 1.130.2
       '@tanstack/router-generator': 1.130.2
-      '@tanstack/router-plugin': 1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/router-plugin': 1.130.2(@tanstack/react-router@1.130.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/router-utils': 1.129.7
       '@tanstack/server-functions-plugin': 1.129.7(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/start-server-core': 1.130.3
@@ -9773,6 +9787,60 @@ snapshots:
       cheerio: 1.1.2
       h3: 1.13.0
       nitropack: 2.12.4(@netlify/blobs@9.1.2)(drizzle-orm@0.44.4(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))
+      pathe: 2.0.3
+      ufo: 1.6.1
+      vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      xmlbuilder2: 3.1.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rsbuild/core'
+      - '@tanstack/react-router'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - rolldown
+      - sqlite3
+      - supports-color
+      - uploadthing
+      - vite-plugin-solid
+      - webpack
+      - xml2js
+
+  '@tanstack/start-plugin-core@1.130.3(@netlify/blobs@9.1.2)(@tanstack/react-router@1.130.2)(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/core': 7.28.0
+      '@babel/types': 7.28.2
+      '@tanstack/router-core': 1.130.2
+      '@tanstack/router-generator': 1.130.2
+      '@tanstack/router-plugin': 1.130.2(@tanstack/react-router@1.130.2)(vite-plugin-solid@2.11.8(@testing-library/jest-dom@6.6.4)(solid-js@1.9.7)(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/router-utils': 1.129.7
+      '@tanstack/server-functions-plugin': 1.129.7(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@tanstack/start-server-core': 1.130.3
+      '@types/babel__code-frame': 7.0.6
+      '@types/babel__core': 7.20.5
+      babel-dead-code-elimination: 1.0.10
+      cheerio: 1.1.2
+      h3: 1.13.0
+      nitropack: 2.12.4(@netlify/blobs@9.1.2)(drizzle-orm@0.40.1(@types/pg@8.15.5)(gel@2.1.1)(kysely@0.28.3)(pg@8.16.3)(postgres@3.4.7))
       pathe: 2.0.3
       ufo: 1.6.1
       vite: 6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -10011,8 +10079,6 @@ snapshots:
   '@types/mime@1.3.5': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/murmurhash-js@1.0.6': {}
 
   '@types/node@12.20.55': {}
 


### PR DESCRIPTION
This PR changes how we hash values. We used to `JSON.stringify` the values and then hash them. Now, we walk over the value's structure and hash each part. This implementation adapts the implementation from the [composites polyfill](https://github.com/tc39/proposal-composites). The composites hashing only supports hashing composites, we adapted it too also handle arrays, maps, and sets. We also support `Buffer`, `Uint8Array`, and `File` but hash them based on their object reference rather than their value because their value is likely to be big and hence hashing it would be too costly.