### PR TITLE
Add helper to extract the result type from a query `QueryResult`

### DIFF
--- a/.changeset/export-extract-context.md
+++ b/.changeset/export-extract-context.md
@@ -2,15 +2,17 @@
 '@tanstack/db': patch
 ---
 
-Export `ExtractContext` type to enable extracting query result types from Query instances.
+Export `QueryResult` helper type for easily extracting query result types (similar to Zod's `z.infer`).
 
 ```typescript
-import { Query, ExtractContext, GetResult } from '@tanstack/db'
+import { Query, QueryResult } from '@tanstack/db'
 
 const myQuery = new Query()
   .from({ users })
   .select(({ users }) => ({ name: users.name }))
 
-// Extract the result type:
-type MyQueryResult = GetResult<ExtractContext<typeof myQuery>>
+// Extract the result type - clean and simple!
+type MyQueryResult = QueryResult<typeof myQuery>
 ```
+
+Also exports `ExtractContext` for advanced use cases where you need the full context type.

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -29,6 +29,7 @@ import type {
 import type {
   CompareOptions,
   Context,
+  GetResult,
   GroupByCallback,
   JoinOnCallback,
   MergeContextForJoinCallback,
@@ -863,6 +864,9 @@ export type ExtractContext<T> =
     : T extends QueryBuilder<infer TContext>
       ? TContext
       : never
+
+// Helper type to extract the result type from a QueryBuilder (similar to Zod's z.infer)
+export type QueryResult<T> = GetResult<ExtractContext<T>>
 
 // Export the types from types.ts for convenience
 export type {

--- a/packages/db/src/query/index.ts
+++ b/packages/db/src/query/index.ts
@@ -11,6 +11,7 @@ export {
   type GetResult,
   type InferResultType,
   type ExtractContext,
+  type QueryResult,
 } from './builder/index.js'
 
 // Expression functions exports


### PR DESCRIPTION
This allows users to extract the result type from a Query instance:

```typescript
import { Query, QueryResult } from '@tanstack/db'

const myQuery = new Query()
  .from({ users })
  .select(({ users }) => ({ name: users.name }))

// Clean and simple!
type MyQueryResult = QueryResult<typeof myQuery>
```

Fixes a gap in the public API where ExtractContext was defined but not re-exported from the main query module.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
