### PR TITLE
Add Pre-created Collection Support to useLiveInfiniteQuery

### DIFF
--- a/.changeset/brown-otters-grab.md
+++ b/.changeset/brown-otters-grab.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/react-db": patch
+"@tanstack/db": patch
+---
+
+Add support for pre-created live query collections in useLiveInfiniteQuery, enabling router loader patterns where live queries can be created, preloaded, and passed to components.

--- a/packages/react-db/src/useLiveInfiniteQuery.ts
+++ b/packages/react-db/src/useLiveInfiniteQuery.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { CollectionImpl } from "@tanstack/db"
 import { useLiveQuery } from "./useLiveQuery"
 import type {
+  Collection,
   Context,
   InferResultType,
   InitialQueryBuilder,
   LiveQueryCollectionUtils,
+  NonSingleResult,
   QueryBuilder,
 } from "@tanstack/db"
 
@@ -82,61 +85,176 @@ export type UseLiveInfiniteQueryReturn<TContext extends Context> = Omit<
  *   },
  *   [category]
  * )
+ *
+ * @example
+ * // Router loader pattern with pre-created collection
+ * // In loader:
+ * const postsQuery = createLiveQueryCollection({
+ *   query: (q) => q
+ *     .from({ posts: postsCollection })
+ *     .orderBy(({ posts }) => posts.createdAt, 'desc')
+ *     .limit(20)
+ * })
+ * await postsQuery.preload()
+ * return { postsQuery }
+ *
+ * // In component:
+ * const { postsQuery } = useLoaderData()
+ * const { data, fetchNextPage, hasNextPage } = useLiveInfiniteQuery(
+ *   postsQuery,
+ *   {
+ *     pageSize: 20,
+ *     getNextPageParam: (lastPage) => lastPage.length === 20 ? lastPage.length : undefined
+ *   }
+ * )
  */
