### PR TITLE
fix(powersync-db-collection): additional export to make type definitions portable

### DIFF
--- a/.changeset/hungry-buckets-hear.md
+++ b/.changeset/hungry-buckets-hear.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/powersync-db-collection': minor
+---
+
+additional export to make collection type "portable" in monorepo setups

--- a/packages/powersync-db-collection/src/index.ts
+++ b/packages/powersync-db-collection/src/index.ts
@@ -1,3 +1,4 @@
 export * from './definitions'
 export * from './powersync'
 export * from './PowerSyncTransactor'
+export * from './helpers'


### PR DESCRIPTION
## 🎯 Changes

In monorepo setups you might have something like this:
- packages/db/powersync/schema.ts
- web/db/powersync.ts // new PowerSyncDatabase({database: WaSqlite, schema: SchemaFromSharedPackage}
- expo/db/powersync.ts // new PowerSyncDatabase({database: opSqlite, schema: SchemaFromSharedPackage}
- packages/db/tanstack-db/index.ts 

However currently it's not possible to make a function that will take db: AbstractPowerSyncDatabase and return a tanstack collection due to type issues.

Error is:
```
The inferred type of 'createTanstackCollection' cannot be named without a reference to '../../../../node_modules/@tanstack/powersync-db-collection/dist/esm/helpers'. This is likely not portable. A type annotation is necessary
```

Collection type looks like this
```
type SomeCollection = Collection<OptionalExtractedTable<SomeTableType>, string, PowerSyncCollectionUtils<SomeTableType> never,OptionalExtractedTable<SomeTableType>> &  NonSingleResult;
```
The only export missing from `@tanstack/powersync-db-collection` is OptionalExtractedTable.

Video demonstration of me patching node_modules and the typescript issue going away

https://github.com/user-attachments/assets/d433ad29-2580-4c29-9a47-be089f045e59



## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
