### PR TITLE
fix: use PR workflow for CI docs updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,25 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            BRANCH="docs/auto-update-$(date +%s)"
+            git checkout -b "$BRANCH"
             git add docs/
             git commit -m "docs: regenerate API documentation"
-            git push
+            git push origin "$BRANCH"
+
+            gh pr create \
+              --title "docs: regenerate API documentation" \
+              --body "Automated documentation update from release" \
+              --base main \
+              --head "$BRANCH"
+
+            gh pr merge "$BRANCH" --auto --squash
           else
             echo "No changes in generated docs"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Changesets (version or publish)
         id: changesets
         uses: changesets/action@v1.5.3


### PR DESCRIPTION
## Summary

Changes CI to create and auto-merge PRs instead of pushing directly to main, which was being blocked by branch protection rules requiring all changes go through PRs.

- Create timestamped branch for docs updates  
- Submit PR with auto-merge enabled
- Respects branch protection while maintaining automation

## Changes

- Modified `.github/workflows/release.yml` to create a branch, push changes, create PR, and enable auto-merge
- Added `GH_TOKEN` env variable for `gh` CLI commands

## Testing

- The workflow will be tested on the next release
- Branch protection rules will be respected
- PRs will auto-merge once checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)