### PR TITLE
Fix Claude review workflow allowed_tools patterns

### DIFF
--- a/.github/workflows/review-pr-claude.yml
+++ b/.github/workflows/review-pr-claude.yml
@@ -48,7 +48,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: 'Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep,Task,Skill'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'pr-review-toolkit'
+          allowed_tools: 'Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep,Task,Skill'
           claude_args: |
             --model claude-opus-4-5
           prompt: |


### PR DESCRIPTION
## Summary
- Add `plugin_marketplaces` to install from the official Anthropic marketplace (`https://github.com/anthropics/claude-code.git`)
- Add `plugins: 'pr-review-toolkit'` to install the PR review toolkit with specialized agents
- Fix `allowed_tools` syntax: use space wildcards instead of colons (`gh pr *` not `gh pr:*`)
- Add git commands (`git diff`, `git log`, `git show`) and `Skill` to allowed_tools
- Restore the skill-based review prompt using `/pr-review-toolkit:review-pr`

## Plugin Details
The `pr-review-toolkit` plugin provides 6 specialized review agents:
- **comment-analyzer** - Reviews code comments for accuracy
- **pr-test-analyzer** - Identifies test coverage gaps
- **silent-failure-hunter** - Finds inadequate error handling
- **type-design-analyzer** - Reviews type design quality
- **code-reviewer** - General code review with confidence scoring
- **code-simplifier** - Suggests simplifications

## Test plan
- [ ] Comment `/review` on a PR and verify:
  - Plugin is installed successfully
  - Skill `/pr-review-toolkit:review-pr` is available
  - Review comment is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)