### PR TITLE
collection: option to sync while persisting.

### DIFF
--- a/.changeset/poor-worlds-glow.md
+++ b/.changeset/poor-worlds-glow.md
@@ -2,4 +2,24 @@
 '@tanstack/db': patch
 ---
 
-Added an `allowSyncWhilePersisting?: boolean` flag to core collection sync config. If present and true then this allows concurrent updates to sync into a collection whilst an optimistic transaction is persisting.
+Added `onSyncWhilePersisting` callback to collection sync config for fine-grained control over whether synced data should be applied while optimistic transactions are persisting.
+
+The callback receives context about pending sync operations and persisting transactions, allowing developers to make selective decisions:
+
+```typescript
+sync: {
+  sync: ({ begin, write, commit }) => { /* ... */ },
+  // Allow sync only when there are no conflicting keys
+  onSyncWhilePersisting: ({ conflictingKeys }) => conflictingKeys.size === 0,
+}
+```
+
+Context provided to the callback:
+
+- `pendingSyncKeys` - Keys of items in pending sync operations
+- `persistingKeys` - Keys being modified by persisting optimistic transactions
+- `conflictingKeys` - Keys that appear in both (potential conflicts)
+- `persistingTransactionCount` - Number of persisting transactions
+- `isTruncate` - Whether this includes a truncate operation
+
+If no callback is provided, sync is deferred while any optimistic transaction is persisting (the safe default). Truncate operations always proceed regardless of the callback.

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -420,19 +420,24 @@ export class CollectionStateManager<
   /**
    * Attempts to commit pending synced transactions.
    * Commits are normally deferred while optimistic transactions are persisting,
-   * unless allowSyncWhilePersisting is enabled on the collection's sync config.
+   * unless the onSyncWhilePersisting callback returns true.
    */
   commitPendingTransactions = () => {
-    // Check if there are any persisting transaction
-    let hasPersistingTransaction = false
+    // Check for persisting transactions and collect their keys
+    let persistingTransactionCount = 0
+    const persistingKeys = new Set<TKey>()
     for (const transaction of this.transactions.values()) {
       if (transaction.state === `persisting`) {
-        hasPersistingTransaction = true
-        break
+        persistingTransactionCount++
+        // Collect keys from this transaction's mutations for this collection
+        for (const mutation of transaction.mutations) {
+          if (mutation.collection === this.collection) {
+            persistingKeys.add(mutation.key as TKey)
+          }
+        }
       }
     }
-    const allowSyncWhilePersisting =
-      this.config.sync.allowSyncWhilePersisting === true
+    const hasPersistingTransaction = persistingTransactionCount > 0
 
     // pending synced transactions could be either `committed` or still open.
     // we only want to process `committed` transactions here
@@ -462,6 +467,34 @@ export class CollectionStateManager<
         hasTruncateSync: false,
       },
     )
