### PR TITLE
Add link to schemas guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -82,6 +82,10 @@
           "to": "guides/mutations"
         },
         {
+          "label": "Schemas",
+          "to": "guides/schemas"
+        },
+        {
           "label": "Error Handling",
           "to": "guides/error-handling"
         },


### PR DESCRIPTION
The schemas guide was available at /guides/schemas but wasn't linked in the sidebar navigation.