### PR TITLE
docs: fix broken GitHub link and add missing frontmatter

### DIFF
--- a/docs/community/resources.md
+++ b/docs/community/resources.md
@@ -1,3 +1,8 @@
+---
+title: Community Resources
+id: community-resources
+---
+
 # Community Resources
 
 This page contains a curated list of community-created packages, tools, and resources that extend or complement TanStack DB.
@@ -5,7 +10,7 @@ This page contains a curated list of community-created packages, tools, and reso
 ## Community Packages
 
 ### Dexie.js Integration (Unofficial)
-- **[tanstack-dexie-db-collection](https://github.com/yourusername/tanstack-dexie-db-collection)** - Community-maintained Dexie.js adapter for TanStack DB
+- **[tanstack-dexie-db-collection](https://github.com/HimanshuKumarDutt094/tanstack-dexie-db-collection)** - Community-maintained Dexie.js adapter for TanStack DB
   - Local persistence using [Dexie.js](https://dexie.org) (IndexedDB wrapper)
   - Lightweight integration for browser-based storage
   - Install: `npm install tanstack-dexie-db-collection`


### PR DESCRIPTION
## Summary
- Fixed placeholder GitHub link for tanstack-dexie-db-collection repository
- Added missing frontmatter (title and id fields) to community resources page to match other documentation pages

## Changes
- Updated `docs/community/resources.md`:
  - Replaced placeholder `yourusername` with actual GitHub username `HimanshuKumarDutt094`
  - Added frontmatter section with `title: Community Resources` and `id: community-resources`

Fixes #586

🤖 Generated with [Claude Code](https://claude.ai/code)