### PR TITLE
Powersync docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -105,6 +105,10 @@
         {
           "label": "RxDB Collection",
           "to": "collections/rxdb-collection"
+        },
+        {
+          "label": "PowerSync Collection",
+          "to": "collections/powersync-collection"
         }
       ]
     },
@@ -171,6 +175,14 @@
         {
           "label": "rxdbCollectionOptions",
           "to": "reference/rxdb-db-collection/functions/rxdbcollectionoptions"
+        },
+        {
+          "label": "PowerSync Collection",
+          "to": "reference/powersync-db-collection/index"
+        },
+        {
+          "label": "powersyncCollectionOptions",
+          "to": "reference/powersync-db-collection/functions/powerSyncCollectionOptions"
         }
       ],
       "frameworks": [

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -143,6 +143,8 @@ TanStack DB provides several built-in collection types for different data source
 
 - **[RxDBCollection](./collections/rxdb-collection.md)** &mdash; Integrate with RxDB for offline-first local persistence with powerful replication and sync capabilities.
 
+- **[PowerSyncCollection](./collections/powersync-collection.md)** &mdash; Sync with PowerSync's SQLite-based database for offline-first persistence with real-time synchronization with PostgreSQL, MongoDB, and MySQL backends.
+
 **Local Collections**
 
 - **[LocalStorageCollection](./collections/local-storage-collection.md)** &mdash; Store small amounts of local-only state that persists across sessions and syncs across browser tabs.

--- a/docs/reference/powersync-db-collection/classes/PowerSyncTransactor.md
+++ b/docs/reference/powersync-db-collection/classes/PowerSyncTransactor.md
@@ -1,0 +1,240 @@
+---
+id: PowerSyncTransactor
+title: PowerSyncTransactor
+---
+
+# Class: PowerSyncTransactor
+
+Defined in: [PowerSyncTransactor.ts:51](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L51)
+
+Applies mutations to the PowerSync database. This method is called automatically by the collection's
+insert, update, and delete operations. You typically don't need to call this directly unless you
+have special transaction requirements.
+
+## Example
+
+```typescript
+// Create a collection
+const collection = createCollection(
+  powerSyncCollectionOptions<Document>({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+  })
+)
+
+const addTx = createTransaction({
+  autoCommit: false,
+  mutationFn: async ({ transaction }) => {
+    await new PowerSyncTransactor({ database: db }).applyTransaction(transaction)
+  },
+})
+
+addTx.mutate(() => {
+  for (let i = 0; i < 5; i++) {
+    collection.insert({ id: randomUUID(), name: `tx-${i}` })
+  }
+})
+
+await addTx.commit()
+await addTx.isPersisted.promise
+```
+
+## Param
+
+The transaction containing mutations to apply
+
+## Constructors
+
+### Constructor
+
+```ts
+new PowerSyncTransactor(options): PowerSyncTransactor;
+```
+
+Defined in: [PowerSyncTransactor.ts:55](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L55)
+
+#### Parameters
+
+##### options
+
+[`TransactorOptions`](../type-aliases/TransactorOptions.md)
+
+#### Returns
+
+`PowerSyncTransactor`
+
+## Properties
+
+### database
+
+```ts
+database: AbstractPowerSyncDatabase;
+```
+
+Defined in: [PowerSyncTransactor.ts:52](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L52)
+
+***
+
+### pendingOperationStore
+
+```ts
+pendingOperationStore: PendingOperationStore;
+```
+
+Defined in: [PowerSyncTransactor.ts:53](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L53)
+
+## Methods
+
+### applyTransaction()
+
+```ts
+applyTransaction(transaction): Promise<void>;
+```
+
+Defined in: [PowerSyncTransactor.ts:63](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L63)
+
+Persists a Transaction to the PowerSync SQLite database.
+
+#### Parameters
+
+##### transaction
+
+`Transaction`\<`any`\>
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### handleDelete()
+
+```ts
+protected handleDelete(
+   mutation, 
+   context, 
+waitForCompletion): Promise<PendingOperation | null>;
+```
+
+Defined in: [PowerSyncTransactor.ts:204](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L204)
+
+#### Parameters
+
+##### mutation
+
+`PendingMutation`\<`any`\>
+
+##### context
+
+`LockContext`
+
+##### waitForCompletion
+
+`boolean` = `false`
+
+#### Returns
+
+`Promise`\<`PendingOperation` \| `null`\>
+
+***
+
+### handleInsert()
+
+```ts
+protected handleInsert(
+   mutation, 
+   context, 
+waitForCompletion): Promise<PendingOperation | null>;
+```
+
+Defined in: [PowerSyncTransactor.ts:149](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L149)
+
+#### Parameters
+
+##### mutation
+
+`PendingMutation`\<`any`\>
+
+##### context
+
+`LockContext`
+
+##### waitForCompletion
+
+`boolean` = `false`
+
+#### Returns
+
+`Promise`\<`PendingOperation` \| `null`\>
+
+***
+
+### handleOperationWithCompletion()
+
+```ts
+protected handleOperationWithCompletion(
+   mutation, 
+   context, 
+   waitForCompletion, 
+handler): Promise<PendingOperation | null>;
+```
+
+Defined in: [PowerSyncTransactor.ts:232](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L232)
+
+Helper function which wraps a persistence operation by:
+- Fetching the mutation's collection's SQLite table details
+- Executing the mutation
+- Returning the last pending diff operation if required
+
+#### Parameters
+
+##### mutation
+
+`PendingMutation`\<`any`\>
+
+##### context
+
+`LockContext`
+
+##### waitForCompletion
+
+`boolean`
+
+##### handler
+
+(`tableName`, `mutation`, `serializeValue`) => `Promise`\<`void`\>
+
+#### Returns
+
+`Promise`\<`PendingOperation` \| `null`\>
+
+***
+
+### handleUpdate()
+
+```ts
+protected handleUpdate(
+   mutation, 
+   context, 
+waitForCompletion): Promise<PendingOperation | null>;
+```
+
+Defined in: [PowerSyncTransactor.ts:177](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L177)
+
+#### Parameters
+
+##### mutation
+
+`PendingMutation`\<`any`\>
+
+##### context
+
+`LockContext`
+
+##### waitForCompletion
+
+`boolean` = `false`
+
+#### Returns
+
+`Promise`\<`PendingOperation` \| `null`\>

--- a/docs/reference/powersync-db-collection/functions/powerSyncCollectionOptions.md
+++ b/docs/reference/powersync-db-collection/functions/powerSyncCollectionOptions.md
@@ -1,0 +1,213 @@
+---
+id: powerSyncCollectionOptions
+title: powerSyncCollectionOptions
+---
+
+# Function: powerSyncCollectionOptions()
+
+Implementation of powerSyncCollectionOptions that handles both schema and non-schema configurations.
+
+## Call Signature
+
+```ts
+function powerSyncCollectionOptions<TTable>(config): EnhancedPowerSyncCollectionConfig<TTable, OptionalExtractedTable<TTable>, never>;
+```
+
+Defined in: [powersync.ts:71](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/powersync.ts#L71)
+
+Creates a PowerSync collection configuration with basic default validation.
+Input and Output types are the SQLite column types.
+
+### Type Parameters
+
+#### TTable
+
+`TTable` *extends* `Table`\<`ColumnsType`\> = `Table`\<`ColumnsType`\>
+
+### Parameters
+
+#### config
+
+`Omit`\<`BaseCollectionConfig`\<`ExtractedTable`\<`TTable`\>, `string`, `never`, `UtilsRecord`, `any`\>, `"onInsert"` \| `"onUpdate"` \| `"onDelete"` \| `"getKey"`\> & `object`
+
+### Returns
+
+[`EnhancedPowerSyncCollectionConfig`](../type-aliases/EnhancedPowerSyncCollectionConfig.md)\<`TTable`, `OptionalExtractedTable`\<`TTable`\>, `never`\>
+
+### Example
+
+```typescript
+const APP_SCHEMA = new Schema({
+  documents: new Table({
+    name: column.text,
+  }),
+})
+
+type Document = (typeof APP_SCHEMA)["types"]["documents"]
+
+const db = new PowerSyncDatabase({
+  database: {
+    dbFilename: "test.sqlite",
+  },
+  schema: APP_SCHEMA,
+})
+
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents
+  })
+)
+```
+
+## Call Signature
+
+```ts
+function powerSyncCollectionOptions<TTable, TSchema>(config): CollectionConfig<InferPowerSyncOutputType<TTable, TSchema>, string, TSchema, UtilsRecord> & object & object;
+```
+
+Defined in: [powersync.ts:128](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/powersync.ts#L128)
+
+Creates a PowerSync collection configuration with schema validation.
+
+The input types satisfy the SQLite column types.
+
+The output types are defined by the provided schema. This schema can enforce additional
+validation or type transforms.
+Arbitrary output typed mutations are encoded to SQLite for persistence. We provide a basic standard
+serialization implementation to serialize column values. Custom or advanced types require providing additional
+serializer specifications. Partial column overrides can be supplied to `serializer`.
+
+### Type Parameters
+
+#### TTable
+
+`TTable` *extends* `Table`\<`ColumnsType`\>
+
+#### TSchema
+
+`TSchema` *extends* `StandardSchemaV1`\<`OptionalExtractedTable`\<`TTable`\>, `AnyTableColumnType`\<`TTable`\>\>
+
+### Parameters
+
+#### config
+
+`Omit`\<`BaseCollectionConfig`\<`ExtractedTable`\<`TTable`\>, `string`, `TSchema`, `UtilsRecord`, `any`\>, `"onInsert"` \| `"onUpdate"` \| `"onDelete"` \| `"getKey"`\> & `object` & [`SerializerConfig`](../type-aliases/SerializerConfig.md)\<`InferOutput`\<`TSchema`\>, `ExtractedTable`\<`TTable`\>\> & `object`
+
+### Returns
+
+`CollectionConfig`\<[`InferPowerSyncOutputType`](../type-aliases/InferPowerSyncOutputType.md)\<`TTable`, `TSchema`\>, `string`, `TSchema`, `UtilsRecord`\> & `object` & `object`
+
+### Example
+
+```typescript
+import { z } from "zod"
+
+// The PowerSync SQLite schema
+const APP_SCHEMA = new Schema({
+  documents: new Table({
+    name: column.text,
+    // Dates are stored as ISO date strings in SQLite
+    created_at: column.text
+  }),
+})
+
+// Advanced Zod validations. The output type of this schema
+// is constrained to the SQLite schema of APP_SCHEMA
+const schema = z.object({
+  id: z.string(),
+  // Notice that `name` is not nullable (is required) here and it has additional validation
+  name: z.string().min(3, { message: "Should be at least 3 characters" }).nullable(),
+  // The input type is still the SQLite string type. While collections will output smart Date instances.
+  created_at: z.string().transform(val => new Date(val))
+})
+
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+    schema,
+    serializer: {
+       // The default is toISOString, this is just to demonstrate custom overrides
+       created_at: (outputValue) => outputValue.toISOString(),
+    },
+  })
+)
+```
+
+## Call Signature
+
+```ts
+function powerSyncCollectionOptions<TTable, TSchema>(config): CollectionConfig<InferPowerSyncOutputType<TTable, TSchema>, string, TSchema, UtilsRecord> & object & object;
+```
+
+Defined in: [powersync.ts:196](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/powersync.ts#L196)
+
+Creates a PowerSync collection configuration with schema validation.
+
+The input types are not linked to the internal SQLite table types. This can
+give greater flexibility, e.g. by accepting rich types as input for `insert` or `update` operations.
+An additional `deserializationSchema` is required in order to process incoming SQLite updates to the output type.
+
+The output types are defined by the provided schema. This schema can enforce additional
+validation or type transforms.
+Arbitrary output typed mutations are encoded to SQLite for persistence. We provide a basic standard
+serialization implementation to serialize column values. Custom or advanced types require providing additional
+serializer specifications. Partial column overrides can be supplied to `serializer`.
+
+### Type Parameters
+
+#### TTable
+
+`TTable` *extends* `Table`\<`ColumnsType`\>
+
+#### TSchema
+
+`TSchema` *extends* `StandardSchemaV1`\<`AnyTableColumnType`\<`TTable`\>, `AnyTableColumnType`\<`TTable`\>\>
+
+### Parameters
+
+#### config
+
+`Omit`\<`BaseCollectionConfig`\<`ExtractedTable`\<`TTable`\>, `string`, `TSchema`, `UtilsRecord`, `any`\>, `"onInsert"` \| `"onUpdate"` \| `"onDelete"` \| `"getKey"`\> & `object` & [`SerializerConfig`](../type-aliases/SerializerConfig.md)\<`InferOutput`\<`TSchema`\>, `ExtractedTable`\<`TTable`\>\> & `object`
+
+### Returns
+
+`CollectionConfig`\<[`InferPowerSyncOutputType`](../type-aliases/InferPowerSyncOutputType.md)\<`TTable`, `TSchema`\>, `string`, `TSchema`, `UtilsRecord`\> & `object` & `object`
+
+### Example
+
+```typescript
+import { z } from "zod"
+
+// The PowerSync SQLite schema
+const APP_SCHEMA = new Schema({
+  documents: new Table({
+    name: column.text,
+    // Booleans are represented as integers in SQLite
+    is_active: column.integer
+  }),
+})
+
+// Advanced Zod validations.
+// We accept boolean values as input for operations and expose Booleans in query results
+const schema = z.object({
+  id: z.string(),
+  isActive: z.boolean(), // TInput and TOutput are boolean
+})
+
+// The deserializationSchema converts the SQLite synced INTEGER (0/1) values to booleans.
+const deserializationSchema = z.object({
+  id: z.string(),
+  isActive: z.number().nullable().transform((val) => val == null ? true : val > 0),
+})
+
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+    schema,
+    deserializationSchema,
+  })
+)
+```

--- a/docs/reference/powersync-db-collection/index.md
+++ b/docs/reference/powersync-db-collection/index.md
@@ -1,0 +1,33 @@
+---
+id: "@tanstack/powersync-db-collection"
+title: "@tanstack/powersync-db-collection"
+---
+
+# @tanstack/powersync-db-collection
+
+## Classes
+
+- [PowerSyncTransactor](classes/PowerSyncTransactor.md)
+
+## Type Aliases
+
+- [BasePowerSyncCollectionConfig](type-aliases/BasePowerSyncCollectionConfig.md)
+- [ConfigWithArbitraryCollectionTypes](type-aliases/ConfigWithArbitraryCollectionTypes.md)
+- [ConfigWithSQLiteInputType](type-aliases/ConfigWithSQLiteInputType.md)
+- [ConfigWithSQLiteTypes](type-aliases/ConfigWithSQLiteTypes.md)
+- [CustomSQLiteSerializer](type-aliases/CustomSQLiteSerializer.md)
+- [EnhancedPowerSyncCollectionConfig](type-aliases/EnhancedPowerSyncCollectionConfig.md)
+- [InferPowerSyncOutputType](type-aliases/InferPowerSyncOutputType.md)
+- [PowerSyncCollectionConfig](type-aliases/PowerSyncCollectionConfig.md)
+- [PowerSyncCollectionMeta](type-aliases/PowerSyncCollectionMeta.md)
+- [PowerSyncCollectionUtils](type-aliases/PowerSyncCollectionUtils.md)
+- [SerializerConfig](type-aliases/SerializerConfig.md)
+- [TransactorOptions](type-aliases/TransactorOptions.md)
+
+## Variables
+
+- [DEFAULT\_BATCH\_SIZE](variables/DEFAULT_BATCH_SIZE.md)
+
+## Functions
+
+- [powerSyncCollectionOptions](functions/powerSyncCollectionOptions.md)

--- a/docs/reference/powersync-db-collection/type-aliases/BasePowerSyncCollectionConfig.md
+++ b/docs/reference/powersync-db-collection/type-aliases/BasePowerSyncCollectionConfig.md
@@ -1,0 +1,58 @@
+---
+id: BasePowerSyncCollectionConfig
+title: BasePowerSyncCollectionConfig
+---
+
+# Type Alias: BasePowerSyncCollectionConfig\<TTable, TSchema\>
+
+```ts
+type BasePowerSyncCollectionConfig<TTable, TSchema> = Omit<BaseCollectionConfig<ExtractedTable<TTable>, string, TSchema>, "onInsert" | "onUpdate" | "onDelete" | "getKey"> & object;
+```
+
+Defined in: [definitions.ts:165](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L165)
+
+## Type Declaration
+
+### database
+
+```ts
+database: AbstractPowerSyncDatabase;
+```
+
+The PowerSync database instance
+
+### syncBatchSize?
+
+```ts
+optional syncBatchSize: number;
+```
+
+The maximum number of documents to read from the SQLite table
+in a single batch during the initial sync between PowerSync and the
+in-memory TanStack DB collection.
+
+#### Remarks
+
+- Defaults to [DEFAULT\_BATCH\_SIZE](../variables/DEFAULT_BATCH_SIZE.md) if not specified.
+- Larger values reduce the number of round trips to the storage
+  engine but increase memory usage per batch.
+- Smaller values may lower memory usage and allow earlier
+  streaming of initial results, at the cost of more query calls.
+
+### table
+
+```ts
+table: TTable;
+```
+
+The PowerSync schema Table definition
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table` = `Table`
+
+### TSchema
+
+`TSchema` *extends* `StandardSchemaV1` = `never`

--- a/docs/reference/powersync-db-collection/type-aliases/ConfigWithArbitraryCollectionTypes.md
+++ b/docs/reference/powersync-db-collection/type-aliases/ConfigWithArbitraryCollectionTypes.md
@@ -1,0 +1,62 @@
+---
+id: ConfigWithArbitraryCollectionTypes
+title: ConfigWithArbitraryCollectionTypes
+---
+
+# Type Alias: ConfigWithArbitraryCollectionTypes\<TTable, TSchema\>
+
+```ts
+type ConfigWithArbitraryCollectionTypes<TTable, TSchema> = SerializerConfig<StandardSchemaV1.InferOutput<TSchema>, ExtractedTable<TTable>> & object;
+```
+
+Defined in: [definitions.ts:125](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L125)
+
+Config where TInput and TOutput have arbitrarily typed values.
+The keys of the types need to equal the SQLite types.
+Since TInput is not the SQLite types, we require a schema in order to deserialize incoming SQLite updates. The schema should validate from SQLite to TOutput.
+
+## Type Declaration
+
+### deserializationSchema
+
+```ts
+deserializationSchema: StandardSchemaV1<ExtractedTable<TTable>, StandardSchemaV1.InferOutput<TSchema>>;
+```
+
+Schema for deserializing and validating input data from the sync stream.
+
+This schema defines how to transform and validate data coming from SQLite types (as stored in the database)
+into the desired output types (`TOutput`) expected by your application or validation logic.
+
+The generic parameters allow for arbitrary input and output types, so you can specify custom conversion rules
+for each column. This is especially useful when your application expects richer types (e.g., Date, enums, objects)
+than what SQLite natively supports.
+
+Use this to ensure that incoming data from the sync stream is properly converted and validated before use.
+
+Example:
+```typescript
+deserializationSchema: z.object({
+  createdAt: z.preprocess((val) => new Date(val as string), z.date()),
+  meta: z.preprocess((val) => JSON.parse(val as string), z.object({ ... })),
+})
+```
+
+This enables robust type safety and validation for incoming data, bridging the gap between SQLite storage
+and your application's expected types.
+
+### schema
+
+```ts
+schema: TSchema;
+```
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table`
+
+### TSchema
+
+`TSchema` *extends* `StandardSchemaV1`\<`AnyTableColumnType`\<`TTable`\>, `AnyTableColumnType`\<`TTable`\>\>

--- a/docs/reference/powersync-db-collection/type-aliases/ConfigWithSQLiteInputType.md
+++ b/docs/reference/powersync-db-collection/type-aliases/ConfigWithSQLiteInputType.md
@@ -1,0 +1,33 @@
+---
+id: ConfigWithSQLiteInputType
+title: ConfigWithSQLiteInputType
+---
+
+# Type Alias: ConfigWithSQLiteInputType\<TTable, TSchema\>
+
+```ts
+type ConfigWithSQLiteInputType<TTable, TSchema> = SerializerConfig<StandardSchemaV1.InferOutput<TSchema>, ExtractedTable<TTable>> & object;
+```
+
+Defined in: [definitions.ts:106](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L106)
+
+Config where TInput is the SQLite types while TOutput can be defined by TSchema.
+We can use the same schema to validate TInput and incoming SQLite changes.
+
+## Type Declaration
+
+### schema
+
+```ts
+schema: TSchema;
+```
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table`
+
+### TSchema
+
+`TSchema` *extends* `StandardSchemaV1`\<`OptionalExtractedTable`\<`TTable`\>, `AnyTableColumnType`\<`TTable`\>\>

--- a/docs/reference/powersync-db-collection/type-aliases/ConfigWithSQLiteTypes.md
+++ b/docs/reference/powersync-db-collection/type-aliases/ConfigWithSQLiteTypes.md
@@ -1,0 +1,14 @@
+---
+id: ConfigWithSQLiteTypes
+title: ConfigWithSQLiteTypes
+---
+
+# Type Alias: ConfigWithSQLiteTypes
+
+```ts
+type ConfigWithSQLiteTypes = object;
+```
+
+Defined in: [definitions.ts:100](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L100)
+
+Config for when TInput and TOutput are both the SQLite types.

--- a/docs/reference/powersync-db-collection/type-aliases/CustomSQLiteSerializer.md
+++ b/docs/reference/powersync-db-collection/type-aliases/CustomSQLiteSerializer.md
@@ -1,0 +1,48 @@
+---
+id: CustomSQLiteSerializer
+title: CustomSQLiteSerializer
+---
+
+# Type Alias: CustomSQLiteSerializer\<TOutput, TSQLite\>
+
+```ts
+type CustomSQLiteSerializer<TOutput, TSQLite> = Partial<{ [Key in keyof TOutput]: (value: TOutput[Key]) => Key extends keyof TSQLite ? TSQLite[Key] : never }>;
+```
+
+Defined in: [definitions.ts:52](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L52)
+
+A mapping type for custom serialization of object properties to SQLite-compatible values.
+
+This type allows you to override, for keys in the input object (`TOutput`), a function that transforms
+the value to the corresponding SQLite type (`TSQLite`). Keys not specified will use the default SQLite serialization.
+
+## Generics
+- `TOutput`: The input object type, representing the row data to be serialized.
+- `TSQLite`: The target SQLite-compatible type for each property, typically inferred from the table schema.
+
+## Usage
+Use this type to define a map of serialization functions for specific keys when you need custom handling
+(e.g., converting complex objects, formatting dates, or handling enums).
+
+Example:
+```ts
+const serializer: CustomSQLiteSerializer<MyRowType, MySQLiteType> = {
+  createdAt: (date) => date.toISOString(),
+  status: (status) => status ? 1 : 0,
+  meta: (meta) => JSON.stringify(meta),
+};
+```
+
+## Behavior
+- Each key maps to a function that receives the value and returns the SQLite-compatible value.
+- Used by `serializeForSQLite` to override default serialization for specific columns.
+
+## Type Parameters
+
+### TOutput
+
+`TOutput` *extends* `Record`\<`string`, `unknown`\>
+
+### TSQLite
+
+`TSQLite` *extends* `Record`\<`string`, `unknown`\>

--- a/docs/reference/powersync-db-collection/type-aliases/EnhancedPowerSyncCollectionConfig.md
+++ b/docs/reference/powersync-db-collection/type-aliases/EnhancedPowerSyncCollectionConfig.md
@@ -1,0 +1,48 @@
+---
+id: EnhancedPowerSyncCollectionConfig
+title: EnhancedPowerSyncCollectionConfig
+---
+
+# Type Alias: EnhancedPowerSyncCollectionConfig\<TTable, OutputType, TSchema\>
+
+```ts
+type EnhancedPowerSyncCollectionConfig<TTable, OutputType, TSchema> = CollectionConfig<OutputType, string, TSchema> & object;
+```
+
+Defined in: [definitions.ts:254](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L254)
+
+A CollectionConfig which includes utilities for PowerSync.
+
+## Type Declaration
+
+### id?
+
+```ts
+optional id: string;
+```
+
+### schema?
+
+```ts
+optional schema: TSchema;
+```
+
+### utils
+
+```ts
+utils: PowerSyncCollectionUtils<TTable>;
+```
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table`
+
+### OutputType
+
+`OutputType` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
+
+### TSchema
+
+`TSchema` *extends* `StandardSchemaV1` = `never`

--- a/docs/reference/powersync-db-collection/type-aliases/InferPowerSyncOutputType.md
+++ b/docs/reference/powersync-db-collection/type-aliases/InferPowerSyncOutputType.md
@@ -1,0 +1,26 @@
+---
+id: InferPowerSyncOutputType
+title: InferPowerSyncOutputType
+---
+
+# Type Alias: InferPowerSyncOutputType\<TTable, TSchema\>
+
+```ts
+type InferPowerSyncOutputType<TTable, TSchema> = TSchema extends never ? ExtractedTable<TTable> : InferSchemaOutput<TSchema>;
+```
+
+Defined in: [definitions.ts:20](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L20)
+
+Small helper which determines the output type if:
+- Standard SQLite types are to be used OR
+- If the provided schema should be used.
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table` = `Table`
+
+### TSchema
+
+`TSchema` *extends* `StandardSchemaV1`\<`PowerSyncRecord`\> = `never`

--- a/docs/reference/powersync-db-collection/type-aliases/PowerSyncCollectionConfig.md
+++ b/docs/reference/powersync-db-collection/type-aliases/PowerSyncCollectionConfig.md
@@ -1,0 +1,51 @@
+---
+id: PowerSyncCollectionConfig
+title: PowerSyncCollectionConfig
+---
+
+# Type Alias: PowerSyncCollectionConfig\<TTable, TSchema\>
+
+```ts
+type PowerSyncCollectionConfig<TTable, TSchema> = BasePowerSyncCollectionConfig<TTable, TSchema> & 
+  | ConfigWithSQLiteTypes
+  | ConfigWithSQLiteInputType<TTable, TSchema>
+| ConfigWithArbitraryCollectionTypes<TTable, TSchema>;
+```
+
+Defined in: [definitions.ts:222](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L222)
+
+Configuration options for creating a PowerSync collection.
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table` = `Table`
+
+### TSchema
+
+`TSchema` *extends* `StandardSchemaV1`\<`any`\> = `never`
+
+## Example
+
+```typescript
+const APP_SCHEMA = new Schema({
+  documents: new Table({
+    name: column.text,
+  }),
+})
+
+const db = new PowerSyncDatabase({
+  database: {
+    dbFilename: "test.sqlite",
+  },
+  schema: APP_SCHEMA,
+})
+
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents
+  })
+)
+```

--- a/docs/reference/powersync-db-collection/type-aliases/PowerSyncCollectionMeta.md
+++ b/docs/reference/powersync-db-collection/type-aliases/PowerSyncCollectionMeta.md
@@ -1,0 +1,66 @@
+---
+id: PowerSyncCollectionMeta
+title: PowerSyncCollectionMeta
+---
+
+# Type Alias: PowerSyncCollectionMeta\<TTable\>
+
+```ts
+type PowerSyncCollectionMeta<TTable> = object;
+```
+
+Defined in: [definitions.ts:235](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L235)
+
+Metadata for the PowerSync Collection.
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table` = `Table`
+
+## Properties
+
+### serializeValue()
+
+```ts
+serializeValue: (value) => ExtractedTable<TTable>;
+```
+
+Defined in: [definitions.ts:248](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L248)
+
+Serializes a collection value to the SQLite type
+
+#### Parameters
+
+##### value
+
+`any`
+
+#### Returns
+
+`ExtractedTable`\<`TTable`\>
+
+***
+
+### tableName
+
+```ts
+tableName: string;
+```
+
+Defined in: [definitions.ts:239](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L239)
+
+The SQLite table representing the collection.
+
+***
+
+### trackedTableName
+
+```ts
+trackedTableName: string;
+```
+
+Defined in: [definitions.ts:243](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L243)
+
+The internal table used to track diffs for the collection.

--- a/docs/reference/powersync-db-collection/type-aliases/PowerSyncCollectionUtils.md
+++ b/docs/reference/powersync-db-collection/type-aliases/PowerSyncCollectionUtils.md
@@ -1,0 +1,34 @@
+---
+id: PowerSyncCollectionUtils
+title: PowerSyncCollectionUtils
+---
+
+# Type Alias: PowerSyncCollectionUtils\<TTable\>
+
+```ts
+type PowerSyncCollectionUtils<TTable> = object;
+```
+
+Defined in: [definitions.ts:267](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L267)
+
+Collection-level utilities for PowerSync.
+
+## Type Parameters
+
+### TTable
+
+`TTable` *extends* `Table` = `Table`
+
+## Properties
+
+### getMeta()
+
+```ts
+getMeta: () => PowerSyncCollectionMeta<TTable>;
+```
+
+Defined in: [definitions.ts:268](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L268)
+
+#### Returns
+
+[`PowerSyncCollectionMeta`](PowerSyncCollectionMeta.md)\<`TTable`\>

--- a/docs/reference/powersync-db-collection/type-aliases/SerializerConfig.md
+++ b/docs/reference/powersync-db-collection/type-aliases/SerializerConfig.md
@@ -1,0 +1,77 @@
+---
+id: SerializerConfig
+title: SerializerConfig
+---
+
+# Type Alias: SerializerConfig\<TOutput, TSQLite\>
+
+```ts
+type SerializerConfig<TOutput, TSQLite> = object;
+```
+
+Defined in: [definitions.ts:61](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L61)
+
+## Type Parameters
+
+### TOutput
+
+`TOutput` *extends* `Record`\<`string`, `unknown`\>
+
+### TSQLite
+
+`TSQLite` *extends* `Record`\<`string`, `unknown`\>
+
+## Properties
+
+### onDeserializationError()
+
+```ts
+onDeserializationError: (error) => void;
+```
+
+Defined in: [definitions.ts:94](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L94)
+
+Application logic should ensure that incoming synced data is always valid.
+Failing to deserialize and apply incoming changes results in data inconsistency - which is a fatal error.
+Use this callback to react to deserialization errors.
+
+#### Parameters
+
+##### error
+
+`StandardSchemaV1.FailureResult`
+
+#### Returns
+
+`void`
+
+***
+
+### serializer?
+
+```ts
+optional serializer: CustomSQLiteSerializer<TOutput, TSQLite>;
+```
+
+Defined in: [definitions.ts:87](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L87)
+
+Optional partial serializer object for customizing how individual columns are serialized for SQLite.
+
+This should be a partial map of column keys to serialization functions, following the
+[CustomSQLiteSerializer](CustomSQLiteSerializer.md) type. Each function receives the column value and returns a value
+compatible with SQLite storage.
+
+If not provided for a column, the default behavior is used:
+  - `TEXT`: Strings are stored as-is; Dates are converted to ISO strings; other types are JSON-stringified.
+  - `INTEGER`/`REAL`: Numbers are stored as-is; booleans are mapped to 1/0.
+
+Use this option to override serialization for specific columns, such as formatting dates, handling enums,
+or serializing complex objects.
+
+Example:
+```typescript
+serializer: {
+  createdAt: (date) => date.getTime(), // Store as timestamp
+  meta: (meta) => JSON.stringify(meta), // Custom object serialization
+}
+```

--- a/docs/reference/powersync-db-collection/type-aliases/TransactorOptions.md
+++ b/docs/reference/powersync-db-collection/type-aliases/TransactorOptions.md
@@ -1,0 +1,22 @@
+---
+id: TransactorOptions
+title: TransactorOptions
+---
+
+# Type Alias: TransactorOptions
+
+```ts
+type TransactorOptions = object;
+```
+
+Defined in: [PowerSyncTransactor.ts:12](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L12)
+
+## Properties
+
+### database
+
+```ts
+database: AbstractPowerSyncDatabase;
+```
+
+Defined in: [PowerSyncTransactor.ts:13](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/PowerSyncTransactor.ts#L13)

--- a/docs/reference/powersync-db-collection/variables/DEFAULT_BATCH_SIZE.md
+++ b/docs/reference/powersync-db-collection/variables/DEFAULT_BATCH_SIZE.md
@@ -1,0 +1,14 @@
+---
+id: DEFAULT_BATCH_SIZE
+title: DEFAULT_BATCH_SIZE
+---
+
+# Variable: DEFAULT\_BATCH\_SIZE
+
+```ts
+const DEFAULT_BATCH_SIZE: 1000 = 1000;
+```
+
+Defined in: [definitions.ts:274](https://github.com/powersync-ja/temp-tanstack-db/blob/main/packages/powersync-db-collection/src/definitions.ts#L274)
+
+Default value for [PowerSyncCollectionConfig#syncBatchSize](../type-aliases/BasePowerSyncCollectionConfig.md).

--- a/scripts/generateDocs.ts
+++ b/scripts/generateDocs.ts
@@ -1,6 +1,6 @@
+import { readFileSync, writeFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { readFileSync, writeFileSync } from "node:fs"
 import { generateReferenceDocs } from "@tanstack/config/typedoc"
 import { glob } from "tinyglobby"
 
@@ -36,6 +36,21 @@ await generateReferenceDocs({
         `../packages/query-db-collection/tsconfig.docs.json`
       ),
       outputDir: resolve(__dirname, `../docs/reference/query-db-collection`),
+      exclude: [`packages/db/**/*`],
+    },
+    {
+      name: `powersync-db-collection`,
+      entryPoints: [
+        resolve(__dirname, `../packages/powersync-db-collection/src/index.ts`),
+      ],
+      tsconfig: resolve(
+        __dirname,
+        `../packages/powersync-db-collection/tsconfig.docs.json`
+      ),
+      outputDir: resolve(
+        __dirname,
+        `../docs/reference/powersync-db-collection`
+      ),
       exclude: [`packages/db/**/*`],
     },
     {


### PR DESCRIPTION
## 🎯 Changes

This adds doc entries for the recently introduced PowerSync collection from https://github.com/TanStack/db/pull/747

This only adds the generated docs (generated using the `generateDocs` script) for the `powersync-collection` section. The current docs might be outdated (or I've misunderstood something), since running the script generated many doc updates for other packages.

This has been tested locally with the `tanstack.com` repo.
<img width="1363" height="1044" alt="image" src="https://github.com/user-attachments/assets/f403e286-5311-4c85-a96b-a570e153484f" />

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
