### PR TITLE
Move identifier quoting to Electric client

### DIFF
--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -75,9 +75,7 @@ function serializeExpression(
 /**
  * Serializes IR OrderBy clauses to structured format.
  */
-function serializeOrderBy(
-  orderBy: IR.OrderBy,
-): Array<SerializedOrderByClause> {
+function serializeOrderBy(orderBy: IR.OrderBy): Array<SerializedOrderByClause> {
   return orderBy.map((clause: IR.OrderByClause) => {
     const { expression, compareOptions } = clause
     if (expression.type !== `ref`) {
@@ -100,7 +98,9 @@ function serializeOrderBy(
   })
 }
 
-export function compileSQL<T>(options: LoadSubsetOptions): ExtendedSubsetParams {
+export function compileSQL<T>(
+  options: LoadSubsetOptions,
+): ExtendedSubsetParams {
   const { where, orderBy, limit } = options
 
   const params: Array<T> = []

--- a/packages/electric-db-collection/tests/sql-compiler.test.ts
+++ b/packages/electric-db-collection/tests/sql-compiler.test.ts
@@ -394,9 +394,7 @@ describe(`sql-compiler`, () => {
             },
           ],
         })
-        expect(result.orderByExpr).toEqual([
-          { column: `name`, nulls: `last` },
-        ])
+        expect(result.orderByExpr).toEqual([{ column: `name`, nulls: `last` }])
       })
 
       it(`should include orderByExpr for multiple columns`, () => {


### PR DESCRIPTION
Remove quoteIdentifier function from sql-compiler.ts so that Electric's encodeWhereClause can see the original unquoted identifiers and properly apply columnMapper transformations (e.g., camelCase → snake_case) before quoting.

This fixes an issue where columnMapper encoding was not applied to subset queries because double-quoted identifiers were preserved by Electric's encodeWhereClause per PostgreSQL semantics.

Fixes #1032

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
