### PR TITLE
Add a scheduler that ensures single batch of changes from live query due to a transaction that touches multiple source collections

### DIFF
--- a/.changeset/olive-crews-love.md
+++ b/.changeset/olive-crews-love.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Add a scheduler that ensures that if a transaction touches multiple collections that feed into a single live query, the live query only emits a single batch of updates. This fixes an issue where multiple renders could be triggered from a live query under this situation.

--- a/packages/db/src/query/live/collection-registry.ts
+++ b/packages/db/src/query/live/collection-registry.ts
@@ -1,0 +1,47 @@
+import type { Collection } from "../../collection/index.js"
+import type { CollectionConfigBuilder } from "./collection-config-builder.js"
+
+const collectionBuilderRegistry = new WeakMap<
+  Collection<any, any, any>,
+  CollectionConfigBuilder<any, any>
+>()
+
+/**
+ * Retrieves the builder attached to a config object via its utils.getBuilder() method.
+ *
+ * @param config - The collection config object
+ * @returns The attached builder, or `undefined` if none exists
+ */
+export function getBuilderFromConfig(
+  config: object
+): CollectionConfigBuilder<any, any> | undefined {
+  return (config as any).utils?.getBuilder?.()
+}
+
+/**
+ * Registers a builder for a collection in the global registry.
+ * Used to detect when a live query depends on another live query,
+ * enabling the scheduler to ensure parent queries run first.
+ *
+ * @param collection - The collection to register the builder for
+ * @param builder - The builder that produces this collection
+ */
+export function registerCollectionBuilder(
+  collection: Collection<any, any, any>,
+  builder: CollectionConfigBuilder<any, any>
+): void {
+  collectionBuilderRegistry.set(collection, builder)
+}
+
+/**
+ * Retrieves the builder registered for a collection.
+ * Used to discover dependencies when a live query subscribes to another live query.
+ *
+ * @param collection - The collection to look up
+ * @returns The registered builder, or `undefined` if none exists
+ */
+export function getCollectionBuilder(
+  collection: Collection<any, any, any>
+): CollectionConfigBuilder<any, any> | undefined {
+  return collectionBuilderRegistry.get(collection)
+}

