### PR TITLE
fix(query-db-collection): forward structuralSharing to QueryObserver

### DIFF
--- a/.changeset/open-ideas-fix.md
+++ b/.changeset/open-ideas-fix.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-db-collection': patch
+---
+
+Forward structuralSharing option to QueryObserver

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -34,8 +34,8 @@ import type {
 import type {
   CompareOptions,
   Context,
-  GetResult,
   FunctionalHavingRow,
+  GetResult,
   GroupByCallback,
   JoinOnCallback,
   MergeContextForJoinCallback,

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -112,6 +112,13 @@ export interface QueryCollectionConfig<
     Array<T>,
     TQueryKey
   >[`staleTime`]
+  structuralSharing?: QueryObserverOptions<
+    Array<T>,
+    TError,
+    Array<T>,
+    Array<T>,
+    TQueryKey
+  >['structuralSharing']
 
   /**
    * Metadata to pass to the query.
@@ -543,6 +550,7 @@ export function queryCollectionOptions(
     onUpdate,
     onDelete,
     meta,
+    structuralSharing,
     ...baseCollectionConfig
   } = config
 
@@ -717,7 +725,6 @@ export function queryCollectionOptions(
         queryKey: key,
         queryFn: queryFunction,
         meta: extendedMeta,
-        structuralSharing: true,
         notifyOnChangeProps: `all`,
 
         // Only include options that are explicitly defined to allow QueryClient defaultOptions to be used
@@ -726,6 +733,7 @@ export function queryCollectionOptions(
         ...(retry !== undefined && { retry }),
         ...(retryDelay !== undefined && { retryDelay }),
         ...(staleTime !== undefined && { staleTime }),
+        ...(structuralSharing !== undefined && { structuralSharing }),
       }
 
       const localObserver = new QueryObserver<

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -3500,6 +3500,32 @@ describe(`QueryCollection`, () => {
       // Clean up
       customQueryClient.clear()
     })
+
+    it(`should forward structuralSharing option to QueryObserver`, async () => {
+      const queryKey = [`structuralSharingTest`]
+      const queryFn = vi.fn().mockResolvedValue([])
+
+      const options = queryCollectionOptions({
+        id: `test`,
+        queryClient,
+        queryKey,
+        queryFn,
+        getKey,
+        structuralSharing: false,
+        startSync: true,
+      })
+
+      createCollection(options)
+
+      await vi.waitFor(() => {
+        expect(queryFn).toHaveBeenCalled()
+      })
+
+      const query = queryClient.getQueryCache().find({ queryKey })
+
+      expect(query).toBeDefined()
+      expect(query!.options.structuralSharing).toBe(false)
+    })
   })
 
   describe(`Query Garbage Collection`, () => {


### PR DESCRIPTION
## 🎯 Changes

- Forward the `structuralSharing` option from `QueryCollectionConfig` to the underlying `QueryObserver`.
- Removes the hard-coded default and allows consumers to control TanStack Query structural sharing behavior.
- Adds a regression test verifying the option is forwarded correctly.

## ✅ Checklist

- [✓ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [✓ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ✓] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
