### PR TITLE
feat(types): export InferCollectionType type helper

### DIFF
--- a/.changeset/export-infer-collection-type.md
+++ b/.changeset/export-infer-collection-type.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Export `InferCollectionType` type helper from package entry point

--- a/packages/db/src/query/index.ts
+++ b/packages/db/src/query/index.ts
@@ -11,6 +11,7 @@ export {
   type Source,
   type GetResult,
   type InferResultType,
+  type InferCollectionType,
   type ExtractContext,
   type QueryResult,
   // Types needed for declaration emit (https://github.com/TanStack/db/issues/1012)


### PR DESCRIPTION
## Summary
- Exports the existing `InferCollectionType` type helper from the `@tanstack/db` package entry point so consumers can use it to infer the item type from a collection instance

Closes #675

## Usage

```ts
import { InferCollectionType, createLocalOnlyCollection } from '@tanstack/db'

const usersCollection = createLocalOnlyCollection<{ id: string; name: string }>({
  id: 'users',
  primaryKey: 'id',
})

type User = InferCollectionType<typeof usersCollection>
// ^? { id: string; name: string }
```

## Test plan
- [x] Package builds successfully with the new export
- [x] Type appears in both ESM and CJS declaration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)