--- a/packages/db/src/scheduler.ts
+++ b/packages/db/src/scheduler.ts
@@ -1,0 +1,198 @@
+/**
+ * Identifier used to scope scheduled work. Maps to a transaction id for live queries.
+ */
+export type SchedulerContextId = string | symbol
+
+/**
+ * Options for {@link Scheduler.schedule}. Jobs are identified by `jobId` within a context
+ * and may declare dependencies.
+ */
+interface ScheduleOptions {
+  contextId?: SchedulerContextId
+  jobId: unknown
+  dependencies?: Iterable<unknown>
+  run: () => void
+}
+
+/**
+ * State per context. Queue preserves order, jobs hold run functions, dependencies track
+ * prerequisites, and completed records which jobs have run during the current flush.
+ */
+interface SchedulerContextState {
+  queue: Array<unknown>
+  jobs: Map<unknown, () => void>
+  dependencies: Map<unknown, Set<unknown>>
+  completed: Set<unknown>
+}
+
+/**
+ * Scoped scheduler that coalesces work by context and job.
+ *
+ * - **context** (e.g. transaction id) defines the batching boundary; work is queued until flushed.
+ * - **job id** deduplicates work within a context; scheduling the same job replaces the previous run function.
+ * - Without a context id, work executes immediately.
+ *
+ * Callers manage their own state; the scheduler only orchestrates execution order.
+ */
+export class Scheduler {
+  private contexts = new Map<SchedulerContextId, SchedulerContextState>()
+  private clearListeners = new Set<(contextId: SchedulerContextId) => void>()
+
+  /**
+   * Get or create the state bucket for a context.
+   */
+  private getOrCreateContext(
+    contextId: SchedulerContextId
+  ): SchedulerContextState {
+    let context = this.contexts.get(contextId)
+    if (!context) {
+      context = {
+        queue: [],
+        jobs: new Map(),
+        dependencies: new Map(),
+        completed: new Set(),
+      }
+      this.contexts.set(contextId, context)
+    }
+    return context
+  }
+
+  /**
+   * Schedule work. Without a context id, executes immediately.
+   * Otherwise queues the job to be flushed once dependencies are satisfied.
+   * Scheduling the same jobId again replaces the previous run function.
+   */
+  schedule({ contextId, jobId, dependencies, run }: ScheduleOptions): void {
+    if (typeof contextId === `undefined`) {
+      run()
+      return
+    }
+
+    const context = this.getOrCreateContext(contextId)
+
+    // If this is a new job, add it to the queue
+    if (!context.jobs.has(jobId)) {
+      context.queue.push(jobId)
+    }
+
+    // Store or replace the run function
+    context.jobs.set(jobId, run)
+
+    // Update dependencies
+    if (dependencies) {
+      const depSet = new Set<unknown>(dependencies)
+      depSet.delete(jobId)
+      context.dependencies.set(jobId, depSet)
+    } else if (!context.dependencies.has(jobId)) {
+      context.dependencies.set(jobId, new Set())
+    }
+
+    // Clear completion status since we're rescheduling
+    context.completed.delete(jobId)
+  }
+
+  /**
+   * Flush all queued work for a context. Jobs with unmet dependencies are retried.
+   * Throws if a pass completes without running any job (dependency cycle).
+   */
+  flush(contextId: SchedulerContextId): void {
+    const context = this.contexts.get(contextId)
+    if (!context) return
+
+    const { queue, jobs, dependencies, completed } = context
+
+    while (queue.length > 0) {
+      let ranThisPass = false
+      const jobsThisPass = queue.length
+
+      for (let i = 0; i < jobsThisPass; i++) {
+        const jobId = queue.shift()!
+        const run = jobs.get(jobId)
+        if (!run) {
+          dependencies.delete(jobId)
+          completed.delete(jobId)
+          continue
+        }
+
+        const deps = dependencies.get(jobId)
+        let ready = !deps
+        if (deps) {
+          ready = true
+          for (const dep of deps) {
+            if (dep !== jobId && !completed.has(dep)) {
+              ready = false
+              break
+            }
+          }
+        }
+
+        if (ready) {
+          jobs.delete(jobId)
+          dependencies.delete(jobId)
+          // Run the job. If it throws, we don't mark it complete, allowing the
+          // error to propagate while maintaining scheduler state consistency.
+          run()
+          completed.add(jobId)
+          ranThisPass = true
+        } else {
+          queue.push(jobId)
+        }
+      }
+
+      if (!ranThisPass) {
+        throw new Error(
+          `Scheduler detected unresolved dependencies for context ${String(
+            contextId
+          )}.`
+        )
+      }
+    }
+
+    this.contexts.delete(contextId)
+  }
+
+  /**
+   * Flush all contexts with pending work. Useful during tear-down.
+   */
+  flushAll(): void {
+    for (const contextId of Array.from(this.contexts.keys())) {
+      this.flush(contextId)
+    }
+  }
+
+  /** Clear all scheduled jobs for a context. */
+  clear(contextId: SchedulerContextId): void {
+    this.contexts.delete(contextId)
+    // Notify listeners that this context was cleared
+    this.clearListeners.forEach((listener) => listener(contextId))
+  }
+
+  /** Register a listener to be notified when a context is cleared. */
+  onClear(listener: (contextId: SchedulerContextId) => void): () => void {
+    this.clearListeners.add(listener)
+    return () => this.clearListeners.delete(listener)
+  }
+
+  /** Check if a context has pending jobs. */
+  hasPendingJobs(contextId: SchedulerContextId): boolean {
+    const context = this.contexts.get(contextId)
+    return !!context && context.jobs.size > 0
+  }
+
+  /** Remove a single job from a context and clean up its dependencies. */
+  clearJob(contextId: SchedulerContextId, jobId: unknown): void {
+    const context = this.contexts.get(contextId)
+    if (!context) return
+
+    context.jobs.delete(jobId)
+    context.dependencies.delete(jobId)
+    context.completed.delete(jobId)
+    context.queue = context.queue.filter((id) => id !== jobId)
+
+    if (context.jobs.size === 0) {
+      this.contexts.delete(contextId)
+    }
+  }
+}
+
+export const transactionScopedScheduler = new Scheduler()

