### PR TITLE
Fix broken documentation link in sidebar

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -124,7 +124,7 @@
         },
         {
           "label": "Collection",
-          "to": "reference/interfaces/collection"
+          "to": "reference/interfaces/Collection"
         },
         {
           "label": "createCollection",


### PR DESCRIPTION
The sidebar was linking to reference/interfaces/collection (lowercase) but the actual interface documentation is at reference/interfaces/Collection (uppercase). This was causing a broken link in the docs.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
