### PR TITLE
Fix query syntax in examples (remove ===)

### DIFF
--- a/docs/collections/local-only-collection.md
+++ b/docs/collections/local-only-collection.md
@@ -162,7 +162,7 @@ await tx.commit()
 ## Complete Example: Modal State Management
 
 ```typescript
-import { createCollection } from '@tanstack/react-db'
+import { createCollection, eq } from '@tanstack/react-db'
 import { localOnlyCollectionOptions } from '@tanstack/react-db'
 import { useLiveQuery } from '@tanstack/react-db'
 import { z } from 'zod'
@@ -194,7 +194,7 @@ export const modalStateCollection = createCollection(
 function UserProfileModal() {
   const { data: modals } = useLiveQuery((q) =>
     q.from({ modal: modalStateCollection })
-      .where(({ modal }) => modal.id === 'user-profile')
+      .where(({ modal }) => eq(modal.id, 'user-profile'))
   )
 
   const modalState = modals[0]
@@ -228,7 +228,7 @@ function UserProfileModal() {
 ## Complete Example: Form Draft State
 
 ```typescript
-import { createCollection } from '@tanstack/react-db'
+import { createCollection, eq } from '@tanstack/react-db'
 import { localOnlyCollectionOptions } from '@tanstack/react-db'
 import { useLiveQuery } from '@tanstack/react-db'
 
@@ -250,7 +250,7 @@ export const formDraftsCollection = createCollection(
 function CreatePostForm() {
   const { data: drafts } = useLiveQuery((q) =>
     q.from({ draft: formDraftsCollection })
-      .where(({ draft }) => draft.id === 'new-post')
+      .where(({ draft }) => eq(draft.id, 'new-post'))
   )
 
   const currentDraft = drafts[0]

--- a/docs/collections/local-storage-collection.md
+++ b/docs/collections/local-storage-collection.md
@@ -236,7 +236,7 @@ await tx.commit()
 ## Complete Example
 
 ```typescript
-import { createCollection } from '@tanstack/react-db'
+import { createCollection, eq } from '@tanstack/react-db'
 import { localStorageCollectionOptions } from '@tanstack/react-db'
 import { useLiveQuery } from '@tanstack/react-db'
 import { z } from 'zod'
@@ -265,7 +265,7 @@ export const userPreferencesCollection = createCollection(
 function SettingsPanel() {
   const { data: prefs } = useLiveQuery((q) =>
     q.from({ pref: userPreferencesCollection })
-      .where(({ pref }) => pref.id === 'current-user')
+      .where(({ pref }) => eq(pref.id, 'current-user'))
   )
 
   const currentPrefs = prefs[0]


### PR DESCRIPTION
The where() callback in useLiveQuery requires query builder functions like eq() instead of JavaScript comparison operators. Using === causes QueryCompilationError: Unknown expression type: undefined.

Fixes examples in:
- docs/collections/local-only-collection.md (2 examples)
- docs/collections/local-storage-collection.md (1 example)

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
