### PR TITLE
docs: add navigation workflow pattern for optimistic: false mutations

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -880,6 +880,44 @@ tx.mutate(() => {
 })
 ```
 
+##### Common workflow: Wait for persistence before navigation
+
+A common pattern with `optimistic: false` is to wait for the mutation to complete before navigating to a new page or showing success feedback:
+
+```typescript
+const handleCreatePost = async (postData) => {
+  // Insert without optimistic updates
+  const tx = postsCollection.insert(postData, { optimistic: false })
+
+  try {
+    // Wait for write to server and sync back to complete
+    await tx.isPersisted.promise
+
+    // Server write and sync back were successful - safe to navigate
+    navigate(`/posts/${postData.id}`)
+  } catch (error) {
+    // Show error toast or notification
+    toast.error('Failed to create post: ' + error.message)
+  }
+}
+
+// Works with updates and deletes too
+const handleUpdateTodo = async (todoId, changes) => {
+  const tx = todoCollection.update(
+    todoId,
+    { optimistic: false },
+    (draft) => Object.assign(draft, changes)
+  )
+
+  try {
+    await tx.isPersisted.promise
+    navigate('/todos')
+  } catch (error) {
+    toast.error('Failed to update todo: ' + error.message)
+  }
+}
+```
+
 ## Usage examples
 
 Here we illustrate two common ways of using TanStack DB:


### PR DESCRIPTION
## Summary
- Add common workflow example for using `optimistic: false` with navigation
- Documents the `tx.isPersisted.promise` pattern for waiting until server write and sync back complete
- Includes practical examples with error handling and user feedback

## Test plan
- [x] Review documentation changes for clarity and accuracy
- [x] Verify examples align with existing test patterns in the codebase
- [x] Check that code examples follow repository conventions

🤖 Generated with [Claude Code](https://claude.ai/code)