### PR TITLE
Fix awaitMatch helper on collection inserts and export isChangeMessage

### DIFF
--- a/.changeset/fix-await-match-inserts.md
+++ b/.changeset/fix-await-match-inserts.md
@@ -1,0 +1,16 @@
+---
+'@tanstack/electric-db-collection': patch
+---
+
+Fix awaitMatch race condition on inserts and export isChangeMessage/isControlMessage.
+
+**Bug fixes:**
+
+- Fixed race condition where `awaitMatch` would timeout on inserts when Electric synced faster than the API call
+- Messages are now preserved in buffer until next batch arrives, allowing `awaitMatch` to find them
+- Added `batchCommitted` flag to track commit state, consistent with `awaitTxId` semantics
+- Fixed `batchCommitted` to also trigger on `snapshot-end` in `on-demand` mode (matching "ready" semantics)
+
+**Export fixes:**
+
+- `isChangeMessage` and `isControlMessage` are now exported from the package index as documented

--- a/packages/electric-db-collection/src/index.ts
+++ b/packages/electric-db-collection/src/index.ts
@@ -1,5 +1,7 @@
 export {
   electricCollectionOptions,
+  isChangeMessage,
+  isControlMessage,
   type ElectricCollectionConfig,
   type ElectricCollectionUtils,
   type Txid,


### PR DESCRIPTION
Two issues fixed:

1. **isChangeMessage not exported**: The `isChangeMessage` and `isControlMessage` utilities were exported from electric.ts but not re-exported from the package's index.ts, making them unavailable to users despite documentation stating otherwise.

2. **awaitMatch race condition on inserts**: When `awaitMatch` was called after the Electric messages had already been processed (including up-to-date), it would timeout because:
   - The message buffer (`currentBatchMessages`) was cleared on up-to-date
   - Immediate matches found in the buffer still waited for another up-to-date to resolve

   Fixed by:
   - Moving buffer clearing to the START of batch processing (preserves messages until next batch)
   - Adding `batchCommitted` flag to track when a batch is committed
   - For immediate matches: resolve immediately only if batch is committed (consistent with awaitTxId)
   - For immediate matches during batch processing: wait for up-to-date (maintains commit semantics)

Fixes issue reported on Discord where inserts would timeout while updates worked.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
