### PR TITLE
Don't push down where clauses that only touch the namespace of a source and not a prop

### DIFF
--- a/.changeset/curvy-mangos-yell.md
+++ b/.changeset/curvy-mangos-yell.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Prevent pushing down of where clauses that only touch the namespace of a source, rather than a prop on that namespace. This ensures that the semantics of the query are maintained for things such as `isUndefined(namespace)` after a join.

--- a/packages/db/tests/query/join.test.ts
+++ b/packages/db/tests/query/join.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, test } from "vitest"
-import { createLiveQueryCollection, eq } from "../../src/query/index.js"
+import {
+  createLiveQueryCollection,
+  eq,
+  isUndefined,
+} from "../../src/query/index.js"
 import { createCollection } from "../../src/collection/index.js"
 import { mockSyncCollectionOptions } from "../utils.js"
 
@@ -1404,6 +1408,47 @@ function createJoinTests(autoIndex: `off` | `eager`): void {
       }).toThrow(
         `Invalid join condition: both expressions refer to the same table "user"`
       )
+    })
+
+    test(`should not push down isUndefined(namespace) to subquery`, () => {
+      const usersCollection = createUsersCollection()
+      const specialUsersCollection = createCollection(
+        mockSyncCollectionOptions({
+          id: `special-users`,
+          getKey: (user) => user.id,
+          initialData: [{ id: 1, special: true }],
+        })
+      )
+
+      const joinQuery = createLiveQueryCollection({
+        startSync: true,
+        query: (q) =>
+          q
+            .from({ user: usersCollection })
+            .leftJoin(
+              { special: specialUsersCollection },
+              ({ user, special }) => eq(user.id, special.id)
+            )
+            .where(({ special }) => isUndefined(special)),
+      })
+
+      // Should return users that don't have a matching special user
+      // This should be users with IDs 2, 3, 4 (since only user 1 has a special record)
+      const results = joinQuery.toArray
+      expect(results).toHaveLength(3)
+
+      // All results should have special as undefined
+      for (const row of results) {
+        expect(row.special).toBeUndefined()
+      }
+
+      // Should not include user 1 (Alice) since she has a special record
+      const aliceResult = results.find((r) => r.user.id === 1)
+      expect(aliceResult).toBeUndefined()
+
+      // Should include users 2, 3, 4 (Bob, Charlie, Dave)
+      const userIds = results.map((r) => r.user.id).sort()
+      expect(userIds).toEqual([2, 3, 4])
     })
   })
 }


### PR DESCRIPTION
Fixes #574

CI run where the new test failed before the fix: https://github.com/TanStack/db/actions/runs/18094012999/job/51480945391?pr=600