### PR TITLE
Fix changeset for PR #669 - Update to accurately describe loadSubset features

### DIFF
--- a/.changeset/cruel-buckets-shop.md
+++ b/.changeset/cruel-buckets-shop.md
@@ -1,5 +1,14 @@
 ---
-"@tanstack/db": patch
+"@tanstack/db": minor
 ---
 
-Added `isLoadingMore` property and `loadingMore:change` events to collections and live queries, enabling UIs to display loading indicators when more data is being fetched via `syncMore`. Each live query maintains its own isolated loading state based on its subscriptions, preventing loading status "bleed" between independent queries that share the same source collections.
+Added comprehensive loading state tracking and configurable sync modes to collections and live queries:
+
+- Added `isLoadingSubset` property and `loadingSubset:change` events to all collections for tracking when data is being loaded
+- Added `syncMode` configuration option to collections:
+  - `'eager'` (default): Loads all data immediately during initial sync
+  - `'on-demand'`: Only loads data as requested via `loadSubset` calls
+- Added comprehensive status tracking to collection subscriptions with `status` property (`'ready'` | `'loadingSubset'`) and events (`status:change`, `status:ready`, `status:loadingSubset`, `unsubscribed`)
+- Live queries automatically reflect loading state from their source collection subscriptions, with each query maintaining isolated loading state to prevent status "bleed" between independent queries
+- Enhanced `setWindow` utility to return `Promise<void>` when loading is triggered, allowing callers to await data loading completion
+- Added `subscription` parameter to `loadSubset` handler for advanced sync implementations that need to track subscription lifecycle


### PR DESCRIPTION
## Summary

The changeset for PR #669 (b0687ab4) had incorrect information and was incomplete. This PR updates it to accurately describe all the features added.

## Changes

Updated `.changeset/cruel-buckets-shop.md` to:
- Correct property name: `isLoadingSubset` (was incorrectly `isLoadingMore`)
- Correct event name: `loadingSubset:change` (was incorrectly `loadingMore:change`)
- Add missing features:
  - `syncMode` configuration option (`'eager'` | `'on-demand'`)
  - Comprehensive status tracking for collection subscriptions
  - Enhanced `setWindow` utility that returns `Promise<void>` for async loading
  - `subscription` parameter in `loadSubset` handler
- Change version bump from `patch` to `minor` (this adds significant new features)

## Context

The original changeset was merged before being properly updated to reflect the full scope of changes in PR #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)