### PR TITLE
refactor joins to use direct implementation or each type rather than composition of inner+anti joins

### DIFF
--- a/.changeset/fast-joins-redesign.md
+++ b/.changeset/fast-joins-redesign.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db-ivm": patch
+---
+
+Redesign of the join operators with direct algorithms for major performance improvements by replacing composition-based joins (inner+anti) with implementation using mass tracking. Delivers significant performance gains while maintaining full correctness for all join types (inner, left, right, full, anti).

--- a/packages/db-ivm/src/multiset.ts
+++ b/packages/db-ivm/src/multiset.ts
@@ -209,6 +209,12 @@ export class MultiSet<T> {
     chunkedArrayPush(this.#inner, otherArray)
   }
 
+  add(item: T, multiplicity: number): void {
+    if (multiplicity !== 0) {
+      this.#inner.push([item, multiplicity])
+    }
+  }
+
   getInner(): MultiSetArray<T> {
     return this.#inner
   }

--- a/packages/db-ivm/src/operators/join.ts
+++ b/packages/db-ivm/src/operators/join.ts
@@ -13,27 +13,22 @@ export type JoinType = `inner` | `left` | `right` | `full` | `anti`
 /**
  * Helper to build delta index and mass map from messages
  */
-function buildDelta<K, V>(messages: Array<unknown>): [Index<K, V>, Map<K, number>] {
+function buildDelta<K, V>(
+  messages: Array<unknown>
+): [Index<K, V>, Map<K, number>] {
   const delta = new Index<K, V>()
   const deltaMass = new Map<K, number>()
-  
+
   for (const message of messages) {
-    const multiSetMessage = message as unknown as MultiSet<[K, V]>
+    const multiSetMessage = message as MultiSet<[K, V]>
     for (const [item, multiplicity] of multiSetMessage.getInner()) {
       const [key, value] = item
       delta.addValue(key, [value, multiplicity])
       deltaMass.set(key, (deltaMass.get(key) || 0) + multiplicity)
     }
   }
-  
-  return [delta, deltaMass]
-}
 
-/**
- * Check if a key has presence (non-zero mass)
- */
-function hasPresence<K>(mass: Map<K, number>, key: K): boolean {
-  return (mass.get(key) || 0) !== 0
+  return [delta, deltaMass]
 }
 
 /**
@@ -53,14 +48,13 @@ export class JoinOperator<K, V1, V2> extends BinaryOperator<
     inputA: DifferenceStreamReader<[K, V1]>,
     inputB: DifferenceStreamReader<[K, V2]>,
     output: DifferenceStreamWriter<any>,
-    mode: JoinType = 'inner'
+    mode: JoinType = `inner`
   ) {
     super(id, inputA, inputB, output)
     this.#mode = mode
   }
 
   run(): void {
-    const start = performance.now()
     // 1) Ingest messages and build deltas (no state mutation yet)
     const [deltaA, deltaMassA] = buildDelta<K, V1>(this.inputAMessages())
     const [deltaB, deltaMassB] = buildDelta<K, V2>(this.inputBMessages())
@@ -68,53 +62,61 @@ export class JoinOperator<K, V1, V2> extends BinaryOperator<
     const results = new MultiSet<any>()
 
     // 2) INNER part (used by inner/left/right/full, but NOT anti)
-    if (this.#mode === 'inner' || this.#mode === 'left' || this.#mode === 'right' || this.#mode === 'full') {
-      // Emit deltaA ⋈ indexB
+    if (
+      this.#mode === `inner` ||
+      this.#mode === `left` ||
+      this.#mode === `right` ||
+      this.#mode === `full`
+    ) {
+      // Emit the three standard delta terms: ΔA⋈B_old, A_old⋈ΔB, ΔA⋈ΔB
+      // This avoids copying the entire left index each tick
       results.extend(deltaA.join(this.#indexB))
-
-      // Create logical indexA ⊎ deltaA and join with deltaB
-      const tempIndexA = new Index<K, V1>()
-      tempIndexA.append(this.#indexA)
-      tempIndexA.append(deltaA)
-      results.extend(tempIndexA.join(deltaB))
+      results.extend(this.#indexA.join(deltaB))
+      results.extend(deltaA.join(deltaB))
     }
 
     // 3) OUTER/ANTI specifics
 
     // LEFT side nulls or anti-left (depend only on B's presence)
-    if (this.#mode === 'left' || this.#mode === 'full' || this.#mode === 'anti') {
-      // 3a) New/deleted left rows that are currently unmatched 
+    if (
+      this.#mode === `left` ||
+      this.#mode === `full` ||
+      this.#mode === `anti`
+    ) {
+      // 3a) New/deleted left rows that are currently unmatched
       // For initial state, check final presence after applying deltaB
       for (const [key, valueIterator] of deltaA.entriesIterators()) {
-        const finalMassB = (this.#massB.get(key) || 0) + (deltaMassB.get(key) || 0)
+        const finalMassB =
+          (this.#massB.get(key) || 0) + (deltaMassB.get(key) || 0)
         if (finalMassB === 0) {
           for (const [value, multiplicity] of valueIterator) {
             if (multiplicity !== 0) {
-              results.extend([[[key, [value, null]], multiplicity]])
+              results.add([key, [value, null]], multiplicity)
             }
           }
         }
       }
 
       // 3b) Right-side presence transitions flip match status for *current* left rows
-      for (const key of deltaMassB.keys()) {
-        const wasEmpty = !hasPresence(this.#massB, key)
-        const currentMass = this.#massB.get(key) || 0
-        const deltaMass = deltaMassB.get(key) || 0
-        const willEmpty = (currentMass + deltaMass) === 0
+      for (const [key, deltaMass] of deltaMassB) {
+        const before = this.#massB.get(key) || 0
+        const after = before + deltaMass
 
-        if (wasEmpty && !willEmpty) {
+        // Skip if presence doesn't flip (0->0, >0->different>0)
+        if ((before === 0) === (after === 0)) continue
+
+        if (before === 0 && after !== 0) {
           // B: 0 -> >0 — retract previously unmatched left-at-k
           for (const [value, multiplicity] of this.#indexA.getIterator(key)) {
             if (multiplicity !== 0) {
-              results.extend([[[key, [value, null]], -multiplicity]])
+              results.add([key, [value, null]], -multiplicity)
             }
           }
-        } else if (!wasEmpty && willEmpty) {
+        } else if (before !== 0 && after === 0) {
           // B: >0 -> 0 — emit left-at-k as unmatched
           for (const [value, multiplicity] of this.#indexA.getIterator(key)) {
             if (multiplicity !== 0) {
-              results.extend([[[key, [value, null]], multiplicity]])
+              results.add([key, [value, null]], multiplicity)
             }
           }
         }
@@ -122,39 +124,41 @@ export class JoinOperator<K, V1, V2> extends BinaryOperator<
     }
 
     // RIGHT side nulls (depend only on A's presence)
-    if (this.#mode === 'right' || this.#mode === 'full') {
+    if (this.#mode === `right` || this.#mode === `full`) {
       // 3a) New/deleted right rows that are currently unmatched
       // For initial state, check final presence after applying deltaA
       for (const [key, valueIterator] of deltaB.entriesIterators()) {
-        const finalMassA = (this.#massA.get(key) || 0) + (deltaMassA.get(key) || 0)
+        const finalMassA =
+          (this.#massA.get(key) || 0) + (deltaMassA.get(key) || 0)
         if (finalMassA === 0) {
           for (const [value, multiplicity] of valueIterator) {
             if (multiplicity !== 0) {
-              results.extend([[[key, [null, value]], multiplicity]])
+              results.add([key, [null, value]], multiplicity)
             }
           }
         }
       }
 
       // 3b) Left-side presence transitions flip match status for *current* right rows
-      for (const key of deltaMassA.keys()) {
-        const wasEmpty = !hasPresence(this.#massA, key)
-        const currentMass = this.#massA.get(key) || 0
-        const deltaMass = deltaMassA.get(key) || 0
-        const willEmpty = (currentMass + deltaMass) === 0
+      for (const [key, deltaMass] of deltaMassA) {
+        const before = this.#massA.get(key) || 0
+        const after = before + deltaMass
 
-        if (wasEmpty && !willEmpty) {
+        // Skip if presence doesn't flip (0->0, >0->different>0)
+        if ((before === 0) === (after === 0)) continue
+
+        if (before === 0 && after !== 0) {
           // A: 0 -> >0 — retract previously unmatched right-at-k
           for (const [value, multiplicity] of this.#indexB.getIterator(key)) {
             if (multiplicity !== 0) {
-              results.extend([[[key, [null, value]], -multiplicity]])
+              results.add([key, [null, value]], -multiplicity)
             }
           }
-        } else if (!wasEmpty && willEmpty) {
+        } else if (before !== 0 && after === 0) {
           // A: >0 -> 0 — emit right-at-k as unmatched
           for (const [value, multiplicity] of this.#indexB.getIterator(key)) {
             if (multiplicity !== 0) {
-              results.extend([[[key, [null, value]], multiplicity]])
+              results.add([key, [null, value]], multiplicity)
             }
           }
         }
@@ -162,9 +166,12 @@ export class JoinOperator<K, V1, V2> extends BinaryOperator<
     }
 
     // 4) Commit — update state
+    // IMPORTANT: All emissions use pre-append snapshots of indexA/indexB.
+    // For unmatched-on-delta (3a), use final presence (mass + deltaMass) to avoid churn.
+    // Append deltas and update masses only after all emissions.
     this.#indexA.append(deltaA)
     this.#indexB.append(deltaB)
-    
+
     // Update masses
     for (const [key, deltaMass] of deltaMassA) {
       this.#massA.set(key, (this.#massA.get(key) || 0) + deltaMass)
@@ -177,8 +184,6 @@ export class JoinOperator<K, V1, V2> extends BinaryOperator<
     if (results.getInner().length > 0) {
       this.output.sendData(results)
     }
-    const end = performance.now()
-    console.log(`join took ${end - start}ms`)
   }
 }
 
@@ -196,7 +201,9 @@ export function join<
   other: IStreamBuilder<KeyValue<K, V2>>,
   type: JoinType = `inner`
 ): PipedOperator<T, KeyValue<K, [V1 | null, V2 | null]>> {
-  return (stream: IStreamBuilder<T>): IStreamBuilder<KeyValue<K, [V1 | null, V2 | null]>> => {
+  return (
+    stream: IStreamBuilder<T>
+  ): IStreamBuilder<KeyValue<K, [V1 | null, V2 | null]>> => {
     if (stream.graph !== other.graph) {
       throw new Error(`Cannot join streams from different graphs`)
     }
@@ -229,7 +236,10 @@ export function innerJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1, V2]>> {
-  return join(other, 'inner') as unknown as PipedOperator<T, KeyValue<K, [V1, V2]>>
+  return join(other, `inner`) as unknown as PipedOperator<
+    T,
+    KeyValue<K, [V1, V2]>
+  >
 }
 
 /**
@@ -244,7 +254,10 @@ export function antiJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1, null]>> {
-  return join(other, 'anti') as unknown as PipedOperator<T, KeyValue<K, [V1, null]>>
+  return join(other, `anti`) as unknown as PipedOperator<
+    T,
+    KeyValue<K, [V1, null]>
+  >
 }
 
 /**
@@ -259,7 +272,10 @@ export function leftJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1, V2 | null]>> {
-  return join(other, 'left') as unknown as PipedOperator<T, KeyValue<K, [V1, V2 | null]>>
+  return join(other, `left`) as unknown as PipedOperator<
+    T,
+    KeyValue<K, [V1, V2 | null]>
+  >
 }
 
 /**
@@ -274,7 +290,10 @@ export function rightJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1 | null, V2]>> {
-  return join(other, 'right') as unknown as PipedOperator<T, KeyValue<K, [V1 | null, V2]>>
+  return join(other, `right`) as unknown as PipedOperator<
+    T,
+    KeyValue<K, [V1 | null, V2]>
+  >
 }
 
 /**
@@ -289,5 +308,8 @@ export function fullJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1 | null, V2 | null]>> {
-  return join(other, 'full') as unknown as PipedOperator<T, KeyValue<K, [V1 | null, V2 | null]>>
+  return join(other, `full`) as unknown as PipedOperator<
+    T,
+    KeyValue<K, [V1 | null, V2 | null]>
+  >
 }

--- a/packages/db-ivm/src/operators/join.ts
+++ b/packages/db-ivm/src/operators/join.ts
@@ -2,9 +2,6 @@ import { BinaryOperator, DifferenceStreamWriter } from "../graph.js"
 import { StreamBuilder } from "../d2.js"
 import { MultiSet } from "../multiset.js"
 import { Index } from "../indexes.js"
-import { negate } from "./negate.js"
-import { map } from "./map.js"
-import { concat } from "./concat.js"
 import type { DifferenceStreamReader } from "../graph.js"
 import type { IStreamBuilder, KeyValue, PipedOperator } from "../types.js"
 
@@ -14,66 +11,174 @@ import type { IStreamBuilder, KeyValue, PipedOperator } from "../types.js"
 export type JoinType = `inner` | `left` | `right` | `full` | `anti`
 
 /**
- * Operator that joins two input streams
+ * Helper to build delta index and mass map from messages
+ */
+function buildDelta<K, V>(messages: Array<unknown>): [Index<K, V>, Map<K, number>] {
+  const delta = new Index<K, V>()
+  const deltaMass = new Map<K, number>()
+  
+  for (const message of messages) {
+    const multiSetMessage = message as unknown as MultiSet<[K, V]>
+    for (const [item, multiplicity] of multiSetMessage.getInner()) {
+      const [key, value] = item
+      delta.addValue(key, [value, multiplicity])
+      deltaMass.set(key, (deltaMass.get(key) || 0) + multiplicity)
+    }
+  }
+  
+  return [delta, deltaMass]
+}
+
+/**
+ * Check if a key has presence (non-zero mass)
+ */
+function hasPresence<K>(mass: Map<K, number>, key: K): boolean {
+  return (mass.get(key) || 0) !== 0
+}
+
+/**
+ * Operator that joins two input streams using direct join algorithms
  */
 export class JoinOperator<K, V1, V2> extends BinaryOperator<
-  [K, V1] | [K, V2] | [K, [V1, V2]]
+  [K, V1] | [K, V2] | [K, [V1, V2]] | [K, [V1 | null, V2 | null]]
 > {
   #indexA = new Index<K, V1>()
   #indexB = new Index<K, V2>()
+  #massA = new Map<K, number>() // sum of multiplicities per key on side A
+  #massB = new Map<K, number>() // sum of multiplicities per key on side B
+  #mode: JoinType
 
   constructor(
     id: number,
     inputA: DifferenceStreamReader<[K, V1]>,
     inputB: DifferenceStreamReader<[K, V2]>,
-    output: DifferenceStreamWriter<[K, [V1, V2]]>
+    output: DifferenceStreamWriter<any>,
+    mode: JoinType = 'inner'
   ) {
     super(id, inputA, inputB, output)
+    this.#mode = mode
   }
 
   run(): void {
-    const deltaA = new Index<K, V1>()
-    const deltaB = new Index<K, V2>()
+    const start = performance.now()
+    // 1) Ingest messages and build deltas (no state mutation yet)
+    const [deltaA, deltaMassA] = buildDelta<K, V1>(this.inputAMessages())
+    const [deltaB, deltaMassB] = buildDelta<K, V2>(this.inputBMessages())
 
-    // Process input A - process ALL messages, not just the first one
-    const messagesA = this.inputAMessages()
-    for (const message of messagesA) {
-      const multiSetMessage = message as unknown as MultiSet<[K, V1]>
-      for (const [item, multiplicity] of multiSetMessage.getInner()) {
-        const [key, value] = item
-        deltaA.addValue(key, [value, multiplicity])
+    const results = new MultiSet<any>()
+
+    // 2) INNER part (used by inner/left/right/full, but NOT anti)
+    if (this.#mode === 'inner' || this.#mode === 'left' || this.#mode === 'right' || this.#mode === 'full') {
+      // Emit deltaA ⋈ indexB
+      results.extend(deltaA.join(this.#indexB))
+
+      // Create logical indexA ⊎ deltaA and join with deltaB
+      const tempIndexA = new Index<K, V1>()
+      tempIndexA.append(this.#indexA)
+      tempIndexA.append(deltaA)
+      results.extend(tempIndexA.join(deltaB))
+    }
+
+    // 3) OUTER/ANTI specifics
+
+    // LEFT side nulls or anti-left (depend only on B's presence)
+    if (this.#mode === 'left' || this.#mode === 'full' || this.#mode === 'anti') {
+      // 3a) New/deleted left rows that are currently unmatched 
+      // For initial state, check final presence after applying deltaB
+      for (const [key, valueIterator] of deltaA.entriesIterators()) {
+        const finalMassB = (this.#massB.get(key) || 0) + (deltaMassB.get(key) || 0)
+        if (finalMassB === 0) {
+          for (const [value, multiplicity] of valueIterator) {
+            if (multiplicity !== 0) {
+              results.extend([[[key, [value, null]], multiplicity]])
+            }
+          }
+        }
+      }
+
+      // 3b) Right-side presence transitions flip match status for *current* left rows
+      for (const key of deltaMassB.keys()) {
+        const wasEmpty = !hasPresence(this.#massB, key)
+        const currentMass = this.#massB.get(key) || 0
+        const deltaMass = deltaMassB.get(key) || 0
+        const willEmpty = (currentMass + deltaMass) === 0
+
+        if (wasEmpty && !willEmpty) {
+          // B: 0 -> >0 — retract previously unmatched left-at-k
+          for (const [value, multiplicity] of this.#indexA.getIterator(key)) {
+            if (multiplicity !== 0) {
+              results.extend([[[key, [value, null]], -multiplicity]])
+            }
+          }
+        } else if (!wasEmpty && willEmpty) {
+          // B: >0 -> 0 — emit left-at-k as unmatched
+          for (const [value, multiplicity] of this.#indexA.getIterator(key)) {
+            if (multiplicity !== 0) {
+              results.extend([[[key, [value, null]], multiplicity]])
+            }
+          }
+        }
       }
     }
 
-    // Process input B - process ALL messages, not just the first one
-    const messagesB = this.inputBMessages()
-    for (const message of messagesB) {
-      const multiSetMessage = message as unknown as MultiSet<[K, V2]>
-      for (const [item, multiplicity] of multiSetMessage.getInner()) {
-        const [key, value] = item
-        deltaB.addValue(key, [value, multiplicity])
+    // RIGHT side nulls (depend only on A's presence)
+    if (this.#mode === 'right' || this.#mode === 'full') {
+      // 3a) New/deleted right rows that are currently unmatched
+      // For initial state, check final presence after applying deltaA
+      for (const [key, valueIterator] of deltaB.entriesIterators()) {
+        const finalMassA = (this.#massA.get(key) || 0) + (deltaMassA.get(key) || 0)
+        if (finalMassA === 0) {
+          for (const [value, multiplicity] of valueIterator) {
+            if (multiplicity !== 0) {
+              results.extend([[[key, [null, value]], multiplicity]])
+            }
+          }
+        }
+      }
+
+      // 3b) Left-side presence transitions flip match status for *current* right rows
+      for (const key of deltaMassA.keys()) {
+        const wasEmpty = !hasPresence(this.#massA, key)
+        const currentMass = this.#massA.get(key) || 0
+        const deltaMass = deltaMassA.get(key) || 0
+        const willEmpty = (currentMass + deltaMass) === 0
+
+        if (wasEmpty && !willEmpty) {
+          // A: 0 -> >0 — retract previously unmatched right-at-k
+          for (const [value, multiplicity] of this.#indexB.getIterator(key)) {
+            if (multiplicity !== 0) {
+              results.extend([[[key, [null, value]], -multiplicity]])
+            }
+          }
+        } else if (!wasEmpty && willEmpty) {
+          // A: >0 -> 0 — emit right-at-k as unmatched
+          for (const [value, multiplicity] of this.#indexB.getIterator(key)) {
+            if (multiplicity !== 0) {
+              results.extend([[[key, [null, value]], multiplicity]])
+            }
+          }
+        }
       }
     }
 
-    // Process results
-    const results = new MultiSet<[K, [V1, V2]]>()
-
-    // Join deltaA with existing indexB
-    results.extend(deltaA.join(this.#indexB))
-
-    // Append deltaA to indexA
+    // 4) Commit — update state
     this.#indexA.append(deltaA)
-
-    // Join existing indexA with deltaB
-    results.extend(this.#indexA.join(deltaB))
+    this.#indexB.append(deltaB)
+    
+    // Update masses
+    for (const [key, deltaMass] of deltaMassA) {
+      this.#massA.set(key, (this.#massA.get(key) || 0) + deltaMass)
+    }
+    for (const [key, deltaMass] of deltaMassB) {
+      this.#massB.set(key, (this.#massB.get(key) || 0) + deltaMass)
+    }
 
     // Send results
     if (results.getInner().length > 0) {
       this.output.sendData(results)
     }
-
-    // Append deltaB to indexB
-    this.#indexB.append(deltaB)
+    const end = performance.now()
+    console.log(`join took ${end - start}ms`)
   }
 }
 
@@ -91,39 +196,29 @@ export function join<
   other: IStreamBuilder<KeyValue<K, V2>>,
   type: JoinType = `inner`
 ): PipedOperator<T, KeyValue<K, [V1 | null, V2 | null]>> {
-  switch (type) {
-    case `inner`:
-      return innerJoin(other) as unknown as PipedOperator<
-        T,
-        KeyValue<K, [V1, V2]>
-      >
-    case `anti`:
-      return antiJoin(other) as unknown as PipedOperator<
-        T,
-        KeyValue<K, [V1, null]>
-      >
-    case `left`:
-      return leftJoin(other) as unknown as PipedOperator<
-        T,
-        KeyValue<K, [V1, V2 | null]>
-      >
-    case `right`:
-      return rightJoin(other) as unknown as PipedOperator<
-        T,
-        KeyValue<K, [V1 | null, V2]>
-      >
-    case `full`:
-      return fullJoin(other) as unknown as PipedOperator<
-        T,
-        KeyValue<K, [V1 | null, V2 | null]>
-      >
-    default:
-      throw new Error(`Join type ${type} is invalid`)
+  return (stream: IStreamBuilder<T>): IStreamBuilder<KeyValue<K, [V1 | null, V2 | null]>> => {
+    if (stream.graph !== other.graph) {
+      throw new Error(`Cannot join streams from different graphs`)
+    }
+    const output = new StreamBuilder<KeyValue<K, [V1 | null, V2 | null]>>(
+      stream.graph,
+      new DifferenceStreamWriter<KeyValue<K, [V1 | null, V2 | null]>>()
+    )
+    const operator = new JoinOperator<K, V1, V2>(
+      stream.graph.getNextOperatorId(),
+      stream.connectReader() as DifferenceStreamReader<KeyValue<K, V1>>,
+      other.connectReader(),
+      output.writer,
+      type
+    )
+    stream.graph.addOperator(operator)
+    stream.graph.addStream(output.connectReader())
+    return output
   }
 }
 
 /**
- * Joins two input streams
+ * Joins two input streams (inner join)
  * @param other - The other stream to join with
  */
 export function innerJoin<
@@ -134,28 +229,11 @@ export function innerJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1, V2]>> {
-  return (stream: IStreamBuilder<T>): IStreamBuilder<KeyValue<K, [V1, V2]>> => {
-    if (stream.graph !== other.graph) {
-      throw new Error(`Cannot join streams from different graphs`)
-    }
-    const output = new StreamBuilder<KeyValue<K, [V1, V2]>>(
-      stream.graph,
-      new DifferenceStreamWriter<KeyValue<K, [V1, V2]>>()
-    )
-    const operator = new JoinOperator<K, V1, V2>(
-      stream.graph.getNextOperatorId(),
-      stream.connectReader() as DifferenceStreamReader<KeyValue<K, V1>>,
-      other.connectReader(),
-      output.writer
-    )
-    stream.graph.addOperator(operator)
-    stream.graph.addStream(output.connectReader())
-    return output
-  }
+  return join(other, 'inner') as unknown as PipedOperator<T, KeyValue<K, [V1, V2]>>
 }
 
 /**
- * Joins two input streams
+ * Joins two input streams (anti join)
  * @param other - The other stream to join with
  */
 export function antiJoin<
@@ -166,24 +244,11 @@ export function antiJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1, null]>> {
-  return (
-    stream: IStreamBuilder<T>
-  ): IStreamBuilder<KeyValue<K, [V1, null]>> => {
-    const matchedLeft = stream.pipe(
-      innerJoin(other),
-      map(([key, [valueLeft, _valueRight]]) => [key, valueLeft])
-    )
-    const anti = stream.pipe(
-      concat(matchedLeft.pipe(negate())),
-      // @ts-ignore TODO: fix this
-      map(([key, value]) => [key, [value, null]])
-    )
-    return anti as IStreamBuilder<KeyValue<K, [V1, null]>>
-  }
+  return join(other, 'anti') as unknown as PipedOperator<T, KeyValue<K, [V1, null]>>
 }
 
 /**
- * Joins two input streams
+ * Joins two input streams (left join)
  * @param other - The other stream to join with
  */
 export function leftJoin<
@@ -194,21 +259,11 @@ export function leftJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1, V2 | null]>> {
-  return (
-    stream: IStreamBuilder<T>
-  ): IStreamBuilder<KeyValue<K, [V1, V2 | null]>> => {
-    const left = stream
-    const right = other
-    const inner = left.pipe(innerJoin(right))
-    const anti = left.pipe(antiJoin(right))
-    return inner.pipe(concat(anti)) as IStreamBuilder<
-      KeyValue<K, [V1, V2 | null]>
-    >
-  }
+  return join(other, 'left') as unknown as PipedOperator<T, KeyValue<K, [V1, V2 | null]>>
 }
 
 /**
- * Joins two input streams
+ * Joins two input streams (right join)
  * @param other - The other stream to join with
  */
 export function rightJoin<
@@ -219,24 +274,11 @@ export function rightJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1 | null, V2]>> {
-  return (
-    stream: IStreamBuilder<T>
-  ): IStreamBuilder<KeyValue<K, [V1 | null, V2]>> => {
-    const left = stream as IStreamBuilder<KeyValue<K, V1>>
-    const right = other
-    const inner = left.pipe(innerJoin(right))
-    const anti = right.pipe(
-      antiJoin(left),
-      map(([key, [a, b]]) => [key, [b, a]])
-    )
-    return inner.pipe(concat(anti)) as IStreamBuilder<
-      KeyValue<K, [V1 | null, V2]>
-    >
-  }
+  return join(other, 'right') as unknown as PipedOperator<T, KeyValue<K, [V1 | null, V2]>>
 }
 
 /**
- * Joins two input streams
+ * Joins two input streams (full join)
  * @param other - The other stream to join with
  */
 export function fullJoin<
@@ -247,19 +289,5 @@ export function fullJoin<
 >(
   other: IStreamBuilder<KeyValue<K, V2>>
 ): PipedOperator<T, KeyValue<K, [V1 | null, V2 | null]>> {
-  return (
-    stream: IStreamBuilder<T>
-  ): IStreamBuilder<KeyValue<K, [V1 | null, V2 | null]>> => {
-    const left = stream as IStreamBuilder<KeyValue<K, V1>>
-    const right = other
-    const inner = left.pipe(innerJoin(right))
-    const antiLeft = left.pipe(antiJoin(right))
-    const antiRight = right.pipe(
-      antiJoin(left),
-      map(([key, [a, b]]) => [key, [b, a]])
-    )
-    return inner.pipe(concat(antiLeft), concat(antiRight)) as IStreamBuilder<
-      KeyValue<K, [V1 | null, V2 | null]>
-    >
-  }
+  return join(other, 'full') as unknown as PipedOperator<T, KeyValue<K, [V1 | null, V2 | null]>>
 }

--- a/packages/db/src/query/compiler/joins.ts
+++ b/packages/db/src/query/compiler/joins.ts
@@ -1,5 +1,4 @@
 import {
-  consolidate,
   filter,
   join as joinOperator,
   map,
@@ -296,7 +295,6 @@ function processJoin(
 
   return mainPipeline.pipe(
     joinOperator(joinedPipeline, joinClause.type as JoinType),
-    consolidate(),
     processJoinResults(joinClause.type)
   )
 }


### PR DESCRIPTION
This removes all the additional state that was needed for each of the composed joins, and the need for the consolidate step. Delivers a father 50% speedup over the index refactor PR #549 this is stacked on.