### PR TITLE
grouped orderby+limit in db-ivm (groundwork for includes in db)

### DIFF
--- a/.changeset/kind-squids-rest.md
+++ b/.changeset/kind-squids-rest.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/db-ivm": patch
+"@tanstack/db": patch
+---
+
+Add `groupByKey` and `groupKeyFn` options to `orderByWithFractionalIndex` and `topKWithFractionalIndex`. This is groundwork for hierarchical “includes” projections in TanStack DB, where child collections need to enforce limits within each parent’s slice of the stream rather than across the entire dataset. ([Issue #288](https://github.com/TanStack/db/issues/288))

--- a/packages/db-ivm/src/operators/topKWithFractionalIndexBTree.ts
+++ b/packages/db-ivm/src/operators/topKWithFractionalIndexBTree.ts
@@ -277,9 +277,9 @@ export class TopKWithFractionalIndexBTreeOperator<
  */
 export function topKWithFractionalIndexBTree<KType, T>(
   comparator: (a: T, b: T) => number,
-  options?: TopKWithFractionalIndexOptions
+  options?: TopKWithFractionalIndexOptions<KType, T>
 ): PipedOperator<[KType, T], [KType, IndexedValue<T>]> {
-  const opts = options || {}
+  const opts: TopKWithFractionalIndexOptions<KType, T> = options ?? {}
 
   if (BTree === undefined) {
     throw new Error(

--- a/packages/db/src/query/compiler/order-by.ts
+++ b/packages/db/src/query/compiler/order-by.ts
@@ -197,6 +197,7 @@ export function processOrderBy(
       limit,
       offset,
       comparator: compare,
+      groupByKey: false,
       setSizeCallback,
       setWindowFn: (
         windowFn: (options: { offset?: number; limit?: number }) => void


### PR DESCRIPTION
## THIS IS A DRAFT, DO NOT REVIEW

## Summary
- Teach `topKWithFractionalIndex` (array + B-tree) to optionally group by stream keys, maintaining independent windows per group while preserving the global behaviour by default.  
- Thread new `groupByKey` / `groupKeyFn` options through `orderByWithFractionalIndex`, disable grouping for existing compiled queries, and document the multi-element key heuristic.  
- Expand `orderByWithFractionalIndex.test.ts` to cover per-group ordering and incremental updates so regressions are caught.

## Motivation
This is groundwork for hierarchical “includes” projections in TanStack DB, where child collections need to enforce limits within each parent’s slice of the stream rather than across the entire dataset. ([Issue #288](https://github.com/TanStack/db/issues/288))

## Testing
- `pnpm --filter @tanstack/db-ivm test`
- `pnpm --filter @tanstack/db-ivm test -- tests/operators/orderByWithFractionalIndex.test.ts`