### PR TITLE
Investigate Size Change action minification

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,12 +54,14 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./packages/db/dist/**/*.{js,mjs}"
           comment-key: "db-package-size"
+          build-script: "build:minified"
       - name: Compressed Size Action - React DB Package
         uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./packages/react-db/dist/**/*.{js,mjs}"
           comment-key: "react-db-package-size"
+          build-script: "build:minified"
   build-example:
     name: Build Example Site
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter \"./packages/**\" build",
+    "build:minified": "pnpm --filter \"./packages/**\" build:minified",
     "changeset": "changeset",
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version && pnpm install --no-frozen-lockfile",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -49,6 +49,7 @@
   ],
   "scripts": {
     "build": "vite build",
+    "build:minified": "vite build --minify",
     "dev": "vite build --watch",
     "lint": "eslint . --fix",
     "test": "npx vitest --run"

--- a/packages/react-db/package.json
+++ b/packages/react-db/package.json
@@ -54,6 +54,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "build:minified": "vite build --minify",
     "dev": "vite build --watch",
     "test": "npx vitest --run",
     "lint": "eslint . --fix"


### PR DESCRIPTION
Add build:minified scripts that enable minification during builds, and configure the compressed-size-action to use these scripts.

This ensures that bundle size measurements in PRs reflect actual code changes rather than being inflated by comments and whitespace, while keeping the published packages readable and unminified.

Changes:
- Add build:minified script to root package.json
- Add build:minified scripts to @tanstack/db and @tanstack/react-db
- Configure compressed-size-action to use build:minified script

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
