### PR TITLE
consider isLoadingSubset in useLiveQuery isLoading state

### DIFF
--- a/packages/db/src/collection/changes.ts
+++ b/packages/db/src/collection/changes.ts
@@ -108,7 +108,9 @@ export class CollectionChangesManager<
     })
 
     if (options.includeInitialState) {
-      subscription.requestSnapshot({ trackLoadSubsetPromise: false })
+      // Track the loadSubset promise so isLoadingSubset reflects async data loading
+      // This ensures on-demand sync shows loading state until data is available
+      subscription.requestSnapshot()
     }
 
     // Add to batched listeners


### PR DESCRIPTION
Fix a bug where useLiveQuery would return isLoading=false while data was still undefined for on-demand sync mode. This would frequently cause flicker of 'not found' type messages.

For example,   I added a console.log of  isLoading, data for a component I'm working on:
```
{data: undefined, queryLoading: false}
{data: undefined, queryLoading: false}
{data: Array(0), queryLoading: true}
{data: Array(1), queryLoading: false}
```

The useLiveQuery hook now subscribes to loadingSubset:change events and factors isLoadingSubset into the isLoading computation.

I'm not 100% sure this is the best approach to fixing this, but it _seems_ like the best approach I could find given my relative lack of knowledge about the codebase.  Happy to rework with any suggestions anyone has to resolve this.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

the below do not exist but I've followed the spirt of them :) 
- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
