### PR TITLE
Import 'eq' from '@tanstack/react-db' in example.

### DIFF
--- a/docs/framework/react/overview.md
+++ b/docs/framework/react/overview.md
@@ -22,7 +22,7 @@ For comprehensive documentation on writing queries (filtering, joins, aggregatio
 The `useLiveQuery` hook creates a live query that automatically updates your component when data changes:
 
 ```tsx
-import { useLiveQuery } from '@tanstack/react-db'
+import { useLiveQuery, eq } from '@tanstack/react-db'
 
 function TodoList() {
   const { data, isLoading } = useLiveQuery((q) =>


### PR DESCRIPTION
## 🎯 Changes

Updated example to include missing `eq` import.

## ✅ Checklist

- [ ] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
