### PR TITLE
Remove peerDependencies from electric-db-collection

### DIFF
--- a/packages/electric-db-collection/package.json
+++ b/packages/electric-db-collection/package.json
@@ -10,7 +10,6 @@
     "debug": "^4.4.1"
   },
   "devDependencies": {
-    "@electric-sql/client": "^1.0.10",
     "@types/debug": "^4.1.12",
     "@vitest/coverage-istanbul": "^3.2.4"
   },

--- a/packages/electric-db-collection/package.json
+++ b/packages/electric-db-collection/package.json
@@ -34,10 +34,6 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
   "packageManager": "pnpm@10.6.3",
-  "peerDependencies": {
-    "@electric-sql/client": "^1.0.0",
-    "typescript": ">=4.7"
-  },
   "author": "Kyle Mathews",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,9 +636,6 @@ importers:
       debug:
         specifier: ^4.4.1
         version: 4.4.1
-      typescript:
-        specifier: '>=4.7'
-        version: 5.9.2
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12


### PR DESCRIPTION
We have @electric-sql/client as a dependency and you don't want both.