### PR TITLE
Change PR #669 changeset from minor to patch

### DIFF
--- a/.changeset/cruel-buckets-shop.md
+++ b/.changeset/cruel-buckets-shop.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/db": minor
+"@tanstack/db": patch
 ---
 
 Added comprehensive loading state tracking and configurable sync modes to collections and live queries:


### PR DESCRIPTION
## Summary

Changes the version bump in the PR #669 changeset from `minor` to `patch`.

The changeset content is correct (updated in PR #679), but the version bump should be `patch` not `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)