### PR TITLE
fix repeated renders when markReady called when collection already ready

### DIFF
--- a/.changeset/polite-eels-laugh.md
+++ b/.changeset/polite-eels-laugh.md
@@ -3,4 +3,4 @@
 "@tanstack/db": patch
 ---
 
-Fix repeated renders when markReady called when the collection was already ready. This would occur after each long poll on a Electric collection.
+Fix repeated renders when markReady called when the collection was already ready. This would occur after each long poll on an Electric collection.

--- a/.changeset/polite-eels-laugh.md
+++ b/.changeset/polite-eels-laugh.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/electric-db-collection": patch
+"@tanstack/db": patch
+---
+
+Fix repeated renders when markReady called when the collection was already ready. This would occur after each long poll on a Electric collection.

--- a/packages/db/src/collection/lifecycle.ts
+++ b/packages/db/src/collection/lifecycle.ts
@@ -146,12 +146,12 @@ export class CollectionLifecycleManager<
         this.onFirstReadyCallbacks = []
         callbacks.forEach((callback) => callback())
       }
-    }
 
-    // Always notify dependents when markReady is called, after status is set
-    // This ensures live queries get notified when their dependencies become ready
-    if (this.changes.changeSubscriptions.size > 0) {
-      this.changes.emitEmptyReadyEvent()
+      // Notify dependents when markReady is called, after status is set
+      // This ensures live queries get notified when their dependencies become ready
+      if (this.changes.changeSubscriptions.size > 0) {
+        this.changes.emitEmptyReadyEvent()
+      }
     }
   }
 

--- a/packages/db/src/collection/lifecycle.ts
+++ b/packages/db/src/collection/lifecycle.ts
@@ -96,8 +96,11 @@ export class CollectionLifecycleManager<
     allowReady: boolean = false
   ): void {
     if (newStatus === `ready` && !allowReady) {
+      // setStatus('ready') is an internal method that should not be called directly
+      // Instead, use markReady to transition to ready triggering the necessary events
+      // and side effects.
       throw new CollectionStateError(
-        `Cannot set status to anything other than ready, must use markReady instead`
+        `You can't directly call "setStatus('ready'). You must use markReady instead.`
       )
     }
     this.validateStatusTransition(this.status, newStatus)

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -644,7 +644,7 @@ export class CollectionStateManager<
 
         // Ensure listeners are active before emitting this critical batch
         if (this.lifecycle.status !== `ready`) {
-          this.lifecycle.setStatus(`ready`)
+          this.lifecycle.markReady()
         }
       }
 