+
+    // Collect pending sync keys and compute conflicts
+    const pendingSyncKeys = new Set<TKey>()
+    for (const transaction of committedSyncedTransactions) {
+      for (const operation of transaction.operations) {
+        pendingSyncKeys.add(operation.key as TKey)
+      }
+    }
+
+    const conflictingKeys = new Set<TKey>()
+    for (const key of pendingSyncKeys) {
+      if (persistingKeys.has(key)) {
+        conflictingKeys.add(key)
+      }
+    }
+
+    // Determine whether to allow sync while persisting via callback
+    let allowSyncWhilePersisting = false
+    const onSyncWhilePersisting = this.config.sync.onSyncWhilePersisting
+    if (hasPersistingTransaction && onSyncWhilePersisting && !hasTruncateSync) {
+      allowSyncWhilePersisting = onSyncWhilePersisting({
+        pendingSyncKeys,
+        persistingKeys,
+        conflictingKeys,
+        persistingTransactionCount,
+        isTruncate: false,
+      })
+    }
 
     if (
       allowSyncWhilePersisting ||

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -321,6 +321,27 @@ export type SyncConfigRes = {
   loadSubset?: LoadSubsetFn
   unloadSubset?: UnloadSubsetFn
 }
+
+/**
+ * Context passed to the onSyncWhilePersisting callback.
+ * Provides information about pending sync operations and persisting transactions
+ * to help decide whether to allow synced data to be applied immediately.
+ */
+export interface SyncWhilePersistingContext<
+  TKey extends string | number = string | number,
+> {
+  /** Keys of items in pending sync operations waiting to be applied */
+  pendingSyncKeys: Set<TKey>
+  /** Keys of items being modified by currently persisting optimistic transactions */
+  persistingKeys: Set<TKey>
+  /** Keys that appear in both pending sync and persisting transactions (potential conflicts) */
+  conflictingKeys: Set<TKey>
+  /** Number of optimistic transactions currently in the persisting state */
+  persistingTransactionCount: number
+  /** Whether this includes a truncate operation (truncates always proceed regardless) */
+  isTruncate: boolean
+}
+
 export interface SyncConfig<
   T extends object = Record<string, unknown>,
   TKey extends string | number = string | number,
@@ -350,10 +371,30 @@ export interface SyncConfig<
   rowUpdateMode?: `partial` | `full`
 
   /**
-   * Allow applying synced transactions while optimistic transactions are persisting.
-   * @default false
+   * Callback invoked when synced data arrives while optimistic transactions are persisting.
+   * Return true to allow the sync to proceed, false to defer until transactions complete.
+   *
+   * If not provided, synced data is deferred while any optimistic transaction is persisting
+   * (the safe default). Use this callback to selectively allow non-conflicting syncs.
+   *
+   * Note: Truncate operations always proceed regardless of this callback.
+   *
+   * @param context - Information about pending sync and persisting transactions
+   * @returns true to allow sync, false to defer
+   *
+   * @example
+   * // Always allow sync while persisting (most permissive)
+   * onSyncWhilePersisting: () => true
+   *
+   * @example
+   * // Allow only if there are no conflicting keys
+   * onSyncWhilePersisting: ({ conflictingKeys }) => conflictingKeys.size === 0
+   *
+   * @example
+   * // Allow small syncs only
+   * onSyncWhilePersisting: ({ pendingSyncKeys }) => pendingSyncKeys.size < 10
    */
-  allowSyncWhilePersisting?: boolean
+  onSyncWhilePersisting?: (context: SyncWhilePersistingContext<TKey>) => boolean
 }
 
 export interface ChangeMessage<

