### PR TITLE
docs: warn about isPersisted vs isPersisted.promise footgun

### DIFF
--- a/docs/guides/mutations.md
+++ b/docs/guides/mutations.md
@@ -1452,6 +1452,21 @@ try {
 }
 ```
 
+> [!IMPORTANT]
+> **Always use `tx.isPersisted.promise`, not `tx.isPersisted`.** The `isPersisted` property is a `Deferred` object, not a `Promise`. Since `Deferred` does not implement a `.then()` method, `await tx.isPersisted` resolves immediately to the `Deferred` object itself — it does **not** wait for the transaction to persist.
+>
+> This is a silent bug that TypeScript will not catch, because `await` accepts any value.
+>
+> ```typescript
+> // ❌ BUG: resolves immediately — does not wait for persistence
+> await tx.isPersisted
+>
+> // ✅ CORRECT: waits for the transaction to complete or fail
+> await tx.isPersisted.promise
+> ```
+>
+> If you forget `.promise`, your UI may clear forms, navigate, or show success messages before the server has confirmed the write. If the server then rejects the mutation, the optimistic state rolls back silently with no error handling.
+
 ### State Transitions
 
 The normal flow is: `pending` → `persisting` → `completed`


### PR DESCRIPTION
Adds an `IMPORTANT` callout to the Transaction States section warning that `await tx.isPersisted` silently resolves immediately because `Deferred` is not a thenable. Users must use `tx.isPersisted.promise`.

This is a real-world bug we hit in production. TypeScript does not flag it because `await` accepts `any`. The consequence is that forms clear, navigation fires, and success messages display before the server confirms the write — and if the server rejects, the rollback happens silently with no error handling.

**Context:**

- `Deferred<T>` (defined in `src/deferred.ts`) has no `.then()` method
- `await nonThenable` resolves to the value itself per the JS spec
- Every doc example already uses `.promise` correctly, but there's no explicit warning about omitting it