### PR TITLE
test(vue-db): add type tests for findOne

### DIFF
--- a/packages/vue-db/tests/useLiveQuery.test-d.ts
+++ b/packages/vue-db/tests/useLiveQuery.test-d.ts
@@ -132,6 +132,8 @@ describe(`useLiveQuery type assertions`, () => {
     )
 
     // Regular queries should return an array
-    expectTypeOf(data.value).toEqualTypeOf<Array<{ id: string; name: string }>>()
+    expectTypeOf(data.value).toEqualTypeOf<
+      Array<{ id: string; name: string }>
+    >()
   })
 })


### PR DESCRIPTION
Add type tests reproducing issue #1095 where useLiveQuery with findOne() returns `ComputedRef<Array<T>>` instead of `ComputedRef<T | undefined>`.

This differs from the React implementation which correctly types findOne() queries to return a single object or undefined.

The tests currently fail, demonstrating the bug.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
