### PR TITLE
Fix validating bulk insert assigning same ID to all items

### DIFF
--- a/.changeset/fix-bulk-insert-duplicate-keys.md
+++ b/.changeset/fix-bulk-insert-duplicate-keys.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Fix bulk insert not detecting duplicate keys within the same batch. Previously, when inserting multiple items with the same key in a single bulk insert operation, later items would silently overwrite earlier ones. Now, a `DuplicateKeyError` is thrown when duplicate keys are detected within the same batch.

--- a/packages/db/src/collection/mutations.ts
+++ b/packages/db/src/collection/mutations.ts
@@ -163,17 +163,19 @@ export class CollectionMutationsManager<
 
     const items = Array.isArray(data) ? data : [data]
     const mutations: Array<PendingMutation<TOutput>> = []
+    const keysInCurrentBatch = new Set<TKey>()
 
     // Create mutations for each item
     items.forEach((item) => {
       // Validate the data against the schema if one exists
       const validatedData = this.validateData(item, `insert`)
 
-      // Check if an item with this ID already exists in the collection
+      // Check if an item with this ID already exists in the collection or in the current batch
       const key = this.config.getKey(validatedData)
-      if (this.state.has(key)) {
+      if (this.state.has(key) || keysInCurrentBatch.has(key)) {
         throw new DuplicateKeyError(key)
       }
+      keysInCurrentBatch.add(key)
       const globalKey = this.generateGlobalKey(key, item)
 
       const mutation: PendingMutation<TOutput, `insert`> = {


### PR DESCRIPTION
Previously, when inserting multiple items with the same key in a single bulk insert operation, later items would silently overwrite earlier ones. This fix adds tracking of keys already processed within the current batch, throwing a DuplicateKeyError when duplicate keys are detected.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
