### PR TITLE
Fix flaky test

### DIFF
--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -903,13 +903,13 @@ describe(`Query Collections`, () => {
     await waitFor(() => {
       // Verify optimistic state is immediately reflected
       expect(result.current.state.size).toBe(4)
+      expect(result.current.state.get(`[temp-key,1]`)).toMatchObject({
+        id: `temp-key`,
+        name: `John Doe`,
+        title: `New Issue`,
+      })
+      expect(result.current.state.get(`[4,1]`)).toBeUndefined()
     })
-    expect(result.current.state.get(`[temp-key,1]`)).toMatchObject({
-      id: `temp-key`,
-      name: `John Doe`,
-      title: `New Issue`,
-    })
-    expect(result.current.state.get(`[4,1]`)).toBeUndefined()
 
     // Wait for the transaction to be committed
     await transaction.isPersisted.promise


### PR DESCRIPTION
Fixes https://github.com/TanStack/db/issues/417

The test "optimistic state is dropped after commit" was flaky because it had a race condition:
1. The test would wait for state size to become 4
2. Then immediately check that the temp-key exists
3. However, the async mutation (with only 10ms delay) could complete between steps 1 and 2

Fixed by moving all assertions into the same waitFor() block, ensuring they execute atomically. This prevents the mutation from completing between the size check and the temp-key verification.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
