### PR TITLE
chore: add missing changesets for recent PRs

### DIFF
--- a/.changeset/fix-query-collection-dedupe.md
+++ b/.changeset/fix-query-collection-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/query-db-collection": patch
+---
+
+Temporarily remove `loadSubset` call deduplication in query collection. We need to revisit our approach to deduplication to ensure correctness. See https://github.com/TanStack/db/issues/836 for discussion on the proper implementation strategy.

--- a/.changeset/upgrade-pacer-package.md
+++ b/.changeset/upgrade-pacer-package.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Upgrade @tanstack/pacer to v0.16.2 and fix AsyncQueuer API usage. The pacer package API changed significantly, requiring updates to how AsyncQueuer is constructed and items are queued in the queueStrategy implementation.


### PR DESCRIPTION
## Summary

Add changesets for two merged PRs that were missing them:
- Pacer package upgrade (#829)
- Query collection loadSubset dedupe removal (#835)

The first changeset documents the @tanstack/pacer upgrade to v0.16.2. The second documents the temporary removal of loadSubset deduplication with a link to #836 for future discussion on the proper implementation approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)