### PR TITLE
docs: update error handling examples to match new utils api

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -93,7 +93,7 @@ const syncedCollection = createCollection(
 function DataList() {
   const { data } = useLiveQuery((q) => q.from({ item: syncedCollection }))
   const isError = syncedCollection.utils.isError
-  const errorCount = syncedCollection.utils.errorCount()
+  const errorCount = syncedCollection.utils.errorCount
   
   return (
     <>


### PR DESCRIPTION
[This commit](https://github.com/TanStack/db/commit/1367756d0a68447405c5f5c1a3cca30ab0558d74) updated the api of query collection error utils, and it seems like the current examples are outdated!

## 🎯 Changes

Changed 
## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
