### PR TITLE
Improve awaitTxId timeout error with diagnostic info

### DIFF
--- a/.changeset/improve-txid-timeout-error.md
+++ b/.changeset/improve-txid-timeout-error.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/electric-db-collection': patch
+---
+
+Improve awaitTxId timeout error with debugging info showing which txids were received during the timeout period, plus a hint about the common cause (calling pg_current_xact_id outside the mutation transaction).

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -637,13 +637,33 @@ export function electricCollectionOptions<T extends Row<unknown>>(
     if (hasSnapshot) return true
 
     return new Promise((resolve, reject) => {
+      // Track txids at start to know which ones arrived during timeout
+      const txidsAtStart = new Set(seenTxids.state)
+      const txidsReceivedDuringTimeout: Array<Txid> = []
+
       const timeoutId = setTimeout(() => {
         unsubscribeSeenTxids()
         unsubscribeSeenSnapshots()
-        reject(new TimeoutWaitingForTxIdError(txId, config.id))
+        reject(
+          new TimeoutWaitingForTxIdError(
+            txId,
+            config.id,
+            txidsReceivedDuringTimeout,
+          ),
+        )
       }, timeout)
 
       const unsubscribeSeenTxids = seenTxids.subscribe(() => {
+        // Track new txids that arrived during the timeout period
+        for (const seenTxid of seenTxids.state) {
+          if (
+            !txidsAtStart.has(seenTxid) &&
+            !txidsReceivedDuringTimeout.includes(seenTxid)
+          ) {
+            txidsReceivedDuringTimeout.push(seenTxid)
+          }
+        }
+
         if (seenTxids.state.has(txId)) {
           debug(
             `${config.id ? `[${config.id}] ` : ``}awaitTxId found match for txid %o`,

--- a/packages/electric-db-collection/src/errors.ts
+++ b/packages/electric-db-collection/src/errors.ts
@@ -16,8 +16,21 @@ export class ExpectedNumberInAwaitTxIdError extends ElectricDBCollectionError {
 }
 
 export class TimeoutWaitingForTxIdError extends ElectricDBCollectionError {
-  constructor(txId: number, collectionId?: string) {
-    super(`Timeout waiting for txId: ${txId}`, collectionId)
+  constructor(
+    txId: number,
+    collectionId?: string,
+    receivedTxids?: Array<number>,
+  ) {
+    const receivedInfo =
+      receivedTxids === undefined
+        ? ``
+        : receivedTxids.length === 0
+          ? `\nNo txids were received during the timeout period.`
+          : `\nTxids received during timeout: [${receivedTxids.join(`, `)}]`
+
+    const hint = `\n\nThis often happens when pg_current_xact_id() is called outside the transaction that performs the mutation. Make sure to call it INSIDE the same transaction. See: https://electric-sql.com/docs/api/tanstack/troubleshooting#awaittxid-stalls`
+
+    super(`Timeout waiting for txId: ${txId}${receivedInfo}${hint}`, collectionId)
     this.name = `TimeoutWaitingForTxIdError`
   }
 }

--- a/packages/electric-db-collection/src/errors.ts
+++ b/packages/electric-db-collection/src/errors.ts
@@ -30,7 +30,10 @@ export class TimeoutWaitingForTxIdError extends ElectricDBCollectionError {
 
     const hint = `\n\nThis often happens when pg_current_xact_id() is called outside the transaction that performs the mutation. Make sure to call it INSIDE the same transaction. See: https://tanstack.com/db/latest/docs/collections/electric-collection#common-issue-awaittxid-stalls-or-times-out`
 
-    super(`Timeout waiting for txId: ${txId}${receivedInfo}${hint}`, collectionId)
+    super(
+      `Timeout waiting for txId: ${txId}${receivedInfo}${hint}`,
+      collectionId,
+    )
     this.name = `TimeoutWaitingForTxIdError`
   }
 }

--- a/packages/electric-db-collection/src/errors.ts
+++ b/packages/electric-db-collection/src/errors.ts
@@ -28,7 +28,7 @@ export class TimeoutWaitingForTxIdError extends ElectricDBCollectionError {
           ? `\nNo txids were received during the timeout period.`
           : `\nTxids received during timeout: [${receivedTxids.join(`, `)}]`
 
-    const hint = `\n\nThis often happens when pg_current_xact_id() is called outside the transaction that performs the mutation. Make sure to call it INSIDE the same transaction. See: https://electric-sql.com/docs/api/tanstack/troubleshooting#awaittxid-stalls`
+    const hint = `\n\nThis often happens when pg_current_xact_id() is called outside the transaction that performs the mutation. Make sure to call it INSIDE the same transaction. See: https://tanstack.com/db/latest/docs/collections/electric-collection#common-issue-awaittxid-stalls-or-times-out`
 
     super(`Timeout waiting for txId: ${txId}${receivedInfo}${hint}`, collectionId)
     this.name = `TimeoutWaitingForTxIdError`

--- a/packages/electric-db-collection/src/errors.ts
+++ b/packages/electric-db-collection/src/errors.ts
@@ -21,13 +21,7 @@ export class TimeoutWaitingForTxIdError extends ElectricDBCollectionError {
     collectionId?: string,
     receivedTxids?: Array<number>,
   ) {
-    const receivedInfo =
-      receivedTxids === undefined
-        ? ``
-        : receivedTxids.length === 0
-          ? `\nNo txids were received during the timeout period.`
-          : `\nTxids received during timeout: [${receivedTxids.join(`, `)}]`
-
+    const receivedInfo = formatReceivedTxidsInfo(receivedTxids)
     const hint = `\n\nThis often happens when pg_current_xact_id() is called outside the transaction that performs the mutation. Make sure to call it INSIDE the same transaction. See: https://tanstack.com/db/latest/docs/collections/electric-collection#common-issue-awaittxid-stalls-or-times-out`
 
     super(
@@ -36,6 +30,16 @@ export class TimeoutWaitingForTxIdError extends ElectricDBCollectionError {
     )
     this.name = `TimeoutWaitingForTxIdError`
   }
+}
+
+function formatReceivedTxidsInfo(receivedTxids?: Array<number>): string {
+  if (receivedTxids === undefined) {
+    return ``
+  }
+  if (receivedTxids.length === 0) {
+    return `\nNo txids were received during the timeout period.`
+  }
+  return `\nTxids received during timeout: [${receivedTxids.join(`, `)}]`
 }
 
 export class TimeoutWaitingForMatchError extends ElectricDBCollectionError {


### PR DESCRIPTION
## Summary

Enhanced `TimeoutWaitingForTxIdError` to provide actionable debugging information when `awaitTxId` times out, showing which txids arrived during the timeout and linking to documentation about the common cause.

**User impact**: Developers debugging timeout issues can now see whether transactions are being received at all, making it much easier to diagnose whether the issue is network-related or a `pg_current_xact_id()` placement problem.

---

## Root Cause (of the DX problem)

When `awaitTxId` times out, users previously got a generic "Timeout waiting for txId: X" message with no context about what went wrong. The most common cause—calling `pg_current_xact_id()` outside the transaction that performs the mutation—was not surfaced.

## Approach

1. **Track txids during timeout**: Capture a snapshot of seen txids at the start of the wait, then record any new txids that arrive during the timeout period
2. **Enhanced error message**: Include the list of received txids (or "no txids received") plus a hint about the common cause with a link to documentation

**Key code path** (`electric.ts:639-665`):
```typescript
const txidsAtStart = new Set(seenTxids.state)
const txidsReceivedDuringTimeout: Array<Txid> = []

// In timeout handler:
reject(new TimeoutWaitingForTxIdError(txId, config.id, txidsReceivedDuringTimeout))

// In subscription:
for (const seenTxid of seenTxids.state) {
  if (!txidsAtStart.has(seenTxid) && !txidsReceivedDuringTimeout.includes(seenTxid)) {
    txidsReceivedDuringTimeout.push(seenTxid)
  }
}
```

## Key Invariants

- The `receivedTxids` parameter is optional for backward compatibility
- Tracking only starts when entering the Promise (not on immediate resolution)
- Duplicate txids are not added to the tracking array

## Non-goals

- Not changing timeout duration or retry behavior
- Not adding automatic retry logic

---

## Verification

```bash
pnpm test
```

All 404 tests pass.

## Files Changed

| File | Change |
|------|--------|
| `packages/electric-db-collection/src/electric.ts` | Track txids received during timeout, pass to error |
| `packages/electric-db-collection/src/errors.ts` | Add `receivedTxids` param, format debugging info, add hint with docs link |

---

## Checklist

- [x] Tested locally with `pnpm test`
- [x] Generated changeset

🤖 Generated with [Claude Code](https://claude.ai/code)