### PR TITLE
fix AbortController re-initialization (electric-db-collection)

### DIFF
--- a/.changeset/brown-trees-pay.md
+++ b/.changeset/brown-trees-pay.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/electric-db-collection": patch
+---
+
+fix AbortController re-initialization to after being aborted (sync config)

--- a/.changeset/brown-trees-pay.md
+++ b/.changeset/brown-trees-pay.md
@@ -2,4 +2,4 @@
 "@tanstack/electric-db-collection": patch
 ---
 
-fix AbortController re-initialization to after being aborted (sync config)
+fix AbortController re-initialization after a collection is garbage collected

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -465,19 +465,25 @@ function createElectricSync<T extends Row<unknown>>(
 
   return {
     sync: (params: Parameters<SyncConfig<T>[`sync`]>[0]) => {
+      const { begin, write, commit, markReady, truncate, collection } = params
+
       // Abort controller for the stream - wraps the signal if provided
       const abortController = new AbortController()
 
       if (shapeOptions.signal) {
-        shapeOptions.signal.addEventListener(`abort`, () => {
-          abortController.abort()
-        })
+        shapeOptions.signal.addEventListener(
+          `abort`,
+          () => {
+            abortController.abort()
+          },
+          {
+            once: true,
+          }
+        )
         if (shapeOptions.signal.aborted) {
           abortController.abort()
         }
       }
-
-      const { begin, write, commit, markReady, truncate, collection } = params
 
       const stream = new ShapeStream({
         ...shapeOptions,

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -478,7 +478,7 @@ function createElectricSync<T extends Row<unknown>>(
       }
 
       const { begin, write, commit, markReady, truncate, collection } = params
-      
+
       const stream = new ShapeStream({
         ...shapeOptions,
         signal: abortController.signal,

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -461,22 +461,24 @@ function createElectricSync<T extends Row<unknown>>(
     }
   }
 
-  // Abort controller for the stream - wraps the signal if provided
-  const abortController = new AbortController()
-  if (shapeOptions.signal) {
-    shapeOptions.signal.addEventListener(`abort`, () => {
-      abortController.abort()
-    })
-    if (shapeOptions.signal.aborted) {
-      abortController.abort()
-    }
-  }
-
   let unsubscribeStream: () => void
 
   return {
     sync: (params: Parameters<SyncConfig<T>[`sync`]>[0]) => {
+      // Abort controller for the stream - wraps the signal if provided
+      const abortController = new AbortController()
+
+      if (shapeOptions.signal) {
+        shapeOptions.signal.addEventListener(`abort`, () => {
+          abortController.abort()
+        })
+        if (shapeOptions.signal.aborted) {
+          abortController.abort()
+        }
+      }
+
       const { begin, write, commit, markReady, truncate } = params
+
       const stream = new ShapeStream({
         ...shapeOptions,
         signal: abortController.signal,


### PR DESCRIPTION
Hi! I debugged what was happening in #418 and finally I discovered the issue's cause.

The `AbortController` inside the sync config of `electric-db-collection` after being aborted (by the cleanup fn after the `gcTime` and 0 active subscribers) was never re-initialized again.

And cause the signal was already `aborted`, the electric client skips the sync request! (https://github.com/electric-sql/electric/blob/3baf67a11887fea0bd046b06e081a93f16c88173/packages/typescript-client/src/client.ts#L474)

I only moved the AbortController instantiation inside the sync() function instead of the parent scope.