### PR TITLE
feat(db): add type-level queryable field constraints

### DIFF
--- a/packages/db/src/query/index.ts
+++ b/packages/db/src/query/index.ts
@@ -57,8 +57,8 @@ export {
   liveQueryCollectionOptions,
 } from './live-query-collection.js'
 
-export { type LiveQueryCollectionConfig } from './live/types.js'
-export { type LiveQueryCollectionUtils } from './live/collection-config-builder.js'
+export type { LiveQueryCollectionConfig } from './live/types.js'
+export type { LiveQueryCollectionUtils } from './live/collection-config-builder.js'
 
 // Predicate utilities for predicate push-down
 export {
@@ -72,3 +72,8 @@ export {
 } from './predicate-utils.js'
 
 export { DeduplicatedLoadSubset } from './subset-dedupe.js'
+
+export {
+  withQueryableFields,
+  type QueryableFieldsConfig,
+} from './queryable-fields.js'

--- a/packages/db/src/query/live/types.ts
+++ b/packages/db/src/query/live/types.ts
@@ -70,6 +70,15 @@ export interface LiveQueryCollectionConfig<
     | QueryBuilder<TContext>
 
   /**
+   * Optional compile-time queryability hints for constrained `where`/`orderBy` refs.
+   * Runtime behavior is unchanged.
+   */
+  queryable?: {
+    filterable?: ReadonlyArray<string>
+    sortable?: ReadonlyArray<string>
+  }
+
+  /**
    * Function to extract the key from result items
    * If not provided, defaults to using the key from the D2 stream
    */

--- a/packages/db/src/query/queryable-fields.ts
+++ b/packages/db/src/query/queryable-fields.ts
@@ -1,0 +1,81 @@
+import type { CollectionImpl } from '../collection/index.js'
+import type {
+  CollectionWithQuerySchema,
+  InferCollectionType,
+} from './builder/types.js'
+
+type QueryableField<TDocument extends object> = Extract<keyof TDocument, string>
+
+type QueryableFieldList<TDocument extends object> = ReadonlyArray<
+  QueryableField<TDocument>
+>
+
+type KeysFromList<TKeys> =
+  TKeys extends ReadonlyArray<infer TKey> ? TKey : never
+
+type ResolveQueryableKeys<
+  TDocument extends object,
+  TFilterable,
+  TSortable,
+> = Extract<
+  KeysFromList<TFilterable> | KeysFromList<TSortable>,
+  QueryableField<TDocument>
+>
+
+type ResolveQueryableSchema<
+  TDocument extends object,
+  TFilterable,
+  TSortable,
+> = [TFilterable] extends [undefined]
+  ? [TSortable] extends [undefined]
+    ? TDocument
+    : Pick<TDocument, ResolveQueryableKeys<TDocument, TFilterable, TSortable>>
+  : Pick<TDocument, ResolveQueryableKeys<TDocument, TFilterable, TSortable>>
+
+export type QueryableFieldsConfig<
+  TDocument extends object,
+  TFilterable extends QueryableFieldList<TDocument> | undefined = undefined,
+  TSortable extends QueryableFieldList<TDocument> | undefined = undefined,
+> = {
+  filterable?: TFilterable
+  sortable?: TSortable
+}
+
+/**
+ * Adds compile-time queryable field constraints to a collection source.
+ *
+ * Runtime behavior is unchanged. This only affects the refs available in
+ * query callbacks like `where` and `orderBy`.
+ */
+export function withQueryableFields<
+  TCollection extends CollectionImpl<any, any, any, any, any>,
+  TFilterable extends
+    | QueryableFieldList<InferCollectionType<TCollection>>
+    | undefined = undefined,
+  TSortable extends
+    | QueryableFieldList<InferCollectionType<TCollection>>
+    | undefined = undefined,
+>(
+  collection: TCollection,
+  _queryable: QueryableFieldsConfig<
+    InferCollectionType<TCollection>,
+    TFilterable,
+    TSortable
+  >,
+): CollectionWithQuerySchema<
+  TCollection,
+  ResolveQueryableSchema<
+    InferCollectionType<TCollection>,
+    TFilterable,
+    TSortable
+  >
+> {
+  return collection as CollectionWithQuerySchema<
+    TCollection,
+    ResolveQueryableSchema<
+      InferCollectionType<TCollection>,
+      TFilterable,
+      TSortable
+    >
+  >
+}

--- a/packages/db/tests/query/queryable-fields.test-d.ts
+++ b/packages/db/tests/query/queryable-fields.test-d.ts
@@ -1,0 +1,214 @@
+import { describe, expectTypeOf, test } from 'vitest'
+import { createCollection } from '../../src/collection/index.js'
+import {
+  Query,
+  createLiveQueryCollection,
+  eq,
+  withQueryableFields,
+} from '../../src/query/index.js'
+import { mockSyncCollectionOptions } from '../utils.js'
+
+type JobEngagementDocument = {
+  _id: string
+  status: `ACTIVE` | `INACTIVE`
+  user_id: string
+  employer_id: string
+  created_at: string
+  updated_at: string
+  platform_fee_percent: number
+}
+
+function createEngagementsCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<JobEngagementDocument>({
+      id: `test-engagements`,
+      getKey: (engagement) => engagement._id,
+      initialData: [],
+    }),
+  )
+}
+
+describe(`Queryable field constraints`, () => {
+  test(`supports queryable option on createLiveQueryCollection config`, () => {
+    const engagementsCollection = createEngagementsCollection()
+
+    const collection = createLiveQueryCollection({
+      queryable: {
+        filterable: [
+          `_id`,
+          `status`,
+          `user_id`,
+          `employer_id`,
+          `created_at`,
+          `updated_at`,
+        ] as const,
+        sortable: [`created_at`, `updated_at`, `status`] as const,
+      },
+      query: (q) =>
+        q
+          .from({ engagement: engagementsCollection })
+          .where(({ engagement }) => eq(engagement.status, `ACTIVE`))
+          .orderBy(({ engagement }) => engagement.updated_at, `desc`),
+    })
+
+    expectTypeOf(collection.toArray).toEqualTypeOf<
+      Array<JobEngagementDocument>
+    >()
+  })
+
+  test(`queryable option rejects disallowed fields at compile-time`, () => {
+    const engagementsCollection = createEngagementsCollection()
+
+    createLiveQueryCollection({
+      queryable: {
+        filterable: [
+          `_id`,
+          `status`,
+          `user_id`,
+          `employer_id`,
+          `created_at`,
+          `updated_at`,
+        ] as const,
+        sortable: [`created_at`, `updated_at`, `status`] as const,
+      },
+      query: (q) =>
+        q
+          .from({ engagement: engagementsCollection })
+          .where(({ engagement }) => {
+            // @ts-expect-error platform_fee_percent is not queryable
+            return eq(engagement.platform_fee_percent, 0.15)
+          }),
+    })
+  })
+
+  test(`empty queryable lists do not widen back to full document`, () => {
+    const engagementsCollection = createEngagementsCollection()
+
+    createLiveQueryCollection({
+      queryable: {
+        filterable: [] as const,
+        sortable: [] as const,
+      },
+      query: (q) =>
+        q
+          .from({ engagement: engagementsCollection })
+          .where(({ engagement }) => {
+            // @ts-expect-error no fields are queryable when both lists are empty
+            return eq(engagement.status, `ACTIVE`)
+          }),
+    })
+  })
+
+  test(`allows configured fields in where and orderBy`, () => {
+    const engagementsCollection = createEngagementsCollection()
+
+    const queryableEngagements = withQueryableFields(engagementsCollection, {
+      filterable: [
+        `_id`,
+        `status`,
+        `user_id`,
+        `employer_id`,
+        `created_at`,
+        `updated_at`,
+      ] as const,
+      sortable: [`created_at`, `updated_at`, `status`] as const,
+    })
+
+    const collection = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ engagement: queryableEngagements })
+          .where(({ engagement }) => eq(engagement.status, `ACTIVE`))
+          .orderBy(({ engagement }) => engagement.updated_at, `desc`),
+    })
+
+    expectTypeOf(collection.toArray).toEqualTypeOf<
+      Array<JobEngagementDocument>
+    >()
+  })
+
+  test(`rejects disallowed where fields at compile-time`, () => {
+    const engagementsCollection = createEngagementsCollection()
+
+    const queryableEngagements = withQueryableFields(engagementsCollection, {
+      filterable: [
+        `_id`,
+        `status`,
+        `user_id`,
+        `employer_id`,
+        `created_at`,
+        `updated_at`,
+      ] as const,
+      sortable: [`created_at`, `updated_at`, `status`] as const,
+    })
+
+    createLiveQueryCollection({
+      query: (q) =>
+        q.from({ engagement: queryableEngagements }).where(({ engagement }) => {
+          // @ts-expect-error platform_fee_percent is not queryable
+          return eq(engagement.platform_fee_percent, 0.15)
+        }),
+    })
+  })
+
+  test(`rejects disallowed orderBy fields at compile-time`, () => {
+    const engagementsCollection = createEngagementsCollection()
+
+    const queryableEngagements = withQueryableFields(engagementsCollection, {
+      filterable: [
+        `_id`,
+        `status`,
+        `user_id`,
+        `employer_id`,
+        `created_at`,
+        `updated_at`,
+      ] as const,
+      sortable: [`created_at`, `updated_at`, `status`] as const,
+    })
+
+    createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ engagement: queryableEngagements })
+          .where(({ engagement }) => eq(engagement.status, `ACTIVE`))
+          .orderBy(({ engagement }) => {
+            // @ts-expect-error platform_fee_percent is not queryable
+            return engagement.platform_fee_percent
+          }),
+    })
+  })
+
+  test(`keeps restrictions across subquery refs while preserving output shape`, () => {
+    const engagementsCollection = createEngagementsCollection()
+
+    const queryableEngagements = withQueryableFields(engagementsCollection, {
+      filterable: [
+        `_id`,
+        `status`,
+        `user_id`,
+        `employer_id`,
+        `created_at`,
+        `updated_at`,
+      ] as const,
+      sortable: [`created_at`, `updated_at`, `status`] as const,
+    })
+
+    const subquery = new Query().from({ engagement: queryableEngagements })
+
+    createLiveQueryCollection({
+      query: (q) =>
+        q.from({ engagement: subquery }).where(({ engagement }) => {
+          // @ts-expect-error platform_fee_percent is not queryable via subquery refs
+          return eq(engagement.platform_fee_percent, 0.15)
+        }),
+    })
+
+    const resultCollection = createLiveQueryCollection({
+      query: (q) => q.from({ engagement: subquery }),
+    })
+
+    expectTypeOf(resultCollection.toArray).toEqualTypeOf<
+      Array<JobEngagementDocument>
+    >()
+  })
+})


