### PR TITLE
fix: broken image in docs

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -138,8 +138,8 @@ const updateTodo = createOptimisticAction<{ id: string }>({
 This combines to support a model of uni-directional data flow, extending the redux/flux style state management pattern beyond the client, to take in the server as well:
 
 <figure>
-  <a href="./unidirectional-data-flow.lg.png" target="_blank">
-    <img src="./unidirectional-data-flow.png" />
+  <a href="https://raw.githubusercontent.com/TanStack/db/main/docs/unidirectional-data-flow.lg.png" target="_blank">
+    <img src="https://raw.githubusercontent.com/TanStack/db/main/docs/unidirectional-data-flow.png" />
   </a>
 </figure>
 


### PR DESCRIPTION
## 🎯 Changes

<img width="548" height="283" alt="image" src="https://github.com/user-attachments/assets/5b88795e-c996-45af-b993-aede822da2f7" />

An image was broken in `https://tanstack.com/db/latest/docs/overview`, so I updated the url of the image to match [the style we used for displaying images for the docs of `tanstack/form`](https://github.com/TanStack/form/blob/4a2bcfcb2aae9a9c7b349422844bc559cfd8d6ef/docs/framework/react/guides/basic-concepts.md?plain=1#L106).

**Note**: I couldn't test it with tanstack.com locally, because `pnpm dev` fails with a weird error ([others have also experienced this](https://discord.com/channels/719702312431386674/1395788390703566908/1412559377382117530)), but I replaced the urls on `tanstack.com` in the browser, and they worked, so I think it's gonna be fine.


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
