### PR TITLE
Fix Claude review workflow permissions

### DIFF
--- a/.github/workflows/review-pr-claude.yml
+++ b/.github/workflows/review-pr-claude.yml
@@ -48,6 +48,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: 'Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep,Task,Skill'
           claude_args: |
             --model claude-opus-4-5
           prompt: |


### PR DESCRIPTION
## Summary
- Add `allowed_tools` parameter to `claude-code-action` in the PR review workflow
- Permits `gh pr comment`, `gh pr view`, and `gh api` commands needed to post review comments
- Without this, Claude Code's internal permission system blocks the commands even when GitHub token has correct permissions

## Test plan
- [ ] Comment `/review` on a PR and verify Claude can post review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)