### PR TITLE
Add explanation of client-first vs local-first

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -176,6 +176,8 @@ This combines to support a model of uni-directional data flow, extending the red
 
 With an instant inner loop of optimistic state, superseded in time by the slower outer loop of persisting to the server and syncing the updated server state back into the collection.
 
+The Uni-directional and optimistic updates is the reason why Tanstack DB is called a "client-first" framework. Not to be confused with the [Local-first movement](https://www.inkandswitch.com/essay/local-first/), which usually implements bi-directional dataflow. 
+
 ## API reference
 
 ### Collections


### PR DESCRIPTION
## 🎯 Changes

Clarify the distinction between client-first and local-first frameworks in the "Overview" section. Might make sense to even do an own section of the differentiation, not to confuse people.

discord context:
```
hazn: am i correct to assume that tanstack-db uses the 'client-first' terminology instead of 'local-first' because the base assumption is that you have just a server backend + optimistic client state (and not a local backend on addition to the server backend)
Kyle Mathews: yes, local-first isn't what we're doing https://www.inkandswitch.com/essay/local-first/
[Local-first software: You own your data, in spite of the cloud](https://www.inkandswitch.com/essay/local-first/)
A new generation of collaborative software that allows users to retain ownership of their data.
hazn: okay, great my assumption is correct! it seems like tanstack-db is halfway there to local-first, any plans/integrations for the future of tanstack-db local-first-mode?
hazn: thanks for always being very responsive btw 😄
Kyle Mathews: yeah we've discussed adding built-in persistance but it's pretty hard and not a priority for v1 of DB — but it's definitely doable (albeit it's a very different model to develop in from server-first paradigms that most people work in (as you probably know))
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
