### PR TITLE
fix: only regenerate docs on npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,22 @@ jobs:
         uses: tanstack/config/.github/setup@main
       - name: Run Tests
         run: pnpm run lint && pnpm run build && pnpm run test
+      - name: Run Changesets (version or publish)
+        id: changesets
+        uses: changesets/action@v1.5.3
+        with:
+          version: pnpm run changeset:version
+          publish: pnpm run changeset:publish
+          commit: "ci: Version Packages"
+          title: "ci: Version Packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Generate Docs
+        if: steps.changesets.outputs.published == 'true'
         run: pnpm docs:generate
       - name: Commit Generated Docs
+        if: steps.changesets.outputs.published == 'true'
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
@@ -56,17 +69,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Changesets (version or publish)
-        id: changesets
-        uses: changesets/action@v1.5.3
-        with:
-          version: pnpm run changeset:version
-          publish: pnpm run changeset:publish
-          commit: "ci: Version Packages"
-          title: "ci: Version Packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Comment on PRs about release
         if: steps.changesets.outputs.published == 'true'
         uses: tanstack/config/.github/comment-on-release@main


### PR DESCRIPTION
## Summary
- Changes docs regeneration to only run when packages are published to npm
- Previously, docs were regenerated on every merge to main
- Now docs only regenerate when changesets successfully publishes packages

## Changes
- Moved "Generate Docs" and "Commit Generated Docs" steps to run after the changesets action
- Added conditional checks using `steps.changesets.outputs.published == 'true'`
- This ensures docs are updated only when new versions are actually released to npm

## Test plan
- [ ] Verify workflow runs correctly on main branch push without publishing (docs should not regenerate)
- [ ] Verify workflow runs correctly when changesets publishes packages (docs should regenerate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)