### PR TITLE
fix(query-db-collection): align queryOptions interop types

### DIFF
--- a/.changeset/query-options-interop-types.md
+++ b/.changeset/query-options-interop-types.md
@@ -7,4 +7,5 @@ Improve `queryCollectionOptions` type interoperability with TanStack Query optio
 - Accept `queryFn` return types of `T | Promise<T>` instead of Promise-only contracts.
 - Align `enabled`, `staleTime`, `refetchInterval`, `retry`, and `retryDelay` with `QueryObserverOptions` typing.
 - Support tagged `queryKey` values (`DataTag`) from `queryOptions(...)` spread usage.
+- Keep `queryFn` required in the final `queryCollectionOptions` config (including interop paths) so types match runtime expectations.
 - Preserve runtime safety: query collections still require an executable `queryFn`, and wrapped responses still require `select`.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -66,7 +66,7 @@ The `queryCollectionOptions` function accepts the following options:
 
 ### Interop with `queryOptions(...)`
 
-If your app already uses a TanStack Query options helper (for example, `queryOptions` from `@tanstack/react-query`), you can pass those options directly into `queryCollectionOptions`:
+If your app already uses a TanStack Query options helper (for example, `queryOptions` from `@tanstack/react-query`), you can spread those options into `queryCollectionOptions`. Query collections still require an explicit `queryFn` in the final config type:
 
 ```typescript
 import { QueryClient } from "@tanstack/query-core"
@@ -87,13 +87,14 @@ const listOptions = queryOptions({
 const todosCollection = createCollection(
   queryCollectionOptions({
     ...listOptions,
+    queryFn: (context) => listOptions.queryFn!(context),
     queryClient,
     getKey: (item) => item.id,
   }),
 )
 ```
 
-`queryFn` is still required at runtime for query collections. If it is missing, `queryCollectionOptions` throws `QueryFnRequiredError`.
+`queryFn` is required for query collections both in types and at runtime. If it is missing at runtime, `queryCollectionOptions` throws `QueryFnRequiredError`.
 
 ### Collection Options
 

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -77,7 +77,7 @@ type QueryOptionsInteropConfig<
   `queryFn` | `queryKey`
 > & {
   queryKey: TaggedQueryKey<TQueryKey, TQueryData, TError>
-  queryFn?: (
+  queryFn: (
     context: QueryFunctionContext<
       TaggedQueryKey<TQueryKey, TQueryData, TError>
     >,
@@ -617,15 +617,10 @@ export function queryCollectionOptions<
 }
 
 export function queryCollectionOptions(
-  config: Omit<
-    QueryCollectionConfig<
-      Record<string, unknown>,
-      (context: QueryFunctionContext<any>) => any
-    >,
-    `queryFn`
-  > & {
-    queryFn?: (context: QueryFunctionContext<any>) => any
-  },
+  config: QueryCollectionConfig<
+    Record<string, unknown>,
+    (context: QueryFunctionContext<any>) => any
+  >,
 ): CollectionConfig<
   Record<string, unknown>,
   string | number,
@@ -662,6 +657,7 @@ export function queryCollectionOptions(
     throw new QueryKeyRequiredError()
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!queryFn) {
     throw new QueryFnRequiredError()
   }


### PR DESCRIPTION
## Summary
To fix this issue: https://github.com/TanStack/db/issues/1279

This PR makes `queryOptions(...)` interop first-class in `@tanstack/query-db-collection`. You can now spread `...queryOptions(...)` into `queryCollectionOptions(...)` without re-declaring `queryKey`, re-shaping `enabled`, or wrapping `queryFn`.

## 🎯 Changes
1. Aligned query collection types with TanStack Query core contracts:
- `queryFn` now accepts `T | Promise<T>` (not Promise-only).
- `enabled` now aligns with `QueryObserverOptions['enabled']` (boolean or callback).
- `staleTime`, `refetchInterval`, `retry`, and `retryDelay` now follow `QueryObserverOptions` typing with the correct query data/key generics.
- Added typed overloads for `DataTag` query keys returned by `queryOptions(...)`.
2. Kept runtime safety strict and unchanged:
- `queryFn` is still required at runtime.
- wrapped responses still require `select` to extract item arrays.
3. Added coverage and docs:
- Added interop tests (including sync `queryFn` return support).
- Added docs section showing `queryOptions(...)` spread usage.
- Intentionally did not add `SkipToken` support (query collections require an executable fetch function).

## Why
The issue is a type-level mismatch between `query-db-collection` and TanStack Query option shapes. This removes boilerplate for existing Query users while preserving query-collection safety guarantees.

Reference: [original TanStack Query types file](https://github.com/TanStack/query/blob/main/packages/query-core/src/types.ts)


## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

Note: there are some failed test files but I didn't changes them 

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
