### PR TITLE
feat(query-db-collection): expose query state from QueryObserver

### DIFF
--- a/.changeset/tanstack-query-expose-query-state.md
+++ b/.changeset/tanstack-query-expose-query-state.md
@@ -7,6 +7,7 @@
 This change refactors the query state utility properties from function calls to getters, aligning with TanStack Query's API patterns and providing a more intuitive developer experience.
 
 **Breaking Changes:**
+
 - `collection.utils.lastError()` → `collection.utils.lastError`
 - `collection.utils.isError()` → `collection.utils.isError`
 - `collection.utils.errorCount()` → `collection.utils.errorCount`
@@ -18,6 +19,7 @@ This change refactors the query state utility properties from function calls to 
 
 **New Features:**
 Exposes TanStack Query's QueryObserver state through new utility getters:
+
 - `isFetching` - Whether the query is currently fetching (initial or background)
 - `isRefetching` - Whether the query is refetching in the background
 - `isLoading` - Whether the query is loading for the first time
@@ -25,6 +27,7 @@ Exposes TanStack Query's QueryObserver state through new utility getters:
 - `fetchStatus` - Current fetch status ('fetching' | 'paused' | 'idle')
 
 This allows users to:
+
 - Show loading indicators during background refetches
 - Implement "Last updated X minutes ago" UI patterns
 - Understand sync behavior beyond just error states
@@ -35,11 +38,11 @@ Remove parentheses from all utility property access. Properties are now accessed
 ```typescript
 // Before
 if (collection.utils.isFetching()) {
-  console.log('Syncing...', collection.utils.dataUpdatedAt())
+  console.log("Syncing...", collection.utils.dataUpdatedAt())
 }
 
 // After
 if (collection.utils.isFetching) {
-  console.log('Syncing...', collection.utils.dataUpdatedAt)
+  console.log("Syncing...", collection.utils.dataUpdatedAt)
 }
 ```

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -21,6 +21,7 @@ import type {
   InsertMutationFnParams,
   SyncConfig,
   UpdateMutationFnParams,
+  UtilsRecord,
 } from "@tanstack/db"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
 
@@ -151,8 +152,6 @@ export interface QueryCollectionUtils<
   TInsertInput extends object = TItem,
   TError = unknown,
 > {
-  /** Allow additional utility functions to be added */
-  [key: string]: any
   /** Manually trigger a refetch of the query */
   refetch: RefetchFn
   /** Insert one or more items directly into the synced data store without triggering a query refetch or optimistic update */
@@ -314,12 +313,7 @@ export function queryCollectionOptions<
     schema: T
     select: (data: TQueryData) => Array<InferSchemaInput<T>>
   }
-): CollectionConfig<
-  InferSchemaOutput<T>,
-  TKey,
-  T,
-  QueryCollectionUtils<InferSchemaOutput<T>, TKey, InferSchemaInput<T>, TError>
-> & {
+): CollectionConfig<InferSchemaOutput<T>, TKey, T, UtilsRecord> & {
   schema: T
   utils: QueryCollectionUtils<
     InferSchemaOutput<T>,
@@ -352,12 +346,7 @@ export function queryCollectionOptions<
     schema?: never // prohibit schema
     select: (data: TQueryData) => Array<T>
   }
-): CollectionConfig<
-  T,
-  TKey,
-  never,
-  QueryCollectionUtils<T, TKey, T, TError>
-> & {
+): CollectionConfig<T, TKey, never, UtilsRecord> & {
   schema?: never // no schema in the result
   utils: QueryCollectionUtils<T, TKey, T, TError>
 }
@@ -381,12 +370,7 @@ export function queryCollectionOptions<
   > & {
     schema: T
   }
-): CollectionConfig<
-  InferSchemaOutput<T>,
-  TKey,
-  T,
-  QueryCollectionUtils<InferSchemaOutput<T>, TKey, InferSchemaInput<T>, TError>
-> & {
+): CollectionConfig<InferSchemaOutput<T>, TKey, T, UtilsRecord> & {
   schema: T
   utils: QueryCollectionUtils<
     InferSchemaOutput<T>,
@@ -412,12 +396,7 @@ export function queryCollectionOptions<
   > & {
     schema?: never // prohibit schema
   }
-): CollectionConfig<
-  T,
-  TKey,
-  never,
-  QueryCollectionUtils<T, TKey, T, TError>
-> & {
+): CollectionConfig<T, TKey, never, UtilsRecord> & {
   schema?: never // no schema in the result
   utils: QueryCollectionUtils<T, TKey, T, TError>
 }
@@ -428,7 +407,7 @@ export function queryCollectionOptions(
   Record<string, unknown>,
   string | number,
   never,
-  QueryCollectionUtils
+  UtilsRecord
 > & {
   utils: QueryCollectionUtils
 } {
@@ -522,14 +501,6 @@ export function queryCollectionOptions(
 
     // Store reference for imperative refetch
     queryObserver = localObserver
-
-    // Initialize query state with current observer state
-    const initialResult = localObserver.getCurrentResult()
-    queryState.isFetching = initialResult.isFetching
-    queryState.isRefetching = initialResult.isRefetching
-    queryState.isLoading = initialResult.isLoading
-    queryState.dataUpdatedAt = initialResult.dataUpdatedAt
-    queryState.fetchStatus = initialResult.fetchStatus
 
     let isSubscribed = false
     let actualUnsubscribeFn: (() => void) | null = null

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -2097,7 +2097,7 @@ describe(`QueryCollection`, () => {
     const collection2 = createCollection(options2)
 
     await vi.waitFor(() => {
-      expect(collection1.utils.isError()).toBe(true)
+      expect(collection1.utils.isError).toBe(true)
       expect(collection2.status).toBe(`ready`)
     })
 


### PR DESCRIPTION
Adds new utility methods to QueryCollectionUtils to expose TanStack Query's QueryObserver state, addressing user request for visibility into sync status:

New utils exposed:
- isFetching() - Check if query is currently fetching (initial or background)
- isRefetching() - Check if query is refetching in background
- isLoading() - Check if query is loading for first time
- dataUpdatedAt() - Get timestamp of last successful data update
- fetchStatus() - Get current fetch status ('fetching' | 'paused' | 'idle')

This allows users to:
- Show loading indicators during background refetches
- Implement "Last updated X minutes ago" UI patterns
- Understand sync behavior beyond just error states

Resolves user request from Discord where status is always 'ready' after initial load, making it impossible to know if background refetches are happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
