### PR TITLE
Fix: Handle nullable collection getters in svelte-db useLiveQuery

### DIFF
--- a/.changeset/nullable-collection-getter.md
+++ b/.changeset/nullable-collection-getter.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/svelte-db": patch
+---
+
+Fix nullable collection getters in useLiveQuery causing errors during SSR

--- a/.changeset/nullable-collection-getter.md
+++ b/.changeset/nullable-collection-getter.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/svelte-db": patch
+'@tanstack/svelte-db': patch
 ---
 
 Fix nullable collection getters in useLiveQuery causing errors during SSR

--- a/packages/svelte-db/src/useLiveQuery.svelte.ts
+++ b/packages/svelte-db/src/useLiveQuery.svelte.ts
@@ -350,6 +350,9 @@ export function useLiveQuery(
         startSync: true,
       })
     } else {
+      if (unwrappedParam === null || unwrappedParam === undefined) {
+        return null
+      }
       return createLiveQueryCollection({
         ...unwrappedParam,
         startSync: true,


### PR DESCRIPTION
## 🎯 Changes

When `useLiveQuery` receives a getter function that returns `null` during SSR (e.g., `() => documentsCollection` where `documentsCollection` is initially `null`), the implementation was trying to spread `null` into a config object, causing an error.

This adds a null/undefined check before spreading to return `null` early, matching how `react-db` and `solid-db` handle this case.

**Before:** `useLiveQuery(() => nullableCollection)` throws when getter returns `null`
**After:** Returns empty/idle state, then updates reactively when collection becomes available

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).