+
+// Overload for pre-created collection (non-single result)
+export function useLiveInfiniteQuery<
+  TResult extends object,
+  TKey extends string | number,
+  TUtils extends Record<string, any>,
+>(
+  liveQueryCollection: Collection<TResult, TKey, TUtils> & NonSingleResult,
+  config: UseLiveInfiniteQueryConfig<any>
+): UseLiveInfiniteQueryReturn<any>
+
+// Overload for query function
 export function useLiveInfiniteQuery<TContext extends Context>(
   queryFn: (q: InitialQueryBuilder) => QueryBuilder<TContext>,
+  config: UseLiveInfiniteQueryConfig<TContext>,
+  deps?: Array<unknown>
+): UseLiveInfiniteQueryReturn<TContext>
+
+// Implementation
+export function useLiveInfiniteQuery<TContext extends Context>(
+  queryFnOrCollection: any,
   config: UseLiveInfiniteQueryConfig<TContext>,
   deps: Array<unknown> = []
 ): UseLiveInfiniteQueryReturn<TContext> {
   const pageSize = config.pageSize || 20
   const initialPageParam = config.initialPageParam ?? 0
 
+  // Detect if input is a collection or query function
+  const isCollection = queryFnOrCollection instanceof CollectionImpl
+
+  // Validate input type
+  if (!isCollection && typeof queryFnOrCollection !== `function`) {
+    throw new Error(
+      `useLiveInfiniteQuery: First argument must be either a pre-created live query collection (CollectionImpl) ` +
+        `or a query function. Received: ${typeof queryFnOrCollection}`
+    )
+  }
+
   // Track how many pages have been loaded
   const [loadedPageCount, setLoadedPageCount] = useState(1)
   const [isFetchingNextPage, setIsFetchingNextPage] = useState(false)
 
-  // Stringify deps for comparison
+  // Track collection instance and whether we've validated it (only for pre-created collections)
+  const collectionRef = useRef(isCollection ? queryFnOrCollection : null)
+  const hasValidatedCollectionRef = useRef(false)
+
+  // Track deps for query functions (stringify for comparison)
   const depsKey = JSON.stringify(deps)
   const prevDepsKeyRef = useRef(depsKey)
 
-  // Reset page count when dependencies change
+  // Reset pagination when inputs change
   useEffect(() => {
-    if (prevDepsKeyRef.current !== depsKey) {
-      setLoadedPageCount(1)
-      prevDepsKeyRef.current = depsKey
-    }
-  }, [depsKey])
+    let shouldReset = false
 
-  // Create a live query with initial limit and offset
-  // The query function is wrapped to add limit/offset to the query
-  const queryResult = useLiveQuery(
-    (q) => queryFn(q).limit(pageSize).offset(0),
-    deps
-  )
-
-  // Update the window when loadedPageCount changes
-  // We fetch one extra item to peek if there's a next page
-  useEffect(() => {
-    const newLimit = loadedPageCount * pageSize + 1 // +1 to peek ahead
-    const utils = queryResult.collection.utils
-    // setWindow is available on live query collections with orderBy
-    if (isLiveQueryCollectionUtils(utils)) {
-      const result = utils.setWindow({ offset: 0, limit: newLimit })
-      // setWindow returns true if data is immediately available, or Promise<void> if loading
-      if (result !== true) {
-        setIsFetchingNextPage(true)
-        result.then(() => {
-          setIsFetchingNextPage(false)
-        })
-      } else {
-        setIsFetchingNextPage(false)
+    if (isCollection) {
+      // Reset if collection instance changed
+      if (collectionRef.current !== queryFnOrCollection) {
+        collectionRef.current = queryFnOrCollection
+        hasValidatedCollectionRef.current = false
+        shouldReset = true
+      }
+    } else {
+      // Reset if deps changed (for query functions)
+      if (prevDepsKeyRef.current !== depsKey) {
+        prevDepsKeyRef.current = depsKey
+        shouldReset = true
       }
     }
-  }, [loadedPageCount, pageSize, queryResult.collection])
+
+    if (shouldReset) {
+      setLoadedPageCount(1)
+    }
+  }, [isCollection, queryFnOrCollection, depsKey])
+
+  // Create a live query with initial limit and offset
+  // Either pass collection directly or wrap query function
+  const queryResult = isCollection
+    ? useLiveQuery(queryFnOrCollection)
+    : useLiveQuery(
+        (q) => queryFnOrCollection(q).limit(pageSize).offset(0),
+        deps
+      )
+
+  // Adjust window when pagination changes
+  useEffect(() => {
+    const utils = queryResult.collection.utils
+    const expectedOffset = 0
+    const expectedLimit = loadedPageCount * pageSize + 1 // +1 for peek ahead
+
+    // Check if collection has orderBy (required for setWindow)
+    if (!isLiveQueryCollectionUtils(utils)) {
+      // For pre-created collections, throw an error if no orderBy
+      if (isCollection) {
+        throw new Error(
+          `useLiveInfiniteQuery: Pre-created live query collection must have an orderBy clause for infinite pagination to work. ` +
+            `Please add .orderBy() to your createLiveQueryCollection query.`
+        )
+      }
+      return
+    }
+
+    // For pre-created collections, validate window on first check
+    if (isCollection && !hasValidatedCollectionRef.current) {
+      const currentWindow = utils.getWindow()
+      if (
+        currentWindow &&
+        (currentWindow.offset !== expectedOffset ||
+          currentWindow.limit !== expectedLimit)
+      ) {
+        console.warn(
+          `useLiveInfiniteQuery: Pre-created collection has window {offset: ${currentWindow.offset}, limit: ${currentWindow.limit}} ` +
+            `but hook expects {offset: ${expectedOffset}, limit: ${expectedLimit}}. Adjusting window now.`
+        )
+      }
+      hasValidatedCollectionRef.current = true
+    }
+
+    // For query functions, wait until collection is ready
+    if (!isCollection && !queryResult.isReady) return
+
+    // Adjust the window
+    const result = utils.setWindow({
+      offset: expectedOffset,
+      limit: expectedLimit,
+    })
+
+    if (result !== true) {
+      setIsFetchingNextPage(true)
+      result.then(() => {
+        setIsFetchingNextPage(false)
+      })
+    } else {
+      setIsFetchingNextPage(false)
+    }
+  }, [
+    isCollection,
+    queryResult.collection,
+    queryResult.isReady,
+    loadedPageCount,
+    pageSize,
+  ])
 
   // Split the data array into pages and determine if there's a next page
   const { pages, pageParams, hasNextPage, flatData } = useMemo(() => {
-    const dataArray = queryResult.data as InferResultType<TContext>
+    const dataArray = (
+      Array.isArray(queryResult.data) ? queryResult.data : []
+    ) as InferResultType<TContext>
     const totalItemsRequested = loadedPageCount * pageSize
 
     // Check if we have more data than requested (the peek ahead item)
@@ -181,5 +299,5 @@ export function useLiveInfiniteQuery<TContext extends Context>(
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  }
+  } as UseLiveInfiniteQueryReturn<TContext>
 }


### PR DESCRIPTION
## Summary
Extends `useLiveInfiniteQuery` to accept pre-created `LiveQueryCollection` instances in addition to query functions, enabling router loader patterns where collections can be created, awaited for preload, and then passed to route components.

## Changes

### Core Functionality
- **`useLiveInfiniteQuery`** now accepts either:
  - A query function: `(q) => q.from(...).orderBy(...).limit(...)`
  - A pre-created collection: `createLiveQueryCollection({ query: ... })`
- Added automatic window validation and adjustment for pre-created collections
- Window adjustments happen in effects to avoid React subscription timing issues
- Pagination state resets when collection instance changes

### New API: `getWindow()` on LiveQueryCollectionUtils
- Added `getWindow()` method to inspect current window settings
- Returns `{ offset: number, limit: number } | undefined`
- Returns `undefined` for non-windowed queries
- Tracks window state internally in `CollectionConfigBuilder`

### Validation & Error Handling
- Pre-created collections **must** have an `orderBy` clause (throws error if missing)
- Input validation ensures first argument is either a `CollectionImpl` or function
- Logs warning when pre-created collection's initial window doesn't match expected values
- Warning only appears once per collection instance

### Type Safety
- Added overload signatures for type inference based on input type
- Proper type narrowing for both collection and query function paths
- Uses `instanceof CollectionImpl` for reliable runtime type checking

## Example Usage

### Router Loader Pattern
```typescript
// In router loader
export async function loader() {
  const postsQuery = createLiveQueryCollection({
    query: (q) => q
      .from({ posts: postsCollection })
      .orderBy(({ posts }) => posts.createdAt, 'desc')
      .limit(20)
      .offset(0)
  })
  
  await postsQuery.preload()
  return { postsQuery }
}

// In component
function PostsList() {
  const { postsQuery } = useLoaderData()
  
  const { data, pages, hasNextPage, fetchNextPage } = useLiveInfiniteQuery(
    postsQuery,
    { pageSize: 20 }
  )
  
  // ... render
}
```

### Traditional Query Function (unchanged)
```typescript
const { data, pages, hasNextPage, fetchNextPage } = useLiveInfiniteQuery(
  (q) => q
    .from({ posts: postsCollection })
    .orderBy(({ posts }) => posts.createdAt, 'desc'),
  { pageSize: 20 }
)
```

## Testing
- ✅ 24 tests passing (7 new tests for pre-created collections)
- ✅ No linter errors
- ✅ No React warnings
- Tests cover: preloaded collections, pagination, instance changes, error cases, window validation, live updates, and router loader patterns

## Implementation Notes
- Window adjustment happens in `useEffect` after `useLiveQuery` subscribes to avoid triggering subscription callbacks during render which React will log warnings about
- Uses `hasValidatedCollectionRef` to track first-time validation and only log warnings once
- Delegates as much work as possible to the underlying `useLiveQuery` hook
- Both collection and query function code paths use a unified window adjustment effect
