### PR TITLE
Clarify LocalOnly collections use direct local mutations

### DIFF
--- a/docs/collections/local-only-collection.md
+++ b/docs/collections/local-only-collection.md
@@ -41,7 +41,7 @@ const uiStateCollection = createCollection(
 
 **Important:** LocalOnly collections work differently than server-synced collections. With LocalOnly collections, you **directly mutate state** by calling methods like `collection.insert()`, `collection.update()`, and `collection.delete()` — that's all you need to do. The changes are immediately applied to your local in-memory data.
 
-This is different from collections that sync with a server (like `queryCollectionOptions`), where mutation handlers send data to a backend. With LocalOnly collections, everything stays local:
+This is different from collections that sync with a server (like Query Collection), where mutation handlers send data to a backend. With LocalOnly collections, everything stays local:
 
 ```typescript
 // Just call the methods directly - no server sync involved

--- a/docs/collections/local-storage-collection.md
+++ b/docs/collections/local-storage-collection.md
@@ -42,7 +42,7 @@ const userPreferencesCollection = createCollection(
 
 **Important:** LocalStorage collections work differently than server-synced collections. With LocalStorage collections, you **directly mutate state** by calling methods like `collection.insert()`, `collection.update()`, and `collection.delete()` — that's all you need to do. The changes are immediately applied to your local data and automatically persisted to localStorage.
 
-This is different from collections that sync with a server (like `queryCollectionOptions`), where mutation handlers send data to a backend. With LocalStorage collections, everything stays local:
+This is different from collections that sync with a server (like Query Collection), where mutation handlers send data to a backend. With LocalStorage collections, everything stays local:
 
 ```typescript
 // Just call the methods directly - automatically persisted to localStorage


### PR DESCRIPTION
Added a "Direct Local Mutations" section to emphasize that LocalOnly collections work by directly calling collection.insert/update/delete methods, with all changes staying local in-memory. This is different from server-synced collections where mutation handlers send data to a backend.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
