### PR TITLE
fix: use preload internally in stateWhenReady and toArrayWhenReady methods

### DIFF
--- a/.changeset/breezy-queens-drive.md
+++ b/.changeset/breezy-queens-drive.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Fix `stateWhenReady()` and `toArrayWhenReady()` methods to consistently wait for collections to be ready by using `preload()` internally. This ensures the collection starts loading if needed rather than just waiting passively.

--- a/packages/db/src/collection.ts
+++ b/packages/db/src/collection.ts
@@ -2270,12 +2270,8 @@ export class CollectionImpl<
       return Promise.resolve(this.state)
     }
 
-    // Otherwise, wait for the collection to be ready
-    return new Promise<Map<TKey, TOutput>>((resolve) => {
-      this.onFirstReady(() => {
-        resolve(this.state)
-      })
-    })
+    // Use preload to ensure the collection starts loading, then return the state
+    return this.preload().then(() => this.state)
   }
 
   /**
@@ -2299,12 +2295,8 @@ export class CollectionImpl<
       return Promise.resolve(this.toArray)
     }
 
-    // Otherwise, wait for the collection to be ready
-    return new Promise<Array<TOutput>>((resolve) => {
-      this.onFirstReady(() => {
-        resolve(this.toArray)
-      })
-    })
+    // Use preload to ensure the collection starts loading, then return the array
+    return this.preload().then(() => this.toArray)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixed `stateWhenReady()` and `toArrayWhenReady()` methods to consistently wait for collections to be fully ready
- Both methods now use the `preload()` method internally instead of passively waiting with `onFirstReady()`

## Problem
A Discord user reported that `stateWhenReady` wasn't consistently "fully waiting" in some circumstances. The issue was that these methods would wait passively using `onFirstReady()` without actually triggering the loading process if the collection hadn't started syncing yet.

## Solution
By using `preload()` internally, both methods now:
1. Ensure the collection starts loading if it hasn't already
2. Properly handle the loading state and promise management
3. Avoid duplicate sync starts through preload's promise caching

## Test Plan
- [x] All existing tests pass
- [x] TypeScript build succeeds without errors
- [x] The methods still return immediately when data is already available
- [x] The methods properly trigger loading when collection is idle

Fixes #563

🤖 Generated with [Claude Code](https://claude.ai/code)