--- a/packages/electric-db-collection/tests/electric-live-query.test.ts
+++ b/packages/electric-db-collection/tests/electric-live-query.test.ts
@@ -144,6 +144,11 @@ describe.each([
     subscriber(messages)
   }
 
+  function simulateUpToDateOnly() {
+    // Send only an up-to-date message with no data changes
+    subscriber([{ headers: { control: `up-to-date` } }])
+  }
+
   beforeEach(() => {
     electricCollection = createElectricUsersCollection()
   })
@@ -337,5 +342,113 @@ describe.each([
     // Both Electric collection and live query should be ready
     expect(testElectricCollection.status).toBe(`ready`)
     expect(liveQuery.status).toBe(`ready`)
+  })
+
+  it.only(`should not emit changes on up-to-date messages with no data changes`, async () => {
+    // Test to verify that up-to-date messages without actual data changes
+    // don't trigger unnecessary renders in live query collections
+
+    // Create a live query collection
+    const liveQuery = createLiveQueryCollection({
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ user: electricCollection })
+          .where(({ user }) => eq(user.active, true))
+          .select(({ user }) => ({
+            id: user.id,
+            name: user.name,
+            active: user.active,
+          })),
+    })
+
+    // Track changes emitted by the live query
+    const changeNotifications: Array<any> = []
+    const subscription = liveQuery.subscribeChanges((changes) => {
+      changeNotifications.push(changes)
+    })
+
+    // Initial sync with data
+    simulateInitialSync()
+    expect(liveQuery.status).toBe(`ready`)
+    expect(liveQuery.size).toBe(3) // Only active users
+
+    // Clear any initial change notifications
+    changeNotifications.length = 0
+
+    // Send an up-to-date message with no data changes
+    // This simulates the scenario where Electric sends up-to-date
+    // but there are no actual changes to the data
+    simulateUpToDateOnly()
+
+    // Wait a tick to ensure any async operations complete
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The live query should not have emitted any changes
+    // because there were no actual data changes
+    // BUG: Currently emits empty change arrays on up-to-date messages
+    if (changeNotifications.length > 0) {
+      console.log(
+        `BUG DETECTED: Live query emitted ${changeNotifications.length} change notifications on up-to-date with no data changes:`,
+        changeNotifications
+      )
+    }
+    expect(changeNotifications).toHaveLength(0)
+
+    // Verify the collection is still in ready state
+    expect(liveQuery.status).toBe(`ready`)
+    expect(liveQuery.size).toBe(3)
+
+    // Clean up
+    subscription.unsubscribe()
+  })
+
+  it(`should not emit changes on multiple consecutive up-to-date messages with no data changes`, async () => {
+    // Test to verify that multiple consecutive up-to-date messages
+    // without data changes don't accumulate unnecessary renders
+
+    const liveQuery = createLiveQueryCollection({
+      startSync: true,
+      query: (q) => q.from({ user: electricCollection }),
+    })
+
+    // Track changes emitted by the live query
+    const changeNotifications: Array<any> = []
+    const subscription = liveQuery.subscribeChanges((changes) => {
+      changeNotifications.push(changes)
+    })
+
+    // Initial sync
+    simulateInitialSync()
+    expect(liveQuery.status).toBe(`ready`)
+    expect(liveQuery.size).toBe(4)
+
+    // Clear initial change notifications
+    changeNotifications.length = 0
+
+    // Send multiple up-to-date messages with no data changes
+    simulateUpToDateOnly()
+    simulateUpToDateOnly()
+    simulateUpToDateOnly()
+
+    // Wait for any async operations
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Should not have emitted any changes despite multiple up-to-date messages
+    // BUG: Currently emits empty change arrays for each up-to-date message
+    if (changeNotifications.length > 0) {
+      console.log(
+        `BUG DETECTED: Live query emitted ${changeNotifications.length} change notifications on multiple up-to-date messages with no data changes:`,
+        changeNotifications
+      )
+    }
+    expect(changeNotifications).toHaveLength(0)
+
+    // Verify collection state is still correct
+    expect(liveQuery.status).toBe(`ready`)
+    expect(liveQuery.size).toBe(4)
+
+    // Clean up
+    subscription.unsubscribe()
   })
 })

--- a/packages/electric-db-collection/tests/electric-live-query.test.ts
+++ b/packages/electric-db-collection/tests/electric-live-query.test.ts
@@ -344,7 +344,7 @@ describe.each([
     expect(liveQuery.status).toBe(`ready`)
   })
 
-  it.only(`should not emit changes on up-to-date messages with no data changes`, async () => {
+  it(`should not emit changes on up-to-date messages with no data changes`, async () => {
     // Test to verify that up-to-date messages without actual data changes
     // don't trigger unnecessary renders in live query collections
 

--- a/packages/electric-db-collection/tests/electric-live-query.test.ts
+++ b/packages/electric-db-collection/tests/electric-live-query.test.ts
@@ -386,13 +386,6 @@ describe.each([
 
     // The live query should not have emitted any changes
     // because there were no actual data changes
-    // BUG: Currently emits empty change arrays on up-to-date messages
-    if (changeNotifications.length > 0) {
-      console.log(
-        `BUG DETECTED: Live query emitted ${changeNotifications.length} change notifications on up-to-date with no data changes:`,
-        changeNotifications
-      )
-    }
     expect(changeNotifications).toHaveLength(0)
 
     // Verify the collection is still in ready state
@@ -435,13 +428,6 @@ describe.each([
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     // Should not have emitted any changes despite multiple up-to-date messages
-    // BUG: Currently emits empty change arrays for each up-to-date message
-    if (changeNotifications.length > 0) {
-      console.log(
-        `BUG DETECTED: Live query emitted ${changeNotifications.length} change notifications on multiple up-to-date messages with no data changes:`,
-        changeNotifications
-      )
-    }
     expect(changeNotifications).toHaveLength(0)
 
     // Verify collection state is still correct


### PR DESCRIPTION
This fixes #597

We were emitting an empty change event whenever `markReady` was called, which would happed after each Electric long polling request returned.

The code that triggers these additional empty events was added in #532 to fix a suck loading state. That PR introduced a test case that failed without this previous change. My change here initially caused a regression, but I went digging and found the *real* case of the stuck loading state and have fixed that 🥳 

