### PR TITLE
fix(solid/todo): Update query-db-collection version range to match current version

### DIFF
--- a/examples/solid/todo/package.json
+++ b/examples/solid/todo/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@tanstack/electric-db-collection": "^0.2.10",
     "@tanstack/query-core": "^5.90.11",
-    "@tanstack/query-db-collection": ">=0.0.0 <1.0.0",
+    "@tanstack/query-db-collection": ">=1.0.0",
     "@tanstack/solid-db": "^0.1.52",
     "@tanstack/solid-router": "^1.139.12",
     "@tanstack/solid-start": "^1.139.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,8 +557,8 @@ importers:
         specifier: ^5.90.11
         version: 5.90.11
       '@tanstack/query-db-collection':
-        specifier: '>=0.0.0 <1.0.0'
-        version: 0.3.0(@tanstack/db@packages+db)(@tanstack/query-core@5.90.11)(typescript@5.9.3)
+        specifier: '>=1.0.0'
+        version: link:../../../packages/query-db-collection
       '@tanstack/solid-db':
         specifier: ^0.1.52
         version: link:../../../packages/solid-db
@@ -3790,13 +3790,6 @@ packages:
 
   '@tanstack/query-core@5.90.11':
     resolution: {integrity: sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A==}
-
-  '@tanstack/query-db-collection@0.3.0':
-    resolution: {integrity: sha512-v1GSFHHLRL9pOsuknfFIxdlDgO04ax0uVSITf+paPiGLfve1hcAGtxXYFbtBRlxXBKe9UMwI+rDEr6uAxcMiSg==}
-    peerDependencies:
-      '@tanstack/db': '*'
-      '@tanstack/query-core': ^5.0.0
-      typescript: '>=4.7'
 
   '@tanstack/react-query@5.90.11':
     resolution: {integrity: sha512-3uyzz01D1fkTLXuxF3JfoJoHQMU2fxsfJwE+6N5hHy0dVNoZOvwKP8Z2k7k1KDeD54N20apcJnG75TBAStIrBA==}
@@ -11872,13 +11865,6 @@ snapshots:
   '@tanstack/pacer-lite@0.1.0': {}
 
   '@tanstack/query-core@5.90.11': {}
-
-  '@tanstack/query-db-collection@0.3.0(@tanstack/db@packages+db)(@tanstack/query-core@5.90.11)(typescript@5.9.3)':
-    dependencies:
-      '@standard-schema/spec': 1.0.0
-      '@tanstack/db': link:packages/db
-      '@tanstack/query-core': 5.90.11
-      typescript: 5.9.3
 
   '@tanstack/react-query@5.90.11(react@19.2.0)':
     dependencies:


### PR DESCRIPTION
The version range `>=0.0.0 <1.0.0` excluded the current workspace version (1.0.6), causing pnpm to download from the registry instead of linking the local package. Updated to `>=1.0.0` to match other examples.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
