### PR TITLE
Improve merge logic for applyMutations

### DIFF
--- a/.changeset/dirty-trams-nail.md
+++ b/.changeset/dirty-trams-nail.md
@@ -2,8 +2,6 @@
 "@tanstack/db": patch
 ---
 
-Improve merge logic for applyMutations
+Improve mutation merging from crude replacement to sophisticated merge logic
 
-- Update after insert: keeps the insert type with empty original, merges changes from both mutations
-- Delete after insert: removes both mutations (they cancel each other out)
-- Delete after update: maintains current behavior of replacing with delete
+Previously, mutations were simply replaced when operating on the same item. Now mutations are intelligently merged based on their operation types (insert vs update vs delete), reducing network overhead and better preserving user intent.

--- a/.changeset/dirty-trams-nail.md
+++ b/.changeset/dirty-trams-nail.md
@@ -1,0 +1,9 @@
+---
+"@tanstack/db": patch
+---
+
+Improve merge logic for applyMutations
+
+- Update after insert: keeps the insert type with empty original, merges changes from both mutations
+- Delete after insert: removes both mutations (they cancel each other out)
+- Delete after update: maintains current behavior of replacing with delete

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -676,9 +676,7 @@ The merging behavior follows a truth table based on the mutation types:
 | **insert + update** | `insert` | Keeps insert type, merges changes, empty original |
 | **insert + delete** | *removed* | Mutations cancel each other out |
 | **update + delete** | `delete` | Delete dominates |
-| **delete + update** | `delete` | Delete dominates, update ignored |
 | **update + update** | `update` | Union changes, keep first original |
-| **delete + insert** | `insert` | Fresh insert, delete clears the slate |
 | **same type** | *latest* | Replace with most recent mutation |
 
 #### Examples
@@ -711,19 +709,6 @@ tx.mutate(() => todoCollection.insert({ id: '1', text: 'Temp todo' }))
 tx.mutate(() => todoCollection.delete('1'))
 
 // Result: No mutations (they cancel each other out)
-```
-
-**Delete followed by insert (resurrection):**
-```ts
-// Delete an existing item, then insert a new one with same ID
-tx.mutate(() => todoCollection.delete('1'))
-tx.mutate(() => todoCollection.insert({
-  id: '1',
-  text: 'Fresh start',
-  completed: false
-}))
-
-// Result: Single insert mutation (fresh start)
 ```
 
 This intelligent merging ensures that:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -665,6 +665,72 @@ addTodoTx.mutate(() => todoCollection.insert({ id: '2', text: 'Second todo', com
 addTodoTx.commit()
 ```
 
+### Mutation Merging
+
+When multiple mutations operate on the same item within a transaction, TanStack DB intelligently merges them to reduce over-the-wire churn and keep the optimistic local view aligned with user intent.
+
+The merging behavior follows a truth table based on the mutation types:
+
+| Existing → New | Result | Description |
+|---|---|---|
+| **insert + update** | `insert` | Keeps insert type, merges changes, empty original |
+| **insert + delete** | *removed* | Mutations cancel each other out |
+| **update + delete** | `delete` | Delete dominates |
+| **delete + update** | `delete` | Delete dominates, update ignored |
+| **update + update** | `update` | Union changes, keep first original |
+| **delete + insert** | `insert` | Fresh insert, delete clears the slate |
+| **same type** | *latest* | Replace with most recent mutation |
+
+#### Examples
+
+**Insert followed by update:**
+```ts
+const tx = createTransaction({ autoCommit: false, mutationFn })
+
+// Insert a new todo
+tx.mutate(() => todoCollection.insert({
+  id: '1',
+  text: 'Buy groceries',
+  completed: false
+}))
+
+// Update the same todo
+tx.mutate(() => todoCollection.update('1', (draft) => {
+  draft.text = 'Buy organic groceries'
+  draft.priority = 'high'
+}))
+
+// Result: Single insert mutation with merged data
+// { id: '1', text: 'Buy organic groceries', completed: false, priority: 'high' }
+```
+
+**Insert followed by delete:**
+```ts
+// Insert then delete cancels out - no mutations sent to server
+tx.mutate(() => todoCollection.insert({ id: '1', text: 'Temp todo' }))
+tx.mutate(() => todoCollection.delete('1'))
+
+// Result: No mutations (they cancel each other out)
+```
+
+**Delete followed by insert (resurrection):**
+```ts
+// Delete an existing item, then insert a new one with same ID
+tx.mutate(() => todoCollection.delete('1'))
+tx.mutate(() => todoCollection.insert({
+  id: '1',
+  text: 'Fresh start',
+  completed: false
+}))
+
+// Result: Single insert mutation (fresh start)
+```
+
+This intelligent merging ensures that:
+- **Network efficiency**: Fewer mutations sent to the server
+- **User intent preservation**: Final state matches what user expects
+- **Optimistic UI consistency**: Local state always reflects user actions
+
 ## Transaction lifecycle
 
 Transactions progress through the following states:

