### PR TITLE
Update documentation for query collection options

### DIFF
--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -10,7 +10,7 @@ Query collections provide seamless integration between TanStack DB and TanStack 
 
 The `@tanstack/query-db-collection` package allows you to create collections that:
 
-- Automatically sync with remote data via TanStack Query (when using `liveQueryCollectionOptions`)
+- Automatically fetch remote data via TanStack Query
 - Support optimistic updates with automatic rollback on errors
 - Handle persistence through customizable mutation handlers
 - Provide direct write capabilities for directly writing to the sync store
@@ -58,7 +58,7 @@ The `queryCollectionOptions` function accepts the following options:
 
 - `select`: Function that lets extract array items when they're wrapped with metadata
 - `enabled`: Whether the query should automatically run (default: `true`)
-- `refetchInterval`: Refetch interval in milliseconds (has to be set to automatically sync when passing base `queryCollectionOptions`)
+- `refetchInterval`: Refetch interval in milliseconds (default: 0 — set an interval to enable polling refetching)
 - `retry`: Retry configuration for failed queries
 - `retryDelay`: Delay between retries
 - `staleTime`: How long data is considered fresh


### PR DESCRIPTION
Clarify the conditions for automatic syncing and refetching, discord context:
 
hazn:  Is this code absolutely mandatory in my `queryCollectionOptions` to refetch using a livequery? It didn't seem to work before:  
```js
refetchInterval: 5000, // Poll every 5 seconds to sync with server
staleTime: 0, // Data is immediately considered stale
```

Kyle Mathews:  The `staleTime` isn't necessary — but yeah, it won't poll for updates otherwise.

hazn:  Thanks! I'll create a quick PR mentioning this, as it took me a while to figure this out. I expected the default to be automatically refetching.

Kyle Mathews:  Ah yeah sure — we copy the Query defaults for this.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
