### PR TITLE
Release new version of trailbase with changeset

### DIFF
--- a/packages/trailbase-db-collection/CHANGELOG.md
+++ b/packages/trailbase-db-collection/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tanstack/trailbase-db-collection
 
+## 0.1.43
+
+### Patch Changes
+
+- Trigger new release for trailbase-db-collection
+
+  Version 0.1.42 was already published to npm. This changeset bumps the version to 0.1.43 to allow for a new release.
+
 ## 0.1.42
 
 ### Patch Changes

--- a/packages/trailbase-db-collection/package.json
+++ b/packages/trailbase-db-collection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/trailbase-db-collection",
   "description": "TrailBase collection for TanStack DB",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
     "@tanstack/db": "workspace:*",


### PR DESCRIPTION
Version 0.1.42 was already published to npm in a previous release. This commit bumps the version to 0.1.43 to trigger a new release.