### PR TITLE
Fix build example site auth secret error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,4 +89,5 @@ jobs:
       - name: Build Starter Site
         run: |
           cd examples/react/projects
+          cp .env.example .env
           pnpm build

--- a/examples/react/projects/.env.example
+++ b/examples/react/projects/.env.example
@@ -3,4 +3,4 @@
 DATABASE_URL=postgresql://postgres:password@localhost:54321/projects
 
 # Create a secret for better-auth
-BETTER_AUTH_SECRET=
+BETTER_AUTH_SECRET=example-secret-for-development-only


### PR DESCRIPTION
Copy .env.example to .env during CI build to provide required BETTER_AUTH_SECRET that better-auth now enforces.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
