### PR TITLE
fix: Check typeof Buffer before instanceof to avoid ReferenceError in browsers

### DIFF
--- a/.changeset/red-sloths-jog.md
+++ b/.changeset/red-sloths-jog.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db-ivm": patch
+---
+
+Check typeof Buffer before instanceof to avoid ReferenceError in browsers

--- a/packages/db-ivm/src/hashing/hash.ts
+++ b/packages/db-ivm/src/hashing/hash.ts
@@ -54,7 +54,7 @@ function hashObject(input: object): number {
     }
 
     if (
-      input instanceof Buffer ||
+      (typeof Buffer !== `undefined` && input instanceof Buffer) ||
       input instanceof Uint8Array ||
       input instanceof File
     ) {


### PR DESCRIPTION
Fixes #512 