### PR TITLE
fix: explicitly type `electricCollectionOptions` return value

### DIFF
--- a/.changeset/chilly-phones-rest.md
+++ b/.changeset/chilly-phones-rest.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/electric-db-collection": patch
+---
+
+fix: explicitly type `electricCollectionOptions` return value

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -292,7 +292,11 @@ export function electricCollectionOptions<
   TExplicit extends Row<unknown> = Row<unknown>,
   TSchema extends StandardSchemaV1 = never,
   TFallback extends Row<unknown> = Row<unknown>,
->(config: ElectricCollectionConfig<TExplicit, TSchema, TFallback>) {
+>(
+  config: ElectricCollectionConfig<TExplicit, TSchema, TFallback>
+): CollectionConfig<ResolveType<TExplicit, TSchema, TFallback>> & {
+  utils: ElectricCollectionUtils
+} {
   const seenTxids = new Store<Set<Txid>>(new Set([]))
   const sync = createElectricSync<ResolveType<TExplicit, TSchema, TFallback>>(
     config.shapeOptions,


### PR DESCRIPTION
Fixes https://github.com/TanStack/db/issues/392

Currently, if someone used `exactOptionalPropertyTypes` in their tsconfig return type from `electricCollectionOptions` wasn't assignable to `createCollection`. This could be observed in the example in the repository, when added the flag to the tsconfig:

<img width="2218" height="633" alt="image" src="https://github.com/user-attachments/assets/2ba9fe0d-ab61-422b-a462-03bb211ecb38" />

After the fix in the PR:

<img width="2041" height="938" alt="image" src="https://github.com/user-attachments/assets/cc12c747-7d7e-4ea4-b16f-09c568c7407f" />
