### PR TITLE
fix query collection `.preload()`

### DIFF
--- a/.changeset/light-moles-divide.md
+++ b/.changeset/light-moles-divide.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/query-db-collection": patch
+---
+
+Fix collection.preload() hanging when called without startSync or subscribers. The QueryObserver now subscribes immediately when sync starts (from preload(), startSync, or first subscriber), while maintaining the staleTime behavior by dynamically unsubscribing when subscriber count drops to zero.

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -564,10 +564,9 @@ export function queryCollectionOptions(
       }
     }
 
-    // If startSync=true or there are subscribers to the collection, subscribe to the query straight away
-    if (config.startSync || collection.subscriberCount > 0) {
-      subscribeToQuery()
-    }
+    // Always subscribe when sync starts (this could be from preload(), startSync config, or first subscriber)
+    // We'll dynamically unsubscribe/resubscribe based on subscriber count to maintain staleTime behavior
+    subscribeToQuery()
 
     // Set up event listener for subscriber changes
     const unsubscribeFromCollectionEvents = collection.on(


### PR DESCRIPTION
Fixes #633 - a regression introduced in #462

Summary of fix from Claude:

## Analysis: Our Fix Preserves the Intended Behavior ✅

### The Original PR #462 Intention
The PR aimed to fix `staleTime` behavior by:
1. **Not subscribing** to TanStack Query when `startSync=false` AND `subscriberCount=0`
2. **Dynamically subscribing/unsubscribing** based on subscriber count changes
3. Allowing the QueryObserver to go inactive, restoring proper `staleTime`/`gcTime` semantics

### The Bug in the Implementation
The buggy code checked the subscription condition **inside** the sync function:
```typescript
// Inside the sync function (WRONG LOCATION)
if (config.startSync || collection.subscriberCount > 0) {
  subscribeToQuery()
}
```

**Problem**: When `preload()` is called, it starts sync but has:
- `config.startSync` = `undefined`/`false` 
- `collection.subscriberCount` = `0`
- Result: Never subscribes → `queryFn` never runs → `preload()` never resolves ❌

### Our Fix is Correct ✅

The key insight: **The decision to start sync happens BEFORE the sync function is called**

The sync function is only invoked in these cases:
1. **Constructor** with `startSync: true` (line 278-280, collection/index.ts)
2. **First subscriber added** when status is `idle` (line 123-128, collection/changes.ts)  
3. **preload()** called (through startSync() in collection/sync.ts)
4. **Operations on cleaned-up collection** (line 131-133, collection/lifecycle.ts)

Our fix:
```typescript
// Always subscribe when sync starts
subscribeToQuery()

// Dynamically unsubscribe when no subscribers
collection.on('subscribers:change', ({ subscriberCount }) => {
  if (subscriberCount > 0) subscribeToQuery()
  else if (subscriberCount === 0) unsubscribeFromQuery()
})
```

### Why This Preserves the Intended Behavior

| Scenario | Sync Function Called? | Our Fix Behavior | Intended Behavior | ✅ |
|----------|----------------------|------------------|-------------------|---|
| `startSync=false`, no subscribers | ❌ No | N/A (never called) | Should not subscribe | ✅ |
| `startSync=true`, no subscribers | ✅ Yes | Subscribes, unsubscribes when count=0 | Should subscribe initially | ✅ |
| `preload()` called | ✅ Yes | Subscribes | Should subscribe | ✅ |
| Subscriber added to idle collection | ✅ Yes | Subscribes | Should subscribe | ✅ |
| All subscribers removed | Sync running | Unsubscribes via event | Should unsubscribe | ✅ |

### Test Evidence

All 58 tests pass, including:
- ✅ `should not auto-subscribe when startSync=false and no subscribers` (line 1886)
- ✅ `should subscribe/unsubscribe based on subscriber count transitions` (line 1911)
- ✅ `should resolve preload() even without startSync or subscribers` (our new test, line 2275)
- ✅ `should manage startSync vs subscriber count priority correctly` (line 1120)

**Conclusion**: Our fix correctly addresses the `preload()` bug while fully preserving the `staleTime` behavior improvements from PR #462. The staleTime fix is maintained because the sync function is only called when sync should actually be active, and we properly unsubscribe when there are no subscribers.