### PR TITLE
[paced mutations]: Fix how we init AsyncQueuer

### DIFF
--- a/.changeset/fix-async-queuer-constructor.md
+++ b/.changeset/fix-async-queuer-constructor.md
@@ -2,13 +2,14 @@
 "@tanstack/db": patch
 ---
 
-Fix queueStrategy implementation to use asyncQueue helper
+Fix queueStrategy to use AsyncQueuer constructor correctly
 
-The previous implementation incorrectly instantiated `AsyncQueuer` directly, which caused TypeScript build errors due to constructor signature mismatches. This fix switches to using the `asyncQueue` helper function from `@tanstack/pacer`, which provides the correct API for creating queued task processors.
+The previous implementation incorrectly instantiated `AsyncQueuer` with only an options object, but the constructor requires both a processing function and options. This caused TypeScript build errors.
 
 Changes:
-- Use `asyncQueue()` helper instead of `new AsyncQueuer()`
-- Properly pass task processing function and options to asyncQueue
-- Remove cleanup methods that aren't exposed by asyncQueue (not needed as queue is garbage collected)
+- Pass both processing function and options to `new AsyncQueuer(fn, options)`
+- The processing function receives tasks and executes them asynchronously
+- Properly configure concurrency, wait time, and queue position options
+- Restore cleanup methods (stop/clear) for proper resource management
 
 This resolves the type check errors that were preventing builds from completing.


### PR DESCRIPTION
The AsyncQueuer constructor signature requires:
1. A function that processes each queued item as the first parameter
2. An options object as the second parameter

The previous code incorrectly passed only the options object, causing TypeScript errors:
- 'concurrency' does not exist in type '(item void) => Promise<any>'
- Argument of type '() => Promise<void>' is not assignable to parameter type 'void'

Fixed by:
- Changing AsyncQueuer type parameter from void to () => Promise<void>
- Passing an async function as the first parameter that executes queued tasks
- Moving options to the second parameter

This resolves the type check errors that were appearing in test runs.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
