### PR TITLE
Run ESLint only in autofix tests

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,6 +25,8 @@ jobs:
         uses: tanstack/config/.github/setup@main
       - name: Fix formatting
         run: pnpm prettier --ignore-unknown . --check
+      - name: Run ESLint
+        run: pnpm run lint
       - name: Apply fixes
         uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           main-branch-name: main
       - name: Run Checks
-        run: pnpm run lint && pnpm run build && pnpm run test
+        run: pnpm run build && pnpm run test
   preview:
     name: Preview
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Removed ESLint from PR workflow's test job to reduce CI runtime
- Added ESLint to autofix workflow where fixes can be automatically applied
- ESLint will now only run in the autofix CI tests, not in other tests

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
