### PR TITLE
Loosen type for collections in offline transactions

### DIFF
--- a/packages/offline-transactions/src/outbox/OutboxManager.ts
+++ b/packages/offline-transactions/src/outbox/OutboxManager.ts
@@ -10,7 +10,8 @@ export class OutboxManager {
 
   constructor(
     storage: StorageAdapter,
-    collections: Record<string, Collection>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    collections: Record<string, Collection<any, any, any, any, any>>
   ) {
     this.storage = storage
     this.serializer = new TransactionSerializer(collections)

--- a/packages/offline-transactions/src/outbox/TransactionSerializer.ts
+++ b/packages/offline-transactions/src/outbox/TransactionSerializer.ts
@@ -7,10 +7,14 @@ import type {
 import type { Collection, PendingMutation } from "@tanstack/db"
 
 export class TransactionSerializer {
-  private collections: Record<string, Collection>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private collections: Record<string, Collection<any, any, any, any, any>>
   private collectionIdToKey: Map<string, string>
 
-  constructor(collections: Record<string, Collection>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(
+    collections: Record<string, Collection<any, any, any, any, any>>
+  ) {
     this.collections = collections
     // Create reverse lookup from collection.id to registry key
     this.collectionIdToKey = new Map()

--- a/packages/offline-transactions/src/types.ts
+++ b/packages/offline-transactions/src/types.ts
@@ -88,7 +88,8 @@ export interface StorageDiagnostic {
 }
 
 export interface OfflineConfig {
-  collections: Record<string, Collection>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  collections: Record<string, Collection<any, any, any, any, any>>
   mutationFns: Record<string, OfflineMutationFn>
   storage?: StorageAdapter
   maxConcurrency?: number


### PR DESCRIPTION
It should accept any collection.

Fixes #761

Previously, when using queryCollectionOptions with startOfflineExecutor, TypeScript would throw a type error due to Collection type parameter variance.

The issue occurred because:
- queryCollectionOptions creates Collection<ConcreteType, string>
- OfflineConfig expected Record<string, Collection> which defaults to Collection<Record<string, unknown>, string | number>
- TypeScript couldn't assign the more specific collection type to the more general expected type due to function parameter contravariance

Solution:
Updated OfflineConfig and related classes to explicitly accept Collection<any, any, any, any, any> to allow collections of any specific type to be passed in.

This is safe because the offline executor only accesses collection.id and doesn't call any type-specific methods like getKey directly.

Changes:
- OfflineConfig.collections type updated
- OutboxManager constructor parameter type updated
- TransactionSerializer constructor and field types updated

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