--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -216,7 +216,7 @@ class Transaction<T extends object = Record<string, unknown>> {
       )
 
       if (existingIndex >= 0) {
-        const existingMutation = this.mutations[existingIndex]
+        const existingMutation = this.mutations[existingIndex]!
 
         if (newMutation.type === `delete`) {
           if (existingMutation.type === `insert`) {
@@ -231,10 +231,10 @@ class Transaction<T extends object = Record<string, unknown>> {
           existingMutation.type === `insert`
         ) {
           // Update after insert: keep as insert but merge the changes
-          const mergedMutation = {
+          const mergedMutation: PendingMutation<T> = {
             ...existingMutation,
             // Keep the insert type and empty original
-            type: `insert`,
+            type: `insert` as const,
             original: {},
             // Use the update's final modified value
             modified: newMutation.modified,

--- a/packages/db/tests/apply-mutations.test.ts
+++ b/packages/db/tests/apply-mutations.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest"
+import { createTransaction } from "../src/transactions"
+import { createCollection } from "../src/collection"
+import type { PendingMutation } from "../src/types"
+
+describe(`applyMutations merge logic`, () => {
+  const createMockCollection = () =>
+    createCollection<{
+      id: string
+      name: string
+      value?: number
+    }>({
+      id: `test-collection`,
+      getKey: (item) => item.id,
+      sync: {
+        sync: () => {},
+      },
+    })
+
+  const createMockMutation = (
+    type: `insert` | `update` | `delete`,
+    globalKey: string,
+    original: any,
+    modified: any,
+    changes: any
+  ): PendingMutation => ({
+    mutationId: crypto.randomUUID(),
+    type,
+    original,
+    modified,
+    changes,
+    globalKey,
+    key: globalKey,
+    metadata: null,
+    syncMetadata: {},
+    optimistic: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    collection: createMockCollection() as any,
+  })
+
+  it(`should merge update after insert correctly`, () => {
+    const transaction = createTransaction({
+      mutationFn: async () => Promise.resolve(),
+      autoCommit: false,
+    })
+
+    // First, apply an insert mutation
+    const insertMutation = createMockMutation(
+      `insert`,
+      `item-1`,
+      {},
+      { id: `item-1`, name: `Original Name` },
+      { id: `item-1`, name: `Original Name` }
+    )
+    transaction.applyMutations([insertMutation])
+
+    // Then apply an update mutation for the same item
+    const updateMutation = createMockMutation(
+      `update`,
+      `item-1`,
+      { id: `item-1`, name: `Original Name` },
+      { id: `item-1`, name: `Updated Name`, value: 42 },
+      { name: `Updated Name`, value: 42 }
+    )
+    transaction.applyMutations([updateMutation])
+
+    expect(transaction.mutations).toHaveLength(1)
+    const finalMutation = transaction.mutations[0]
+
+    // Should remain an insert with empty original
+    expect(finalMutation.type).toBe(`insert`)
+    expect(finalMutation.original).toEqual({})
+
+    // Should have the final modified state from the update
+    expect(finalMutation.modified).toEqual({
+      id: `item-1`,
+      name: `Updated Name`,
+      value: 42,
+    })
+
+    // Should merge changes from both mutations
+    expect(finalMutation.changes).toEqual({
+      id: `item-1`,
+      name: `Updated Name`,
+      value: 42,
+    })
+  })
+
+  it(`should remove both mutations when delete follows insert`, () => {
+    const transaction = createTransaction({
+      mutationFn: async () => Promise.resolve(),
+      autoCommit: false,
+    })
+
+    // First, apply an insert mutation
+    const insertMutation = createMockMutation(
+      `insert`,
+      `item-1`,
+      {},
+      { id: `item-1`, name: `Original Name` },
+      { id: `item-1`, name: `Original Name` }
+    )
+    transaction.applyMutations([insertMutation])
+
+    // Then apply a delete mutation for the same item
+    const deleteMutation = createMockMutation(
+      `delete`,
+      `item-1`,
+      { id: `item-1`, name: `Original Name` },
+      { id: `item-1`, name: `Original Name` },
+      { id: `item-1`, name: `Original Name` }
+    )
+    transaction.applyMutations([deleteMutation])
+
+    // Both mutations should cancel out - no mutations should remain
+    expect(transaction.mutations).toHaveLength(0)
+  })
+
+  it(`should replace update with delete (current behavior)`, () => {
+    const transaction = createTransaction({
+      mutationFn: async () => Promise.resolve(),
+      autoCommit: false,
+    })
+
+    // First, apply an update mutation
+    const updateMutation = createMockMutation(
+      `update`,
+      `item-1`,
+      { id: `item-1`, name: `Original Name` },
+      { id: `item-1`, name: `Updated Name` },
+      { name: `Updated Name` }
+    )
+    transaction.applyMutations([updateMutation])
+
+    // Then apply a delete mutation for the same item
+    const deleteMutation = createMockMutation(
+      `delete`,
+      `item-1`,
+      { id: `item-1`, name: `Updated Name` },
+      { id: `item-1`, name: `Updated Name` },
+      { id: `item-1`, name: `Updated Name` }
+    )
+    transaction.applyMutations([deleteMutation])
+
+    expect(transaction.mutations).toHaveLength(1)
+    const finalMutation = transaction.mutations[0]
+
+    // Should be a delete mutation
+    expect(finalMutation.type).toBe(`delete`)
+    expect(finalMutation).toBe(deleteMutation)
+  })
+
+  it(`should handle multiple updates after insert correctly`, () => {
+    const transaction = createTransaction({
+      mutationFn: async () => Promise.resolve(),
+      autoCommit: false,
+    })
+
+    // Insert
+    const insertMutation = createMockMutation(
+      `insert`,
+      `item-1`,
+      {},
+      { id: `item-1`, name: `Original` },
+      { id: `item-1`, name: `Original` }
+    )
+    transaction.applyMutations([insertMutation])
+
+    // First update
+    const update1Mutation = createMockMutation(
+      `update`,
+      `item-1`,
+      { id: `item-1`, name: `Original` },
+      { id: `item-1`, name: `Updated`, value: 10 },
+      { name: `Updated`, value: 10 }
+    )
+    transaction.applyMutations([update1Mutation])
+
+    // Second update
+    const update2Mutation = createMockMutation(
+      `update`,
+      `item-1`,
+      { id: `item-1`, name: `Updated`, value: 10 },
+      { id: `item-1`, name: `Final`, value: 20 },
+      { name: `Final`, value: 20 }
+    )
+    transaction.applyMutations([update2Mutation])
+
+    expect(transaction.mutations).toHaveLength(1)
+    const finalMutation = transaction.mutations[0]
+
+    // Should still be an insert
+    expect(finalMutation.type).toBe(`insert`)
+    expect(finalMutation.original).toEqual({})
+
+    // Should have the final state
+    expect(finalMutation.modified).toEqual({
+      id: `item-1`,
+      name: `Final`,
+      value: 20,
+    })
+
+    // Changes should include all fields that were changed
+    expect(finalMutation.changes).toEqual({
+      id: `item-1`,
+      name: `Final`,
+      value: 20,
+    })
+  })
+
+  it(`should maintain default behavior for other mutation combinations`, () => {
+    const transaction = createTransaction({
+      mutationFn: async () => Promise.resolve(),
+      autoCommit: false,
+    })
+
+    // Apply an update mutation
+    const updateMutation1 = createMockMutation(
+      `update`,
+      `item-1`,
+      { id: `item-1`, name: `Original` },
+      { id: `item-1`, name: `Updated` },
+      { name: `Updated` }
+    )
+    transaction.applyMutations([updateMutation1])
+
+    // Apply another update mutation (should replace)
+    const updateMutation2 = createMockMutation(
+      `update`,
+      `item-1`,
+      { id: `item-1`, name: `Updated` },
+      { id: `item-1`, name: `Final` },
+      { name: `Final` }
+    )
+    transaction.applyMutations([updateMutation2])
+
+    expect(transaction.mutations).toHaveLength(1)
+    expect(transaction.mutations[0]).toBe(updateMutation2)
+  })
+})

--- a/packages/db/tests/apply-mutations.test.ts
+++ b/packages/db/tests/apply-mutations.test.ts
@@ -40,7 +40,7 @@ describe(`applyMutations merge logic`, () => {
     })
 
     expect(transaction.mutations).toHaveLength(1)
-    const finalMutation = transaction.mutations[0]
+    const finalMutation = transaction.mutations[0]!
 
     // Should remain an insert with empty original
     expect(finalMutation.type).toBe(`insert`)
@@ -94,7 +94,7 @@ describe(`applyMutations merge logic`, () => {
     })
 
     expect(transaction.mutations).toHaveLength(1)
-    const finalMutation = transaction.mutations[0]
+    const finalMutation = transaction.mutations[0]!
 
     // Should be a delete mutation
     expect(finalMutation.type).toBe(`delete`)
@@ -127,7 +127,7 @@ describe(`applyMutations merge logic`, () => {
     })
 
     expect(transaction.mutations).toHaveLength(1)
-    const finalMutation = transaction.mutations[0]
+    const finalMutation = transaction.mutations[0]!
 
     // Should still be an insert
     expect(finalMutation.type).toBe(`insert`)
@@ -161,7 +161,7 @@ describe(`applyMutations merge logic`, () => {
     })
 
     expect(transaction.mutations).toHaveLength(1)
-    const finalMutation = transaction.mutations[0]
+    const finalMutation = transaction.mutations[0]!
 
     // Should remain a delete mutation (update ignored)
     expect(finalMutation.type).toBe(`delete`)
@@ -221,9 +221,9 @@ describe(`applyMutations merge logic`, () => {
     expect(transaction.mutations).toHaveLength(1)
 
     // Should be a fresh insert (delete cleared the slate)
-    expect(transaction.mutations[0].type).toBe(`insert`)
-    expect(transaction.mutations[0].original).toEqual({})
-    expect(transaction.mutations[0].modified.id).toBe(`item-1`)
-    expect(transaction.mutations[0].modified.name).toBe(`Fresh Insert`)
+    expect(transaction.mutations[0]!.type).toBe(`insert`)
+    expect(transaction.mutations[0]!.original).toEqual({})
+    expect(transaction.mutations[0]!.modified.id).toBe(`item-1`)
+    expect(transaction.mutations[0]!.modified.name).toBe(`Fresh Insert`)
   })
 })


### PR DESCRIPTION
## Summary

Improves the merge logic for `applyMutations` method in transactions to handle mutation combinations more intelligently:

- **Update after insert**: Keeps the mutation as an `insert` type with empty `original`, merges changes from both mutations, and uses the update's final `modified` value
- **Delete after insert**: Removes both mutations since they cancel each other out  
- **Delete after update**: Maintains current behavior of replacing with delete

## Changes

- Enhanced `applyMutations` method in `src/transactions.ts` with smarter merge logic
- Added comprehensive test suite in `tests/apply-mutations.test.ts` covering all scenarios
- Fixed TypeScript errors with proper type annotations
- Added changeset for the improvements

## Test Plan

- [x] All existing transaction tests pass
- [x] New comprehensive test suite covering all mutation merge scenarios  
- [x] Build passes with no TypeScript errors
- [x] Maintains backward compatibility for existing behavior

Fixes #556

🤖 Generated with [Claude Code](https://claude.ai/code)