### PR TITLE
Fix TanStack duplicate dependency versions

### DIFF
--- a/.changeset/fix-tanstack-db-peerdeps.md
+++ b/.changeset/fix-tanstack-db-peerdeps.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/query-db-collection": patch
+"@tanstack/offline-transactions": patch
+---
+
+Use regular dependency for @tanstack/db instead of peerDependency to match the standard pattern used by other TanStack DB packages and prevent duplicate installations

--- a/packages/offline-transactions/package.json
+++ b/packages/offline-transactions/package.json
@@ -50,15 +50,13 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@tanstack/db": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "@tanstack/db": "workspace:*",
     "eslint": "^8.57.1",
     "typescript": "^5.5.4",
     "vitest": "^3.2.4"
-  },
-  "peerDependencies": {
-    "@tanstack/db": "*"
   }
 }

--- a/packages/query-db-collection/package.json
+++ b/packages/query-db-collection/package.json
@@ -3,10 +3,10 @@
   "description": "TanStack Query collection for TanStack DB",
   "version": "1.0.5",
   "dependencies": {
-    "@standard-schema/spec": "^1.0.0"
+    "@standard-schema/spec": "^1.0.0",
+    "@tanstack/db": "workspace:*"
   },
   "devDependencies": {
-    "@tanstack/db": "workspace:*",
     "@tanstack/query-core": "^5.90.11",
     "@vitest/coverage-istanbul": "^3.2.4"
   },
@@ -31,7 +31,6 @@
   "module": "dist/esm/index.js",
   "packageManager": "pnpm@10.24.0",
   "peerDependencies": {
-    "@tanstack/db": "*",
     "@tanstack/query-core": "^5.0.0",
     "typescript": ">=4.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,7 +603,7 @@ importers:
         version: 0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(gel@2.1.1)(kysely@0.28.8)(pg@8.16.3)(postgres@3.4.7)
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(gel@2.1.1)(kysely@0.28.8)(pg@8.16.3)(postgres@3.4.7))(zod@3.25.76)
+        version: 0.8.3(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(gel@2.1.1)(kysely@0.28.8)(pg@8.16.3)(postgres@3.4.7))(zod@4.1.11)
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -819,10 +819,11 @@ importers:
         version: 8.16.3
 
   packages/offline-transactions:
-    devDependencies:
+    dependencies:
       '@tanstack/db':
         specifier: workspace:*
         version: link:../db
+    devDependencies:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.24
@@ -872,13 +873,13 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
+      '@tanstack/db':
+        specifier: workspace:*
+        version: link:../db
       typescript:
         specifier: '>=4.7'
         version: 5.9.3
     devDependencies:
-      '@tanstack/db':
-        specifier: workspace:*
-        version: link:../db
       '@tanstack/query-core':
         specifier: ^5.90.11
         version: 5.90.11
@@ -14042,11 +14043,6 @@ snapshots:
       kysely: 0.28.8
       pg: 8.16.3
       postgres: 3.4.7
-
-  drizzle-zod@0.8.3(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(gel@2.1.1)(kysely@0.28.8)(pg@8.16.3)(postgres@3.4.7))(zod@3.25.76):
-    dependencies:
-      drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(gel@2.1.1)(kysely@0.28.8)(pg@8.16.3)(postgres@3.4.7)
-      zod: 3.25.76
 
   drizzle-zod@0.8.3(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(gel@2.1.1)(kysely@0.28.8)(pg@8.16.3)(postgres@3.4.7))(zod@4.1.11):
     dependencies:


### PR DESCRIPTION
Move @tanstack/db from peerDependencies to dependencies in query-db-collection and offline-transactions to match the standard pattern used by other TanStack DB packages.

This fixes duplicate @tanstack/db installations when users have multiple packages installed together.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
