### PR TITLE
fix(react-db): include peek-ahead item in useLiveInfiniteQuery initial query

### DIFF
--- a/.changeset/fix-infinite-query-peek-ahead.md
+++ b/.changeset/fix-infinite-query-peek-ahead.md
@@ -1,0 +1,7 @@
+---
+"@tanstack/react-db": patch
+---
+
+fix(react-db): include peek-ahead item in useLiveInfiniteQuery initial query
+
+The initial query was fetching exactly `pageSize` items, but the peek-ahead logic requires `pageSize + 1` to determine if more pages exist. This caused `hasNextPage` to incorrectly return `false` on initial load when using SQLite predicate push-down with `syncMode: "on-demand"`.

--- a/packages/react-db/src/useLiveInfiniteQuery.ts
+++ b/packages/react-db/src/useLiveInfiniteQuery.ts
@@ -184,10 +184,11 @@ export function useLiveInfiniteQuery<TContext extends Context>(
 
   // Create a live query with initial limit and offset
   // Either pass collection directly or wrap query function
+  // Use pageSize + 1 for the initial limit to include the peek-ahead item
   const queryResult = isCollection
     ? useLiveQuery(queryFnOrCollection)
     : useLiveQuery(
-        (q) => queryFnOrCollection(q).limit(pageSize).offset(0),
+        (q) => queryFnOrCollection(q).limit(pageSize + 1).offset(0),
         deps,
       )
 


### PR DESCRIPTION
The initial query was fetching exactly `pageSize` items, but the peek-ahead logic requires `pageSize + 1` to determine if more pages exist. This mismatch caused `hasNextPage` to incorrectly return `false` on initial load when using SQLite predicate push-down with `syncMode: "on-demand"`.

The issue occurred because:
1. Initial query loaded exactly `pageSize` items (e.g., 50)
2. `setWindow({ limit: pageSize + 1 })` tried to access the peek-ahead item
3. The item didn't exist yet, and lazy loading had timing issues
4. `hasNextPage` was incorrectly `false` even when more data existed

The fix aligns the initial query limit with what `setWindow` expects, fetching `pageSize + 1` items upfront. The extra item is only used internally for the `hasNextPage` check - the returned `data` is still sliced to `pageSize` items via the existing useMemo logic.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
