### PR TITLE
Fix docs generation CI job after releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,6 @@ jobs:
               --body "Automated documentation update from release" \
               --base main \
               --head "$BRANCH"
-
-            gh pr merge "$BRANCH" --auto --squash
           else
             echo "No changes in generated docs"
           fi


### PR DESCRIPTION
The docs generation CI job after releases was failing because it tried to immediately merge the PR, but tests need to run first. Now the workflow just creates the PR and lets it go through normal CI checks before manual merge.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
