### PR TITLE
fix orderBy field alias bug

### DIFF
--- a/.changeset/good-papers-knock.md
+++ b/.changeset/good-papers-knock.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Fixed bug where orderBy would fail when a collection alias had the same name as one of its schema fields. For example, .from({ email: emailCollection }).orderBy(({ email }) => email.createdAt) now works correctly even when the collection has an email field in its schema.

--- a/packages/db/src/query/compiler/group-by.ts
+++ b/packages/db/src/query/compiler/group-by.ts
@@ -417,16 +417,7 @@ export function replaceAggregatesByRefs(
     }
 
     case `ref`: {
-      const refExpr = havingExpr
-      // Check if this is a direct reference to a SELECT alias
-      if (refExpr.path.length === 1) {
-        const alias = refExpr.path[0]!
-        if (selectClause[alias]) {
-          // This is a reference to a SELECT alias, convert to result.alias
-          return new PropRef([resultAlias, alias])
-        }
-      }
-      // Return as-is for other refs
+      // Non-aggregate refs are passed through unchanged (they reference table columns)
       return havingExpr as BasicExpression
     }
 

--- a/packages/db/src/query/compiler/order-by.ts
+++ b/packages/db/src/query/compiler/order-by.ts
@@ -54,18 +54,12 @@ export function processOrderBy(
 
   // Create a value extractor function for the orderBy operator
   const valueExtractor = (row: NamespacedRow & { __select_results?: any }) => {
-    // For ORDER BY expressions, we need to provide access to both:
-    // 1. The original namespaced row data (for direct table column references)
-    // 2. The __select_results (for SELECT alias references)
-
-    // Create a merged context for expression evaluation
-    const orderByContext = { ...row }
-
-    // If there are select results, merge them at the top level for alias access
-    if (row.__select_results) {
-      // Add select results as top-level properties for alias access
-      Object.assign(orderByContext, row.__select_results)
-    }
+    // The namespaced row contains:
+    // 1. Table aliases as top-level properties (e.g., row["tableName"])
+    // 2. SELECT results in __select_results (e.g., row.__select_results["aggregateAlias"])
+    // The replaceAggregatesByRefs function has already transformed any aggregate expressions
+    // that match SELECT aggregates to use the __select_results namespace.
+    const orderByContext = row
 
     if (orderByClause.length > 1) {
       // For multiple orderBy columns, create a composite key


### PR DESCRIPTION
fixes #610

Description of the fix from Claude:

## Fix: orderBy breaks when collection alias matches schema field name

### Problem

When a collection alias in the `from` clause had the same name as one of its schema fields, `orderBy` would fail to sort correctly. For example:

```typescript
type EmailSchema = {
  email: string
  createdAt: Date
}

// This would break - alias "email" conflicts with the "email" field
q.from({ email: emailCollection })
 .orderBy(({ email }) => email.createdAt, "desc")
```

The query would run but produce unsorted results.

### Root Cause

The `orderBy` compiler was constructing an evaluation context by spreading the row data and then `__select_results`:

```typescript
const orderByContext = { ...row }
if (row.__select_results) {
  Object.assign(orderByContext, row.__select_results)
}
```

When `__select_results` contained a field with the same name as a table alias (e.g., both had `email`), the SELECT result would overwrite the table object, breaking the orderBy expression evaluation.

### Solution

Simplified the context to use the namespaced row directly:

```typescript
const orderByContext = row
```

This works because:
1. Table aliases are top-level properties on `row` (e.g., `row.email` is the table object)
2. SELECT results are in `row.__select_results` (e.g., `row.__select_results.email` is the field value)
3. The `replaceAggregatesByRefs` function already transforms aggregate references to use `__select_results` namespace when needed

This prevents any conflict between table aliases and SELECT field names.

### Additional Cleanup

Removed dead code in `replaceAggregatesByRefs` that attempted to support arbitrary SELECT alias references. The actual design pattern is **aggregate matching**: when you use an aggregate like `count(orders.id)` in HAVING or ORDER BY, it gets matched to the same aggregate in SELECT and replaced with a reference to the already-computed value. SELECT aliases themselves are never directly accessible in HAVING or ORDER BY callbacks.

### Tests

Added comprehensive test coverage for alias/field name conflicts in `order-by.test.ts`.