### PR TITLE
Fixed query collection bug where optimistic state leaked into syncedData when using writeInsert inside onInsert handlers

### DIFF
--- a/.changeset/fix-optimistic-state-in-synced-data.md
+++ b/.changeset/fix-optimistic-state-in-synced-data.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/query-db-collection": patch
+---
+
+Fixed bug where optimistic state leaked into syncedData when using writeInsert inside onInsert handlers. Previously, when syncing server-generated fields (like IDs or timestamps) using writeInsert within an onInsert handler, the QueryClient cache was updated with combined visible state (including optimistic changes), which triggered the query observer to write optimistic values back to syncedData. Now the cache is correctly updated with only server-confirmed state, ensuring syncedData maintains separation from optimistic state.

--- a/packages/query-db-collection/src/manual-sync.ts
+++ b/packages/query-db-collection/src/manual-sync.ts
@@ -204,7 +204,7 @@ export function performWriteOperations<
   ctx.commit()
 
   // Update query cache after successful commit
-  const updatedData = ctx.collection.toArray
+  const updatedData = Array.from(ctx.collection._state.syncedData.values())
   ctx.queryClient.setQueryData(ctx.queryKey, updatedData)
 }
 


### PR DESCRIPTION
Fixes bug where optimistic state Leakes into syncedData when using writeInsert inside onInsert handlers.

Previously, when syncing server-generated fields (like IDs or timestamps) using writeInsert within an onInsert handler, the QueryClient cache was updated with combined visible state (including optimistic changes), which triggered the query observer to write optimistic values back to syncedData.

Now the cache is correctly updated with only server-confirmed state, ensuring syncedData maintains separation from optimistic state.

Fork of the reproduction using preview package from this PR showing it fixed: https://codesandbox.io/p/sandbox/tanstack-db-bug-forked-nqtkvp?file=%2Fsrc%2FApp.tsx

fixes #814
replaces #817