### PR TITLE
fix: correct PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,7 @@
 
 ## ✅ Checklist
 
-- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
-- [ ] I have tested this code locally with `pnpm test:pr`.
+- [ ] I have tested this code locally with `pnpm test`.
 
 ## 🚀 Release Impact
 


### PR DESCRIPTION
## Summary
- Remove reference to nonexistent `CONTRIBUTING.md` in the PR checklist
- Fix test script name from `pnpm test:pr` (doesn't exist) to `pnpm test`

## Test plan
- [x] Verified no `CONTRIBUTING.md` exists in the repo
- [x] Verified `pnpm test` is the correct script (`pnpm test:pr` is not defined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)