### PR TITLE
fix: include all CollectionConfig properties in collection type definitions

### DIFF
--- a/.changeset/cute-eagles-joke.md
+++ b/.changeset/cute-eagles-joke.md
@@ -1,0 +1,8 @@
+---
+"@tanstack/electric-db-collection": patch
+"@tanstack/query-db-collection": patch
+---
+
+fix: include all CollectionConfig properties in collection type definitions
+
+Collection packages were only explicitly including some properties from CollectionConfig, missing gcTime and other standard collection properties. Updated both packages to extend Omit<CollectionConfig<...>, ...> to inherit all base properties including gcTime, startSync, autoIndex, etc.

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -86,11 +86,6 @@ export interface ElectricCollectionConfig<
   >
 
   /**
-   * Optional sync configuration (if you want to provide additional sync behavior)
-   */
-  sync?: CollectionConfig<ResolveType<TExplicit, TSchema, TFallback>>[`sync`]
-
-  /**
    * Optional asynchronous handler function called before an insert operation
    * Must return an object containing a txid number or array of txids
    * @param params Object containing transaction and collection information

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -74,7 +74,10 @@ export interface ElectricCollectionConfig<
   TExplicit extends Row<unknown> = Row<unknown>,
   TSchema extends StandardSchemaV1 = never,
   TFallback extends Row<unknown> = Row<unknown>,
-> {
+> extends Omit<
+    CollectionConfig<ResolveType<TExplicit, TSchema, TFallback>>,
+    `sync` | `onInsert` | `onUpdate` | `onDelete`
+  > {
   /**
    * Configuration options for the ElectricSQL ShapeStream
    */
@@ -83,11 +86,8 @@ export interface ElectricCollectionConfig<
   >
 
   /**
-   * All standard Collection configuration properties
+   * Optional sync configuration (if you want to provide additional sync behavior)
    */
-  id?: string
-  schema?: TSchema
-  getKey: CollectionConfig<ResolveType<TExplicit, TSchema, TFallback>>[`getKey`]
   sync?: CollectionConfig<ResolveType<TExplicit, TSchema, TFallback>>[`sync`]
 
   /**

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -124,9 +124,6 @@ export interface QueryCollectionConfig<
     TQueryKey
   >[`staleTime`]
 
-  /** Optional sync configuration (if you want to provide additional sync behavior) */
-  sync?: CollectionConfig<ResolveType<TExplicit, TSchema, TQueryFn>>[`sync`]
-
   // Direct persistence handlers
   /**
    * Optional asynchronous handler function called before an insert operation

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -74,7 +74,10 @@ export interface QueryCollectionConfig<
   ) => Promise<Array<any>>,
   TError = unknown,
   TQueryKey extends QueryKey = QueryKey,
-> {
+> extends Omit<
+    CollectionConfig<ResolveType<TExplicit, TSchema, TQueryFn>>,
+    `sync` | `onInsert` | `onUpdate` | `onDelete`
+  > {
   /** The query key used by TanStack Query to identify this query */
   queryKey: TQueryKey
   /** Function that fetches data from the server. Must return the complete collection state */
@@ -121,17 +124,8 @@ export interface QueryCollectionConfig<
     TQueryKey
   >[`staleTime`]
 
-  // Standard Collection configuration properties
-  /** Unique identifier for the collection */
-  id?: string
-  /** Function to extract the unique key from an item */
-  getKey: CollectionConfig<ResolveType<TExplicit, TSchema, TQueryFn>>[`getKey`]
-  /** Schema for validating items */
-  schema?: TSchema
+  /** Optional sync configuration (if you want to provide additional sync behavior) */
   sync?: CollectionConfig<ResolveType<TExplicit, TSchema, TQueryFn>>[`sync`]
-  startSync?: CollectionConfig<
-    ResolveType<TExplicit, TSchema, TQueryFn>
-  >[`startSync`]
 
   // Direct persistence handlers
   /**


### PR DESCRIPTION
## Summary
- Fix missing `gcTime` and other CollectionConfig properties in collection package type definitions
- Update `@tanstack/electric-db-collection` and `@tanstack/query-db-collection` to properly inherit all base collection properties

## Changes
- Changed `ElectricCollectionConfig` to extend `Omit<CollectionConfig<...>, 'sync' | 'onInsert' | 'onUpdate' | 'onDelete'>` 
- Changed `QueryCollectionConfig` to extend `Omit<CollectionConfig<...>, 'sync' | 'onInsert' | 'onUpdate' | 'onDelete'>`
- This ensures both packages inherit all standard collection properties including `gcTime`, `startSync`, `autoIndex`, etc.

## Test plan
- [x] Both packages build successfully with TypeScript
- [x] Existing tests that use `gcTime` now pass type checking
- [x] Runtime behavior continues to work as expected

Fixes https://github.com/TanStack/db/issues/497

🤖 Generated with [Claude Code](https://claude.ai/code)