### PR TITLE
Handle pushed down predicates in Electric collection

### DIFF
--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -419,7 +419,7 @@ function createElectricSync<T extends Row<unknown>>(
       })
 
       return {
-        onLoadMore: (opts) => onLoadMore(params, opts),
+        onLoadMore: (opts) => onLoadMore(stream, params, opts),
         cleanup: () => {
           // Unsubscribe from the stream
           unsubscribeStream()
@@ -434,6 +434,7 @@ function createElectricSync<T extends Row<unknown>>(
 }
 
 async function onLoadMore<T extends Row<unknown>>(
+  stream: ShapeStream<T>,
   syncParams: Parameters<SyncConfig<T>[`sync`]>[0],
   options: OnLoadMoreOptions
 ) {
@@ -444,7 +445,7 @@ async function onLoadMore<T extends Row<unknown>>(
 
   const snapshotParams = compileSQL<T>(options)
 
-  const snapshot = await requestSnapshot(snapshotParams)
+  const snapshot = await stream.requestSnapshot(snapshotParams)
 
   begin()
 

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -439,22 +439,15 @@ async function onLoadMore<T extends Row<unknown>>(
   options: OnLoadMoreOptions
 ) {
   const { begin, write, commit } = syncParams
-
-  // TODO: optimize this by keeping track of which snapshot have been loaded already
-  //       and only load this one if it's not a subset of the ones that have been loaded already
-
   const snapshotParams = compileSQL<T>(options)
-
   const snapshot = await stream.requestSnapshot(snapshotParams)
 
   begin()
-
   snapshot.data.forEach((row) => {
     write({
       type: `insert`,
       value: row.value,
     })
   })
-
   commit()
 }

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -15,12 +15,10 @@ import {
 import { compileSQL } from "./sql-compiler"
 import type {
   BaseCollectionConfig,
-  Collection,
   CollectionConfig,
   DeleteMutationFnParams,
   Fn,
   InsertMutationFnParams,
-  OnLoadMoreOptions,
   SyncConfig,
   UpdateMutationFnParams,
   UtilsRecord,
@@ -420,9 +418,9 @@ function createElectricSync<T extends Row<unknown>>(
       })
 
       return {
-        onLoadMore: (opts) => {
+        onLoadMore: async (opts) => {
           const snapshotParams = compileSQL<T>(opts)
-          return stream.requestSnapshot(snapshotParams)
+          await stream.requestSnapshot(snapshotParams)
         },
         cleanup: () => {
           // Unsubscribe from the stream
@@ -436,4 +434,3 @@ function createElectricSync<T extends Row<unknown>>(
     getSyncMetadata,
   }
 }
-

--- a/packages/electric-db-collection/src/pg-serializer.ts
+++ b/packages/electric-db-collection/src/pg-serializer.ts
@@ -1,0 +1,27 @@
+export function serialize(value: unknown): string {
+  if (typeof value === `string`) {
+    return `'${value}'`
+  }
+
+  if (value === null || value === undefined) {
+    return `NULL`
+  }
+
+  if (typeof value === `boolean`) {
+    return value ? `true` : `false`
+  }
+
+  if (value instanceof Date) {
+    return `'${value.toISOString()}'`
+  }
+
+  if (Array.isArray(value)) {
+    return `ARRAY[${value.map(serialize).join(`,`)}]`
+  }
+
+  if (typeof value === `object`) {
+    throw new Error(`Cannot serialize object: ${JSON.stringify(value)}`)
+  }
+
+  return value.toString()
+}

--- a/packages/electric-db-collection/src/pg-serializer.ts
+++ b/packages/electric-db-collection/src/pg-serializer.ts
@@ -3,6 +3,10 @@ export function serialize(value: unknown): string {
     return `'${value}'`
   }
 
+  if (typeof value === `number`) {
+    return value.toString()
+  }
+
   if (value === null || value === undefined) {
     return `NULL`
   }
@@ -19,9 +23,5 @@ export function serialize(value: unknown): string {
     return `ARRAY[${value.map(serialize).join(`,`)}]`
   }
 
-  if (typeof value === `object`) {
-    throw new Error(`Cannot serialize object: ${JSON.stringify(value)}`)
-  }
-
-  return value.toString()
+  throw new Error(`Cannot serialize value: ${JSON.stringify(value)}`)
 }

--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -30,6 +30,7 @@ export function compileSQL<T>(
 
   // Serialize the values in the params array into PG formatted strings
   // and transform the array into a Record<string, string>
+  console.log("params", params)
   const paramsRecord = params.reduce(
     (acc, param, index) => {
       acc[`${index + 1}`] = serialize(param)
@@ -58,7 +59,8 @@ function compileBasicExpression(
     case `val`:
       params.push(exp.value)
       return `$${params.length}`
-    case `ref`:
+    case `ref`: 
+      // TODO: doesn't yet support JSON(B) values which could be accessed with nested props
       if (exp.path.length !== 1) {
         throw new Error(
           `Compiler can't handle nested properties: ${exp.path.join(`.`)}`

--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -1,0 +1,146 @@
+import type { IR, OnLoadMoreOptions } from "@tanstack/db"
+
+export function compileSQL<T>(
+  options: OnLoadMoreOptions
+): ExternalSubsetParamsRecord {
+  const { where, orderBy, limit } = options
+
+  const params: Array<T> = []
+  const compiledSQL: ExternalSubsetParamsRecord = { params }
+
+  if (where) {
+    // TODO: this only works when the where expression's PropRefs directly reference a column of the collection
+    //       doesn't work if it goes through aliases because then we need to know the entire query to be able to follow the reference until the base collection (cf. followRef function)
+    compiledSQL.where = compileBasicExpression(where, params)
+  }
+
+  if (orderBy) {
+    compiledSQL.orderBy = compileOrderBy(orderBy, params)
+  }
+
+  if (limit) {
+    compiledSQL.limit = limit
+  }
+
+  return compiledSQL
+}
+
+/**
+ * Compiles the expression to a SQL string and mutates the params array with the values.
+ * @param exp - The expression to compile
+ * @param params - The params array
+ * @returns The compiled SQL string
+ */
+function compileBasicExpression(
+  exp: IR.BasicExpression<unknown>,
+  params: Array<unknown>
+): string {
+  switch (exp.type) {
+    case `val`:
+      params.push(exp.value)
+      return `$${params.length}`
+    case `ref`:
+      if (exp.path.length !== 1) {
+        throw new Error(
+          `Compiler can't handle nested properties: ${exp.path.join(`.`)}`
+        )
+      }
+      return exp.path[0]!
+    case `func`:
+      return compileFunction(exp, params)
+  }
+}
+
+function compileOrderBy(orderBy: IR.OrderBy, params: Array<unknown>): string {
+  const compiledOrderByClauses = orderBy.map((clause: IR.OrderByClause) =>
+    compileOrderByClause(clause, params)
+  )
+  return compiledOrderByClauses.join(`,`)
+}
+
+function compileOrderByClause(
+  clause: IR.OrderByClause,
+  params: Array<unknown>
+): string {
+  // TODO: what to do with stringSort and locale?
+  //       Correctly supporting them is tricky as it depends on Postgres' collation
+  const { expression, compareOptions } = clause
+  let sql = compileBasicExpression(expression, params)
+
+  if (compareOptions.direction === `desc`) {
+    sql = `${sql} DESC`
+  }
+
+  if (compareOptions.nulls === `first`) {
+    sql = `${sql} NULLS FIRST`
+  }
+
+  if (compareOptions.nulls === `last`) {
+    sql = `${sql} NULLS LAST`
+  }
+
+  return sql
+}
+
+function compileFunction(
+  exp: IR.Func<unknown>,
+  params: Array<unknown> = []
+): string {
+  const { name, args } = exp
+
+  const opName = getOpName(name)
+
+  const compiledArgs = args.map((arg: IR.BasicExpression) =>
+    compileBasicExpression(arg, params)
+  )
+
+  if (isBinaryOp(name)) {
+    if (compiledArgs.length !== 2) {
+      throw new Error(`Binary operator ${name} expects 2 arguments`)
+    }
+    const [lhs, rhs] = compiledArgs
+    return `${lhs} ${opName} ${rhs}`
+  }
+
+  return `${opName}(${compiledArgs.join(`,`)})`
+}
+
+function isBinaryOp(name: string): boolean {
+  const binaryOps = [`eq`, `gt`, `gte`, `lt`, `lte`, `and`, `or`]
+  return binaryOps.includes(name)
+}
+
+function getOpName(name: string): string {
+  const opNames = {
+    eq: `=`,
+    gt: `>`,
+    gte: `>=`,
+    lt: `<`,
+    lte: `<=`,
+    add: `+`,
+    and: `AND`,
+    or: `OR`,
+    not: `NOT`,
+    isUndefined: `IS NULL`,
+    isNull: `IS NULL`,
+    in: `IN`,
+    like: `LIKE`,
+    ilike: `ILIKE`,
+    upper: `UPPER`,
+    lower: `LOWER`,
+    length: `LENGTH`,
+    concat: `CONCAT`,
+    coalesce: `COALESCE`,
+  }
+  return opNames[name as keyof typeof opNames] || name
+}
+
+// TODO: remove this type once we rebase on top of Ilia's PR
+//       that type will be exported by Ilia's PR
+export type ExternalSubsetParamsRecord = {
+  where?: string
+  params?: Record<string, any>
+  limit?: number
+  offset?: number
+  orderBy?: string
+}

--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -48,6 +48,8 @@ function compileBasicExpression(
       return exp.path[0]!
     case `func`:
       return compileFunction(exp, params)
+    default:
+      throw new Error(`Unknown expression type`)
   }
 }
 

--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -30,7 +30,6 @@ export function compileSQL<T>(
 
   // Serialize the values in the params array into PG formatted strings
   // and transform the array into a Record<string, string>
-  console.log("params", params)
   const paramsRecord = params.reduce(
     (acc, param, index) => {
       acc[`${index + 1}`] = serialize(param)
@@ -59,7 +58,7 @@ function compileBasicExpression(
     case `val`:
       params.push(exp.value)
       return `$${params.length}`
-    case `ref`: 
+    case `ref`:
       // TODO: doesn't yet support JSON(B) values which could be accessed with nested props
       if (exp.path.length !== 1) {
         throw new Error(


### PR DESCRIPTION
This PR is a follow up on https://github.com/TanStack/db/pull/617 and modifies the Electric collection to handle predicates that are being pushed down to the Electric collection.