### PR TITLE
Fix: Ensure query collections initialize with existing data

### DIFF
--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -497,7 +497,8 @@ export function queryCollectionOptions<
       TQueryKey
     >(queryClient, observerOptions)
 
-    const actualUnsubscribeFn = localObserver.subscribe((result) => {
+    type UpdateHandler = Parameters<typeof localObserver.subscribe>[0]
+    const handleUpdate: UpdateHandler = (result) => {
       if (result.isSuccess) {
         const newItemsArray = result.data
 
@@ -575,7 +576,13 @@ export function queryCollectionOptions<
         // Mark collection as ready even on error to avoid blocking apps
         markReady()
       }
-    })
+    }
+
+    const actualUnsubscribeFn = localObserver.subscribe(handleUpdate)
+
+    // Ensure we process any existing query data (QueryObserver doesn't invoke its callback automatically with initial
+    // state)
+    handleUpdate(localObserver.getCurrentResult())
 
     return async () => {
       actualUnsubscribeFn()

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -1603,4 +1603,33 @@ describe(`QueryCollection`, () => {
     expect(collection.size).toBe(0)
     expect(collection.status).toBe(`ready`)
   })
+
+  it(`should read the state of a query that is already ready`, async () => {
+    // Populate the query cache, so the query will immediately be loaded
+    const queryKey = [`raceConditionTest`]
+    const initialItems: Array<TestItem> = [
+      { id: `1`, name: `Cached Item 1` },
+      { id: `2`, name: `Cached Item 2` },
+    ]
+    const queryFn = vi.fn().mockReturnValue(initialItems)
+    await queryClient.prefetchQuery({ queryKey, queryFn })
+
+    // The collection should immediately be ready
+    const collection = createCollection(
+      queryCollectionOptions({
+        id: `test`,
+        queryClient,
+        queryKey,
+        queryFn,
+        getKey,
+        startSync: true,
+        staleTime: 60000, // uses the prefetched value without a refetch
+      })
+    )
+    expect(collection.status).toBe(`ready`)
+    expect(collection.size).toBe(2)
+    expect(Array.from(collection.values())).toEqual(
+      expect.arrayContaining(initialItems)
+    )
+  })
 })


### PR DESCRIPTION
Previously, when creating a collection from a TanStack Query that already had data, the collection would remain stuck in the `loading` state until the query refreshed. This happens because [`QueryObserver`](https://tanstack.com/query/latest/docs/reference/QueryObserver) only invokes its callback on _changes_, not when attaching to an already-loaded query.

The issue was especially visible for me with [Fast Refresh](https://nextjs.org/docs/architecture/fast-refresh): working locally, after a hot reload, all query state disappeared until the next time the queries refreshed.

This change makes the callback fire immediately with the current query state when we set up the observer, so collections correctly initialize with existing data. (As far as I could tell, `QueryObserver` doesn’t provide a built-in way to fire the callback automatically with initial state.)