### PR DESCRIPTION
Hey, love Tanstack! here's a quick PR allowing separation of queryable/sortable types from returned types.


## Summary

Problem: TanstackDB live query callbacks expose all model fields even when I want only allow a subset for filtering/sorting.

I return a lot of fields to the client from my API, using a query-backed collection with syncMode on demand. However, I don't want the client to be able to filter/sort by ALL of those fields, since not all of them can be efficiently queried on the backend.

The solution: add optional type-level queryable constraints so `where`/`orderBy` refs can be restricted while result rows remain full objects.

Non-invasive: additive typing only (`querySchema` + optional `queryable`/helper), defaults preserved, no runtime or planner behavior changes.

## Example

```ts
type EngagementDocument = { // Returned from API, fully readable
  _id: string
  status: `ACTIVE` | `INACTIVE`
  user_id: string
  employer_id: string
  created_at: string
  updated_at: string
  platform_fee_percent: number
}
```
```ts
   createLiveQueryCollection({
      queryable: {
        filterable: [ // platform_fee_percent is NOT queryable!
          `_id`,
          `status`,
          `user_id`,
          `employer_id`,
          `created_at`,
          `updated_at`,
        ] as const,
        sortable: [`created_at`, `updated_at`, `status`] as const,
      },
      query: (q) =>
        q
          .from({ engagement: engagementsCollection })
          .where(({ engagement }) => {
            // @ts-expect-error platform_fee_percent is not queryable
            return eq(engagement.platform_fee_percent, 0.15)
          }),
    })
```