--- a/packages/db/tests/query/scheduler.test.ts
+++ b/packages/db/tests/query/scheduler.test.ts
@@ -1,0 +1,527 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createCollection } from "../../src/collection/index.js"
+import { createLiveQueryCollection, eq } from "../../src/query/index.js"
+import { createTransaction } from "../../src/transactions.js"
+import { transactionScopedScheduler } from "../../src/scheduler.js"
+import { CollectionConfigBuilder } from "../../src/query/live/collection-config-builder.js"
+import type { FullSyncState } from "../../src/query/live/types.js"
+import type { SyncConfig } from "../../src/types.js"
+
+interface ChangeMessageLike {
+  type: string
+  value: any
+}
+
+interface User {
+  id: number
+  name: string
+}
+
+interface Task {
+  id: number
+  userId: number
+  title: string
+}
+
+function setupLiveQueryCollections(id: string) {
+  const users = createCollection<User>({
+    id: `${id}-users`,
+    getKey: (user) => user.id,
+    startSync: true,
+    sync: {
+      sync: ({ begin, commit, markReady }) => {
+        begin()
+        commit()
+        markReady()
+      },
+    },
+  })
+
+  const tasks = createCollection<Task>({
+    id: `${id}-tasks`,
+    getKey: (task) => task.id,
+    startSync: true,
+    sync: {
+      sync: ({ begin, commit, markReady }) => {
+        begin()
+        commit()
+        markReady()
+      },
+    },
+  })
+
+  const assignments = createLiveQueryCollection({
+    id: `${id}-assignments`,
+    startSync: true,
+    query: (q) =>
+      q
+        .from({ user: users })
+        .join({ task: tasks }, ({ user, task }) => eq(user.id, task.userId))
+        .select(({ user, task }) => ({
+          userId: user.id,
+          taskId: task?.id,
+          title: task?.title,
+        })),
+  })
+
+  return { users, tasks, assignments }
+}
+
+function recordBatches(collection: any) {
+  const batches: Array<Array<ChangeMessageLike>> = []
+  const subscription = collection.subscribeChanges((changes: any) => {
+    batches.push(changes as Array<ChangeMessageLike>)
+  })
+  return {
+    batches,
+    unsubscribe: () => subscription.unsubscribe(),
+  }
+}
+
+afterEach(() => {
+  transactionScopedScheduler.flushAll()
+})
+
+describe(`live query scheduler`, () => {
+  it(`runs the live query graph once per transaction that touches multiple collections`, async () => {
+    const { users, tasks, assignments } =
+      setupLiveQueryCollections(`single-batch`)
+    await assignments.preload()
+
+    const recorder = recordBatches(assignments)
+
+    const transaction = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+
+    transaction.mutate(() => {
+      users.insert({ id: 1, name: `Alice` })
+      tasks.insert({ id: 1, userId: 1, title: `Write tests` })
+    })
+
+    expect(recorder.batches).toHaveLength(1)
+    expect(recorder.batches[0]).toHaveLength(1)
+    expect(recorder.batches[0]![0]).toMatchObject({
+      type: `insert`,
+      value: {
+        userId: 1,
+        taskId: 1,
+        title: `Write tests`,
+      },
+    })
+
+    recorder.unsubscribe()
+    transaction.rollback()
+  })
+
+  it(`handles nested transactions without emitting duplicate batches`, async () => {
+    const { users, tasks, assignments } = setupLiveQueryCollections(`nested`)
+    await assignments.preload()
+
+    const recorder = recordBatches(assignments)
+
+    const outerTx = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+    const innerTx = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+
+    outerTx.mutate(() => {
+      users.insert({ id: 11, name: `Nested User` })
+      innerTx.mutate(() => {
+        tasks.insert({ id: 21, userId: 11, title: `Nested Task` })
+      })
+    })
+
+    expect(recorder.batches).toHaveLength(1)
+    expect(recorder.batches[0]![0]).toMatchObject({
+      value: {
+        userId: 11,
+        taskId: 21,
+        title: `Nested Task`,
+      },
+    })
+
+    recorder.unsubscribe()
+    innerTx.rollback()
+    outerTx.rollback()
+  })
+
+  it(`clears pending jobs when a transaction rolls back due to an error`, async () => {
+    const { users, tasks, assignments } = setupLiveQueryCollections(`rollback`)
+    await assignments.preload()
+
+    const recorder = recordBatches(assignments)
+    const tx = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+
+    expect(() => {
+      tx.mutate(() => {
+        users.insert({ id: 31, name: `Temp` })
+        tasks.insert({ id: 41, userId: 31, title: `Temp Task` })
+        throw new Error(`boom`)
+      })
+    }).toThrowError(`boom`)
+
+    tx.rollback()
+
+    const batchesBeforeFlush = recorder.batches.length
+    transactionScopedScheduler.flush(tx.id)
+    expect(recorder.batches.length).toBeGreaterThanOrEqual(batchesBeforeFlush)
+    if (recorder.batches.length > batchesBeforeFlush) {
+      const latestBatch = recorder.batches.at(-1)!
+      expect(latestBatch[0]?.type).toBe(`delete`)
+    }
+    expect(transactionScopedScheduler.hasPendingJobs(tx.id)).toBe(false)
+    // We emit the optimistic insert and, after the explicit rollback, possibly a
+    // compensating delete – but no duplicate inserts.
+    expect(recorder.batches[0]![0]).toMatchObject({ type: `insert` })
+
+    recorder.unsubscribe()
+  })
+
+  it(`dedupes batches across multiple subscribers`, async () => {
+    const { users, tasks, assignments } =
+      setupLiveQueryCollections(`multi-subscriber`)
+    await assignments.preload()
+
+    const first = recordBatches(assignments)
+    const second = recordBatches(assignments)
+
+    const tx = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+    tx.mutate(() => {
+      users.insert({ id: 51, name: `Multi` })
+      tasks.insert({ id: 61, userId: 51, title: `Subscriber Task` })
+    })
+
+    expect(first.batches).toHaveLength(1)
+    expect(second.batches).toHaveLength(1)
+    expect(first.batches[0]![0]).toMatchObject({
+      value: {
+        userId: 51,
+        taskId: 61,
+        title: `Subscriber Task`,
+      },
+    })
+
+    first.unsubscribe()
+    second.unsubscribe()
+    tx.rollback()
+  })
+
+  it(`runs join live queries once after their parent queries settle`, async () => {
+    const collectionA = createCollection<{ id: number; value: string }>({
+      id: `diamond-A`,
+      getKey: (row) => row.id,
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const collectionB = createCollection<{ id: number; value: string }>({
+      id: `diamond-B`,
+      getKey: (row) => row.id,
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const liveQueryA = createLiveQueryCollection({
+      id: `diamond-lqA`,
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ a: collectionA })
+          .select(({ a }) => ({ id: a.id, value: a.value })),
+    })
+
+    const liveQueryB = createLiveQueryCollection({
+      id: `diamond-lqB`,
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ b: collectionB })
+          .select(({ b }) => ({ id: b.id, value: b.value })),
+    })
+
+    const liveQueryJoin = createLiveQueryCollection({
+      id: `diamond-join`,
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ left: liveQueryA })
+          .join(
+            { right: liveQueryB },
+            ({ left, right }) => eq(left.id, right.id),
+            `full`
+          )
+          .select(({ left, right }) => ({
+            left: left?.value,
+            right: right?.value,
+          })),
+    })
+
+    await Promise.all([
+      liveQueryA.preload(),
+      liveQueryB.preload(),
+      liveQueryJoin.preload(),
+    ])
+    const baseRunCount = liveQueryJoin.utils.getRunCount()
+
+    const tx = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+
+    tx.mutate(() => {
+      collectionA.insert({ id: 1, value: `A1` })
+      collectionB.insert({ id: 1, value: `B1` })
+    })
+
+    expect(liveQueryJoin.toArray).toEqual([{ left: `A1`, right: `B1` }])
+    expect(liveQueryJoin.utils.getRunCount()).toBe(baseRunCount + 1)
+
+    tx.mutate(() => {
+      collectionA.update(1, (draft) => {
+        draft.value = `A1b`
+      })
+      collectionB.update(1, (draft) => {
+        draft.value = `B1b`
+      })
+    })
+
+    expect(liveQueryJoin.toArray).toEqual([{ left: `A1b`, right: `B1b` }])
+    expect(liveQueryJoin.utils.getRunCount()).toBe(baseRunCount + 2)
+    tx.rollback()
+  })
+
+  it(`runs hybrid joins once when they observe both a live query and a collection`, async () => {
+    const collectionA = createCollection<{ id: number; value: string }>({
+      id: `hybrid-A`,
+      getKey: (row) => row.id,
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const collectionB = createCollection<{ id: number; value: string }>({
+      id: `hybrid-B`,
+      getKey: (row) => row.id,
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const liveQueryA = createLiveQueryCollection({
+      id: `hybrid-lqA`,
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ a: collectionA })
+          .select(({ a }) => ({ id: a.id, value: a.value })),
+    })
+
+    const hybridJoin = createLiveQueryCollection({
+      id: `hybrid-join`,
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ left: liveQueryA })
+          .join(
+            { right: collectionB },
+            ({ left, right }) => eq(left.id, right.id),
+            `full`
+          )
+          .select(({ left, right }) => ({
+            left: left?.value,
+            right: right?.value,
+          })),
+    })
+
+    await Promise.all([liveQueryA.preload(), hybridJoin.preload()])
+    const baseRunCount = hybridJoin.utils.getRunCount()
+
+    const tx = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+
+    tx.mutate(() => {
+      collectionA.insert({ id: 7, value: `A7` })
+      collectionB.insert({ id: 7, value: `B7` })
+    })
+
+    expect(hybridJoin.toArray).toEqual([{ left: `A7`, right: `B7` }])
+    expect(hybridJoin.utils.getRunCount()).toBe(baseRunCount + 1)
+
+    tx.mutate(() => {
+      collectionA.update(7, (draft) => {
+        draft.value = `A7b`
+      })
+      collectionB.update(7, (draft) => {
+        draft.value = `B7b`
+      })
+    })
+
+    expect(hybridJoin.toArray).toEqual([{ left: `A7b`, right: `B7b` }])
+    expect(hybridJoin.utils.getRunCount()).toBe(baseRunCount + 2)
+    tx.rollback()
+  })
+
+  it(`currently single batch when the join sees right-side data before the left`, async () => {
+    const collectionA = createCollection<{ id: number; value: string }>({
+      id: `ordering-A`,
+      getKey: (row) => row.id,
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const collectionB = createCollection<{ id: number; value: string }>({
+      id: `ordering-B`,
+      getKey: (row) => row.id,
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const liveQueryA = createLiveQueryCollection({
+      id: `ordering-lqA`,
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ a: collectionA })
+          .select(({ a }) => ({ id: a.id, value: a.value })),
+    })
+
+    const join = createLiveQueryCollection({
+      id: `ordering-join`,
+      startSync: true,
+      query: (q) =>
+        q
+          .from({ left: liveQueryA })
+          .join(
+            { right: collectionB },
+            ({ left, right }) => eq(left.id, right.id),
+            `full`
+          )
+          .select(({ left, right }) => ({
+            left: left?.value,
+            right: right?.value,
+          })),
+    })
+
+    await Promise.all([liveQueryA.preload(), join.preload()])
+    const baseRunCount = join.utils.getRunCount()
+
+    const tx = createTransaction({
+      mutationFn: async () => {},
+      autoCommit: false,
+    })
+
+    tx.mutate(() => {
+      collectionB.insert({ id: 42, value: `right-first` })
+      collectionA.insert({ id: 42, value: `left-later` })
+    })
+
+    expect(join.toArray).toEqual([{ left: `left-later`, right: `right-first` }])
+    expect(join.utils.getRunCount()).toBe(baseRunCount + 1)
+    tx.rollback()
+  })
+
+  it(`coalesces load-more callbacks scheduled within the same context`, () => {
+    const baseCollection = createCollection<User>({
+      id: `loader-users`,
+      getKey: (user) => user.id,
+      sync: {
+        sync: () => () => {},
+      },
+    })
+
+    const builder = new CollectionConfigBuilder({
+      id: `loader-builder`,
+      query: (q) => q.from({ user: baseCollection }),
+    })
+
+    const contextId = Symbol(`loader-context`)
+    const loader = vi.fn(() => true)
+    const config = {
+      begin: vi.fn(),
+      write: vi.fn(),
+      commit: vi.fn(),
+      markReady: vi.fn(),
+      truncate: vi.fn(),
+    } as unknown as Parameters<SyncConfig<User>[`sync`]>[0]
+
+    const syncState = {
+      messagesCount: 0,
+      subscribedToAllCollections: true,
+      unsubscribeCallbacks: new Set<() => void>(),
+      graph: {
+        pendingWork: () => false,
+        run: vi.fn(),
+      },
+      inputs: {},
+      pipeline: {},
+    } as unknown as FullSyncState
+
+    const maybeRunGraphSpy = vi
+      .spyOn(builder, `maybeRunGraph`)
+      .mockImplementation((combinedLoader) => {
+        combinedLoader?.()
+      })
+
+    // Set instance properties since this test calls scheduleGraphRun directly
+    builder.currentSyncConfig = config
+    builder.currentSyncState = syncState
+
+    builder.scheduleGraphRun(loader, { contextId })
+    builder.scheduleGraphRun(loader, { contextId })
+
+    transactionScopedScheduler.flush(contextId)
+
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(maybeRunGraphSpy).toHaveBeenCalledTimes(1)
+
+    maybeRunGraphSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
stacked on #625

# Live Query Scheduler Overview

## Overview
This change introduces a scoped, dependency-aware scheduler that guarantees every live-query builder runs at most once per transaction, even when multiple source collections or derived queries fire in the same `mutate` call. The scheduler groups work by transaction id, dedupes entries by the `CollectionConfigBuilder` instance, tracks dependencies between builders, and flushes synchronously when `Transaction.mutate` exits. The net effect: optimistic updates from a single transaction coalesce into a single graph run for each live query, so downstream frameworks see one change batch per transaction.

## How scheduling works
- Each `CollectionSubscriber` immediately forwards changes to the D2 input and calls `CollectionConfigBuilder.scheduleGraphRun`.
- `scheduleGraphRun` records which upstream builders the current builder depends on (based on the collections it subscribed to) and hands a job to the shared scheduler with:
  - `contextId`: the transaction id, grouping all work triggered by that transaction.
  - `jobId`: the builder instance; repeated schedules for the same builder merge into a single entry.
  - `dependencies`: the set of upstream builders that must finish before this builder can run.
- The scheduler maintains, per transaction, a queue, entry map, dependency map, and “completed” set. When flushing, it only executes a job once all dependencies are marked completed, deferring the job otherwise. It loops until no work remains and throws if it detects an impossible cycle.

## When the graph actually runs
- Inside `Transaction.mutate`, we call `registerTransaction` before the user’s callback and `unregisterTransaction` in a `finally` block afterward.
- `registerTransaction` clears any stale entries from previous failed scopes.
- `unregisterTransaction` calls `scheduler.flush(tx.id)`. `flush` now loops while a context map exists, so if a job enqueues additional work during its own execution (e.g., the join scheduling itself after its parents run), the scheduler immediately picks up the new entry before leaving the transaction scope.
- If there is no active transaction, `scheduleGraphRun` runs `maybeRunGraph` immediately (backward compatible behaviour).

## Nested live queries (the “diamond” cases)
- Builders register themselves when a live-query collection is created. Whenever a builder subscribes to another live query, it records that dependency.
- During a transaction, updates enqueue jobs for the parent builders. When those builders finish, they mark themselves as completed, which in turn allows child jobs (such as joins) to run exactly once at the end of the flush.
- A hybrid variant (join between `liveQueryA` and raw `collectionB`) behaves the same way: even if `collectionB` fires first, the join job is deferred until `liveQueryA` has finished.
- Because dependencies are tracked explicitly, there are no deadlocks. If the scheduler ever loops without making progress, it throws a clear “dependency cycle” error.

### Order-by loaders and batching
- The `maybeRunGraph` loop keeps calling `graph.run()` while `pendingWork()` is true. If an order-by loader requests more rows, it pushes those changes into the same D2 input, triggering `pendingWork()` again.
- During this loop `CollectionConfigBuilder.isGraphRunning` is `true`, so any nested call to `scheduleGraphRun` is ignored; the loader’s extra rows are consumed by the ongoing loop.
- As a result, even hungry top-K queries emit a single batch per synchronous transaction run. Multiple batches only occur when a loader deliberately yields results asynchronously (for example, the incremental sync features we’re adding)—in that case the UI should expect staged updates.

## Tests
`scheduler.test.ts` now covers:

1. Basic single run per transaction (two collections mutated inside one `mutate`).
2. Nested transactions.
3. Rollback cleanup.
4. Multiple subscribers receiving exactly one batch.
5. Loader deduping.
6. Diamond dependency (live query joining two parents) – verifies parents run first and the join runs once (tracked via `getRunCount`).
7. Hybrid diamond (join of a live query with a base collection) – same single-run guarantee, even when the raw collection fires first.

Each of the diamond tests mutates once and then performs another transaction with updates, demonstrating that we still emit exactly one additional batch—no duplicates, no missed runs—and that `getRunCount()` only increments once per transaction.

## Summary
- Scheduler coalesces work by transaction + builder.
- `Transaction.mutate` clears before and flushes after every scope, so everything runs synchronously in the optimistic phase.
- `flush` loops until no jobs remain, ensuring child live queries (joins) run exactly once per transaction after their parents.
- Comprehensive tests cover simple, nested, rollback, multi-subscriber, loader, diamond, and hybrid patterns; asynchronous loaders will still produce multiple batches by design.
