### PR TITLE
docs: improve incremental updates example in query-collection docs

### DIFF
--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -240,19 +240,16 @@ const todosCollection = createCollection(
       // Send to server and get back items with server-computed fields
       const serverItems = await api.createTodos(newItems)
 
-      // Update the optimistic items with server-computed fields
-      // (like server-generated IDs, timestamps, etc.)
+      // Sync server-computed fields (like server-generated IDs, timestamps, etc.)
+      // to the collection's synced data store
       todosCollection.utils.writeBatch(() => {
-        transaction.mutations.forEach((mutation, index) => {
-          const serverItem = serverItems[index]
-          // Remove temporary optimistic item
-          todosCollection.utils.writeDelete(mutation.key)
-          // Insert with server data
+        serverItems.forEach(serverItem => {
           todosCollection.utils.writeInsert(serverItem)
         })
       })
 
       // Skip automatic refetch since we've already synced the server response
+      // (optimistic state is automatically replaced when handler completes)
       return { refetch: false }
     },
 


### PR DESCRIPTION
Replace confusing manual optimistic update pattern with familiar onInsert/onUpdate handler pattern. Show how to:
- Use persistence handlers (onInsert, onUpdate) like regular collections
- Return { refetch: false } to avoid unnecessary refetches
- Sync server-computed fields using direct writes within handlers

This makes the example more approachable and consistent with the rest of the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
