### PR TITLE
docs: Update query examples to use eq() helper for boolean comparisons

### DIFF
--- a/docs/collections/trailbase-collection.md
+++ b/docs/collections/trailbase-collection.md
@@ -147,7 +147,7 @@ const todosCollection = createCollection(
 ## Complete Example
 
 ```typescript
-import { createCollection } from '@tanstack/react-db'
+import { createCollection, eq } from '@tanstack/react-db'
 import { trailBaseCollectionOptions } from '@tanstack/trailbase-db-collection'
 import { initClient } from 'trailbase'
 import { z } from 'zod'
@@ -195,7 +195,7 @@ export const todosCollection = createCollection<SelectTodo, Todo>(
 function TodoList() {
   const { data: todos } = useLiveQuery((q) =>
     q.from({ todo: todosCollection })
-      .where(({ todo }) => !todo.completed)
+      .where(({ todo }) => eq(todo.completed, false))
       .orderBy(({ todo }) => todo.created_at, 'desc')
   )
 

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -831,7 +831,7 @@ A complete todo application demonstrating validation, transformations, and defau
 
 ```typescript
 import { z } from 'zod'
-import { createCollection } from '@tanstack/react-db'
+import { createCollection, eq } from '@tanstack/react-db'
 import { queryCollectionOptions } from '@tanstack/query-db-collection'
 
 // Schema with validation, transformations, and defaults
@@ -921,7 +921,7 @@ const todoCollection = createCollection(
 function TodoApp() {
   const { data: todos } = useLiveQuery(q =>
     q.from({ todo: todoCollection })
-      .where(({ todo }) => !todo.completed)
+      .where(({ todo }) => eq(todo.completed, false))
       .orderBy(({ todo }) => todo.created_at, 'desc')
   )
 
@@ -991,6 +991,7 @@ function TodoApp() {
 
 ```typescript
 import { z } from 'zod'
+import { eq } from '@tanstack/db'
 
 // Schema with computed fields and transformations
 const productSchema = z.object({
@@ -1046,7 +1047,7 @@ const productCollection = createCollection(
 function ProductList() {
   const { data: products } = useLiveQuery(q =>
     q.from({ product: productCollection })
-      .where(({ product }) => product.in_stock)  // Use computed field
+      .where(({ product }) => eq(product.in_stock, true))  // Use computed field
       .orderBy(({ product }) => product.final_price, 'asc')
   )
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -57,7 +57,7 @@ const todoCollection = createCollection({
 const Todos = () => {
   // Bind data using live queries
   const { data: todos } = useLiveQuery((q) =>
-    q.from({ todo: todoCollection }).where(({ todo }) => todo.completed)
+    q.from({ todo: todoCollection }).where(({ todo }) => eq(todo.completed, false))
   )
 
   const complete = (todo) => {

--- a/docs/reference/classes/BaseQueryBuilder.md
+++ b/docs/reference/classes/BaseQueryBuilder.md
@@ -288,7 +288,7 @@ A QueryBuilder with the specified source
 query.from({ users: usersCollection })
 
 // Query from a subquery
-const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
+const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
 query.from({ activeUsers })
 ```
 
@@ -550,7 +550,7 @@ query
 ```
 
 // Join with a subquery
-const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
+const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
 query
   .from({ activeUsers })
   .join({ p: postsCollection }, ({u, p}) => eq(u.id, p.userId))

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -129,7 +129,7 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
    * query.from({ users: usersCollection })
    *
    * // Query from a subquery
-   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
+   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
    * query.from({ activeUsers })
    * ```
    */
@@ -171,7 +171,7 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
    * ```
    *
    * // Join with a subquery
-   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
+   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
    * query
    *   .from({ activeUsers })
    *   .join({ p: postsCollection }, ({u, p}) => eq(u.id, p.userId))


### PR DESCRIPTION
## 🎯 Changes

fix https://github.com/TanStack/db/issues/1297

Updated documentation examples and code comments to use the `eq()` helper function for boolean field comparisons in `.where()` clauses instead of relying on implicit boolean coercion.

**Changes made:**
- Updated import statements to include `eq` from `@tanstack/react-db` and `@tanstack/db` where needed
- Replaced implicit boolean comparisons (e.g., `!todo.completed`, `product.in_stock`, `u.active`) with explicit `eq()` calls (e.g., `eq(todo.completed, false)`, `eq(product.in_stock, true)`, `eq(u.active, true)`)
- Updated examples across:
  - `docs/guides/schemas.md` (todo and product examples)
  - `docs/collections/trailbase-collection.md` (todo example)
  - `docs/reference/classes/BaseQueryBuilder.md` (API documentation)
  - `docs/overview.md` (overview example)
  - `packages/db/src/query/builder/index.ts` (JSDoc comments)

This change promotes consistency and clarity in query syntax by using the explicit `eq()` helper for all boolean comparisons, making the intent clearer and aligning with best practices for query building.

## ✅ Checklist

- [x] This change is docs/dev-only (no release).

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

https://claude.ai/code/session_01VD8cnL4qhw4k5XKaK9qL8L