--- a/packages/db/tests/collection-getters.test.ts
+++ b/packages/db/tests/collection-getters.test.ts
@@ -7,8 +7,8 @@ import type { SyncConfig } from '../src/types'
 type Item = { id: string; name: string }
 
 describe(`Collection getters`, () => {
-  let collection: CollectionImpl<Item>
-  let mockSync: SyncConfig<Item>
+  let collection: CollectionImpl<Item, string>
+  let mockSync: SyncConfig<Item, string>
 
   beforeEach(() => {
     mockSync = {

--- a/packages/db/tests/query/optimistic-sync-while-persisting.test.ts
+++ b/packages/db/tests/query/optimistic-sync-while-persisting.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { createCollection } from '../../src/collection/index.js'
 import { createLiveQueryCollection } from '../../src/query/index.js'
 import { createOptimisticAction } from '../../src/optimistic-action.js'
+import type { SyncWhilePersistingContext } from '../../src/types.js'
 
 type Item = {
   id: string
@@ -20,7 +21,15 @@ type SyncControls = {
 
 let collectionCounter = 0
 
-function setup() {
+type SetupOptions = {
+  onSyncWhilePersisting?: (
+    context: SyncWhilePersistingContext<string | number>,
+  ) => boolean
+}
+
+function setup(options: SetupOptions = {}) {
+  const { onSyncWhilePersisting = () => true } = options
+
   let syncBegin: SyncControls[`begin`] | undefined
   let syncWrite: SyncControls[`write`] | undefined
   let syncCommit: SyncControls[`commit`] | undefined
@@ -37,7 +46,7 @@ function setup() {
         syncCommit = commit
         syncMarkReady = markReady
       },
-      allowSyncWhilePersisting: true,
+      onSyncWhilePersisting,
     },
   })
 
@@ -63,9 +72,9 @@ function setup() {
   }
 }
 
-function createPendingOptimisticAction(
-  source: ReturnType<typeof setup>[`source`],
-) {
+function createPendingOptimisticAction(source: {
+  insert: (item: Item) => any
+}) {
   let resolveMutation: (() => void) | undefined
   let startResolve: (() => void) | undefined
   const started = new Promise<void>((resolve) => {
@@ -91,9 +100,11 @@ function createPendingOptimisticAction(
   }
 }
 
-describe(`sync while optimistic transaction is persisting (opt-in)`, () => {
-  test(`shows non-conflicting synced rows immediately`, async () => {
-    const { source, derived, sync } = setup()
+describe(`sync while optimistic transaction is persisting (onSyncWhilePersisting callback)`, () => {
+  test(`shows non-conflicting synced rows immediately when callback returns true`, async () => {
+    const { source, derived, sync } = setup({
+      onSyncWhilePersisting: () => true,
+    })
     const { action, started, resolve } = createPendingOptimisticAction(source)
 
     action({ id: `optimistic-1`, value: `optimistic` })
@@ -111,7 +122,9 @@ describe(`sync while optimistic transaction is persisting (opt-in)`, () => {
   })
 
   test(`keeps optimistic row visible on conflicting sync`, async () => {
-    const { source, derived, sync } = setup()
+    const { source, derived, sync } = setup({
+      onSyncWhilePersisting: () => true,
+    })
     const { action, started, resolve } = createPendingOptimisticAction(source)
 
     action({ id: `item-1`, value: `optimistic` })
@@ -127,5 +140,241 @@ describe(`sync while optimistic transaction is persisting (opt-in)`, () => {
     expect(derived.get(`item-1`)?.value).toBe(`optimistic`)
 
     resolve()
+  })
+
+  test(`callback receives correct context`, async () => {
+    const callbackSpy = vi.fn(
+      (_ctx: SyncWhilePersistingContext<string | number>) => true,
+    )
+    const { source, sync } = setup({ onSyncWhilePersisting: callbackSpy })
+    const { action, started, resolve } = createPendingOptimisticAction(source)
+
+    action({ id: `optimistic-1`, value: `optimistic` })
+    await started
+
+    sync.begin()
+    sync.write({ type: `insert`, value: { id: `synced-1`, value: `synced` } })
+    sync.write({ type: `insert`, value: { id: `synced-2`, value: `synced` } })
+    sync.commit()
+
+    expect(callbackSpy).toHaveBeenCalledTimes(1)
+    const context = callbackSpy.mock
+      .calls[0]![0] as unknown as SyncWhilePersistingContext<string | number>
+
+    expect(context.pendingSyncKeys).toBeInstanceOf(Set)
+    expect(context.pendingSyncKeys.has(`synced-1`)).toBe(true)
+    expect(context.pendingSyncKeys.has(`synced-2`)).toBe(true)
+    expect(context.pendingSyncKeys.size).toBe(2)
+
+    expect(context.persistingKeys).toBeInstanceOf(Set)
+    expect(context.persistingKeys.has(`optimistic-1`)).toBe(true)
+    expect(context.persistingKeys.size).toBe(1)
+
+    expect(context.conflictingKeys).toBeInstanceOf(Set)
+    expect(context.conflictingKeys.size).toBe(0)
+
+    expect(context.persistingTransactionCount).toBe(1)
+    expect(context.isTruncate).toBe(false)
+
+    resolve()
+  })
+
+  test(`callback receives conflicting keys correctly`, async () => {
+    const callbackSpy = vi.fn(
+      (_ctx: SyncWhilePersistingContext<string | number>) => true,
+    )
+    const { source, sync } = setup({ onSyncWhilePersisting: callbackSpy })
+    const { action, started, resolve } = createPendingOptimisticAction(source)
+
+    action({ id: `shared-key`, value: `optimistic` })
+    await started
+
+    sync.begin()
+    sync.write({ type: `insert`, value: { id: `shared-key`, value: `synced` } })
+    sync.write({
+      type: `insert`,
+      value: { id: `synced-only`, value: `synced` },
+    })
+    sync.commit()
+
+    const context = callbackSpy.mock
+      .calls[0]![0] as unknown as SyncWhilePersistingContext<string | number>
+
+    expect(context.conflictingKeys.has(`shared-key`)).toBe(true)
+    expect(context.conflictingKeys.size).toBe(1)
+    expect(context.pendingSyncKeys.size).toBe(2)
+    expect(context.persistingKeys.size).toBe(1)
+
+    resolve()
+  })
+
+  test(`callback returning false defers sync until transaction completes`, async () => {
+    const callbackSpy = vi.fn(() => false)
+    const { source, derived, sync } = setup({
+      onSyncWhilePersisting: callbackSpy,
+    })
+    const { action, started, resolve } = createPendingOptimisticAction(source)
+
+    const transaction = action({ id: `optimistic-1`, value: `optimistic` })
+    await started
+
+    // At this point, transaction should be persisting
+    expect(transaction.state).toBe(`persisting`)
+
+    sync.begin()
+    sync.write({ type: `insert`, value: { id: `synced-1`, value: `synced` } })
+    sync.commit()
+
+    // Callback should have been called once (during sync.commit)
+    expect(callbackSpy).toHaveBeenCalledTimes(1)
+
+    // Synced row should NOT be visible yet because callback returned false
+    expect(derived.has(`optimistic-1`)).toBe(true)
+    expect(derived.has(`synced-1`)).toBe(false)
+
+    // Check pending sync transactions before completing
+    expect(source._state.pendingSyncedTransactions.length).toBeGreaterThan(0)
+
+    // Complete the optimistic transaction and wait for it to finish
+    resolve()
+    await transaction.isPersisted.promise
+
+    // Transaction should now be completed
+    expect(transaction.state).toBe(`completed`)
+
+    // Give a tick for any async cleanup
+    await new Promise((r) => setTimeout(r, 0))
+
+    // The callback should NOT be called again (because no persisting transactions)
+    // So it should still be 1 call total
+    expect(callbackSpy).toHaveBeenCalledTimes(1)
+
+    // Pending syncs should have been processed
+    expect(source._state.pendingSyncedTransactions.length).toBe(0)
+
+    // Now synced row should be visible
+    expect(source.has(`synced-1`)).toBe(true)
+    expect(derived.has(`synced-1`)).toBe(true)
+  })
+
+  test(`selective allow based on conflicting keys`, async () => {
+    // Only allow sync if there are no conflicts
+    const { source, derived, sync } = setup({
+      onSyncWhilePersisting: ({ conflictingKeys }) =>
+        conflictingKeys.size === 0,
+    })
+    const { action, started, resolve } = createPendingOptimisticAction(source)
+
+    action({ id: `optimistic-1`, value: `optimistic` })
+    await started
+
+    // Non-conflicting sync should be allowed
+    sync.begin()
+    sync.write({ type: `insert`, value: { id: `synced-1`, value: `synced` } })
+    sync.commit()
+
+    expect(derived.has(`synced-1`)).toBe(true)
+
+    // Conflicting sync should be deferred
+    sync.begin()
+    sync.write({
+      type: `update`,
+      value: { id: `optimistic-1`, value: `synced-update` },
+    })
+    sync.commit()
+
+    // The optimistic value should still be visible (sync was deferred)
+    expect(derived.get(`optimistic-1`)?.value).toBe(`optimistic`)
+
+    resolve()
+  })
+
+  test(`no callback means sync is deferred while persisting (default behavior)`, async () => {
+    // Setup without onSyncWhilePersisting callback
+    let syncBegin: SyncControls[`begin`] | undefined
+    let syncWrite: SyncControls[`write`] | undefined
+    let syncCommit: SyncControls[`commit`] | undefined
+
+    const source = createCollection<Item>({
+      id: `no-callback-test-${++collectionCounter}`,
+      getKey: (item) => item.id,
+      startSync: true,
+      sync: {
+        sync: ({ begin, write, commit }) => {
+          syncBegin = begin
+          syncWrite = write
+          syncCommit = commit
+        },
+        // No onSyncWhilePersisting callback
+      },
+    })
+
+    const derived = createLiveQueryCollection({
+      startSync: true,
+      query: (q) => q.from({ item: source }),
+      getKey: (item: Item) => item.id,
+    })
+
+    const { action, started, resolve } = createPendingOptimisticAction(source)
+
+    const transaction = action({ id: `optimistic-1`, value: `optimistic` })
+    await started
+
+    syncBegin!()
+    syncWrite!({ type: `insert`, value: { id: `synced-1`, value: `synced` } })
+    syncCommit!()
+
+    // Without callback, sync should be deferred
+    expect(derived.has(`optimistic-1`)).toBe(true)
+    expect(derived.has(`synced-1`)).toBe(false)
+
+    resolve()
+    await transaction.isPersisted.promise
+
+    // After transaction completes, sync should apply
+    expect(derived.has(`synced-1`)).toBe(true)
+  })
+
+  test(`callback is not called when no persisting transactions`, async () => {
+    const callbackSpy = vi.fn(() => true)
+    const { sync } = setup({ onSyncWhilePersisting: callbackSpy })
+
+    // Sync without any pending optimistic transaction
+    sync.begin()
+    sync.write({ type: `insert`, value: { id: `synced-1`, value: `synced` } })
+    sync.commit()
+
+    // Callback should not be called since there's no persisting transaction
+    expect(callbackSpy).not.toHaveBeenCalled()
+  })
+
+  test(`multiple persisting transactions are counted correctly`, async () => {
+    const callbackSpy = vi.fn(
+      (_ctx: SyncWhilePersistingContext<string | number>) => true,
+    )
+    const { source, sync } = setup({ onSyncWhilePersisting: callbackSpy })
+
+    // Create two pending optimistic actions
+    const action1 = createPendingOptimisticAction(source)
+    const action2 = createPendingOptimisticAction(source)
+
+    action1.action({ id: `optimistic-1`, value: `optimistic` })
+    await action1.started
+
+    action2.action({ id: `optimistic-2`, value: `optimistic` })
+    await action2.started
+
+    sync.begin()
+    sync.write({ type: `insert`, value: { id: `synced-1`, value: `synced` } })
+    sync.commit()
+
+    const context = callbackSpy.mock
+      .calls[0]![0] as unknown as SyncWhilePersistingContext<string | number>
+    expect(context.persistingTransactionCount).toBe(2)
+    expect(context.persistingKeys.has(`optimistic-1`)).toBe(true)
+    expect(context.persistingKeys.has(`optimistic-2`)).toBe(true)
+
+    action1.resolve()
+    action2.resolve()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

- Added `onSyncWhilePersisting` callback to core sync config types. If returns true then this allows concurrent updates to sync into a collection whilst an optimistic transaction is persisting.
- Added `query/optimistic-sync-while-persisting.test.ts` test

The default behavior is unchanged unless onSyncWhilePersisting is provided. As yet deliberately undocumented to avoid encouraging the complexity / conceptual overhead.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).