### PR TITLE
docs: Use idiomatic boolean filters in query examples

### DIFF
--- a/docs/collections/trailbase-collection.md
+++ b/docs/collections/trailbase-collection.md
@@ -147,7 +147,8 @@ const todosCollection = createCollection(
 ## Complete Example
 
 ```typescript
-import { createCollection, eq } from '@tanstack/react-db'
+import { createCollection } from '@tanstack/react-db'
+import { not } from '@tanstack/db'
 import { trailBaseCollectionOptions } from '@tanstack/trailbase-db-collection'
 import { initClient } from 'trailbase'
 import { z } from 'zod'
@@ -195,7 +196,7 @@ export const todosCollection = createCollection<SelectTodo, Todo>(
 function TodoList() {
   const { data: todos } = useLiveQuery((q) =>
     q.from({ todo: todosCollection })
-      .where(({ todo }) => eq(todo.completed, false))
+      .where(({ todo }) => not(todo.completed))
       .orderBy(({ todo }) => todo.created_at, 'desc')
   )
 

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -831,7 +831,8 @@ A complete todo application demonstrating validation, transformations, and defau
 
 ```typescript
 import { z } from 'zod'
-import { createCollection, eq } from '@tanstack/react-db'
+import { createCollection } from '@tanstack/react-db'
+import { not } from '@tanstack/db'
 import { queryCollectionOptions } from '@tanstack/query-db-collection'
 
 // Schema with validation, transformations, and defaults
@@ -921,7 +922,7 @@ const todoCollection = createCollection(
 function TodoApp() {
   const { data: todos } = useLiveQuery(q =>
     q.from({ todo: todoCollection })
-      .where(({ todo }) => eq(todo.completed, false))
+      .where(({ todo }) => not(todo.completed))
       .orderBy(({ todo }) => todo.created_at, 'desc')
   )
 
@@ -991,7 +992,6 @@ function TodoApp() {
 
 ```typescript
 import { z } from 'zod'
-import { eq } from '@tanstack/db'
 
 // Schema with computed fields and transformations
 const productSchema = z.object({
@@ -1047,7 +1047,7 @@ const productCollection = createCollection(
 function ProductList() {
   const { data: products } = useLiveQuery(q =>
     q.from({ product: productCollection })
-      .where(({ product }) => eq(product.in_stock, true))  // Use computed field
+      .where(({ product }) => product.in_stock)  // Use computed field
       .orderBy(({ product }) => product.final_price, 'asc')
   )
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -57,7 +57,7 @@ const todoCollection = createCollection({
 const Todos = () => {
   // Bind data using live queries
   const { data: todos } = useLiveQuery((q) =>
-    q.from({ todo: todoCollection }).where(({ todo }) => eq(todo.completed, false))
+    q.from({ todo: todoCollection }).where(({ todo }) => not(todo.completed))
   )
 
   const complete = (todo) => {

--- a/docs/reference/classes/BaseQueryBuilder.md
+++ b/docs/reference/classes/BaseQueryBuilder.md
@@ -288,7 +288,7 @@ A QueryBuilder with the specified source
 query.from({ users: usersCollection })
 
 // Query from a subquery
-const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
+const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
 query.from({ activeUsers })
 ```
 
@@ -550,7 +550,7 @@ query
 ```
 
 // Join with a subquery
-const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
+const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
 query
   .from({ activeUsers })
   .join({ p: postsCollection }, ({u, p}) => eq(u.id, p.userId))

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -129,7 +129,7 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
    * query.from({ users: usersCollection })
    *
    * // Query from a subquery
-   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
+   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
    * query.from({ activeUsers })
    * ```
    */
@@ -171,7 +171,7 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
    * ```
    *
    * // Join with a subquery
-   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => eq(u.active, true))
+   * const activeUsers = query.from({ u: usersCollection }).where(({u}) => u.active)
    * query
    *   .from({ activeUsers })
    *   .join({ p: postsCollection }, ({u, p}) => eq(u.id, p.userId))


### PR DESCRIPTION
## Summary
- Replace `eq(todo.completed, false)` with `not(todo.completed)` in query examples
- Replace `eq(product.in_stock, true)` / `eq(u.active, true)` with bare boolean refs (`product.in_stock`, `u.active`)
- Update imports accordingly (swap `eq` for `not` where needed, remove unused `eq` imports)

Depends on #1304 which adds support for bare boolean column refs in `where()`/`having()`.

## Test plan
- [x] Docs-only change, no runtime impact
- [ ] Verify examples render correctly in docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)