### PR TITLE
Add tests for LIKE/ILIKE wildcard matching across newlines

### DIFF
--- a/packages/db/tests/query/compiler/evaluators.test.ts
+++ b/packages/db/tests/query/compiler/evaluators.test.ts
@@ -374,6 +374,59 @@ describe(`evaluators`, () => {
           // In 3-valued logic, ilike with undefined pattern returns UNKNOWN (null)
           expect(compiled({})).toBe(null)
         })
+
+        it(`ilike % wildcard matches across newline characters`, () => {
+          // In SQL/PostgreSQL, % matches any sequence of characters including newlines.
+          // See: https://www.postgresql.org/docs/current/functions-matching.html
+          const func = new Func(`ilike`, [
+            new Value(`hello\nworld`),
+            new Value(`%world`),
+          ])
+          const compiled = compileExpression(func)
+
+          expect(compiled({})).toBe(true)
+        })
+
+        it(`ilike % wildcard matches pattern spanning a newline`, () => {
+          const func = new Func(`ilike`, [
+            new Value(`first line\nsecond line`),
+            new Value(`%line%line%`),
+          ])
+          const compiled = compileExpression(func)
+
+          expect(compiled({})).toBe(true)
+        })
+
+        it(`ilike matches word after newline with surrounding % wildcards`, () => {
+          const func = new Func(`ilike`, [
+            new Value(`some notes\ncontaining a keyword here`),
+            new Value(`%keyword%`),
+          ])
+          const compiled = compileExpression(func)
+
+          expect(compiled({})).toBe(true)
+        })
+
+        it(`like % wildcard matches across newline characters`, () => {
+          const func = new Func(`like`, [
+            new Value(`hello\nworld`),
+            new Value(`%world`),
+          ])
+          const compiled = compileExpression(func)
+
+          expect(compiled({})).toBe(true)
+        })
+
+        it(`ilike _ wildcard matches a newline character`, () => {
+          // In SQL, _ matches any single character, including newline
+          const func = new Func(`ilike`, [
+            new Value(`a\nb`),
+            new Value(`a_b`),
+          ])
+          const compiled = compileExpression(func)
+
+          expect(compiled({})).toBe(true)
+        })
       })
 
       describe(`comparison operators`, () => {


### PR DESCRIPTION
## 🎯 Changes

Added comprehensive test cases to verify that the `LIKE` and `ILIKE` operators correctly handle wildcard matching across newline characters, matching PostgreSQL's standard behavior:

- `%` wildcard now tested to match sequences including newlines
- `_` wildcard tested to match newline characters as single characters
- Multiple test scenarios covering patterns that span across newlines

These tests ensure the query compiler's evaluators properly implement SQL standard wildcard semantics where `%` matches any sequence of characters (including newlines) and `_` matches any single character (including newlines).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

**Note:** This is a test-only change that adds coverage for existing functionality. No changeset needed.

https://claude.ai/code/session_01LZWLuuACLggGCjzY2WvsoB