### PR TITLE
update @electric-sql/client version

### DIFF
--- a/.changeset/upgrade-electric-client-1512.md
+++ b/.changeset/upgrade-electric-client-1512.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/electric-db-collection': patch
+---
+
+fix(electric-db-collection): Upgrade to latest electric client version

--- a/packages/electric-db-collection/package.json
+++ b/packages/electric-db-collection/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "dependencies": {
-    "@electric-sql/client": "^1.5.10",
+    "@electric-sql/client": "^1.5.12",
     "@standard-schema/spec": "^1.1.0",
     "@tanstack/db": "workspace:*",
     "@tanstack/store": "^0.8.0",

--- a/packages/react-db/package.json
+++ b/packages/react-db/package.json
@@ -53,7 +53,7 @@
     "react": ">=16.8.0"
   },
   "devDependencies": {
-    "@electric-sql/client": "^1.5.10",
+    "@electric-sql/client": "^1.5.12",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",

--- a/packages/solid-db/package.json
+++ b/packages/solid-db/package.json
@@ -48,7 +48,7 @@
     "solid-js": ">=1.9.0"
   },
   "devDependencies": {
-    "@electric-sql/client": "^1.5.10",
+    "@electric-sql/client": "^1.5.12",
     "@solidjs/testing-library": "^0.8.10",
     "@vitest/coverage-istanbul": "^3.2.4",
     "jsdom": "^27.4.0",

--- a/packages/vue-db/package.json
+++ b/packages/vue-db/package.json
@@ -51,7 +51,7 @@
     "vue": ">=3.3.0"
   },
   "devDependencies": {
-    "@electric-sql/client": "^1.5.10",
+    "@electric-sql/client": "^1.5.12",
     "@vitejs/plugin-vue": "^6.0.4",
     "@vitest/coverage-istanbul": "^3.2.4",
     "vue": "^3.5.28"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,8 +862,8 @@ importers:
   packages/electric-db-collection:
     dependencies:
       '@electric-sql/client':
-        specifier: ^1.5.10
-        version: 1.5.10
+        specifier: ^1.5.12
+        version: 1.5.12
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -975,8 +975,8 @@ importers:
         version: 1.6.0(react@19.2.4)
     devDependencies:
       '@electric-sql/client':
-        specifier: ^1.5.10
-        version: 1.5.10
+        specifier: ^1.5.12
+        version: 1.5.12
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1040,8 +1040,8 @@ importers:
         version: link:../db
     devDependencies:
       '@electric-sql/client':
-        specifier: ^1.5.10
-        version: 1.5.10
+        specifier: ^1.5.12
+        version: 1.5.12
       '@solidjs/testing-library':
         specifier: ^0.8.10
         version: 0.8.10(solid-js@1.9.11)
@@ -1121,8 +1121,8 @@ importers:
         version: link:../db
     devDependencies:
       '@electric-sql/client':
-        specifier: ^1.5.10
-        version: 1.5.10
+        specifier: ^1.5.12
+        version: 1.5.12
       '@vitejs/plugin-vue':
         specifier: ^6.0.4
         version: 6.0.4(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.5.29(typescript@5.9.3))
@@ -2002,8 +2002,9 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@electric-sql/client@1.5.10':
-    resolution: {integrity: sha512-AMXaGhGSUYPZSQHvtUIYoW0IQVW5MSAT1Oc2jDb1KyAPQa5wypoW6NzGqaUR7jKkNh9vJiqKjT56nH+fh1bu0g==}
+  '@electric-sql/client@1.5.12':
+    resolution: {integrity: sha512-mWDEpKog0Zo4WOjReW4x9ELaHsjTthpziLVJkjmSdh/4Y/ZHw5EoY5e9dJX9itPSKVk9GNFz3YfHFv5EAyCOmw==}
+    hasBin: true
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -11688,7 +11689,7 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@electric-sql/client@1.5.10':
+  '@electric-sql/client@1.5.12':
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Bumps `@electric-sql/client` from `^1.5.10` to `^1.5.12` across all packages that depend on it, picking up the latest patch fixes.

## Approach

Follows the same pattern as #1321. Updated the version specifier in all four packages:

- `electric-db-collection` — production dependency
- `react-db`, `solid-db`, `vue-db` — dev dependencies (used for testing)

## Files changed

| File | Change |
|------|--------|
| `packages/electric-db-collection/package.json` | `^1.5.10` → `^1.5.12` (dependency) |
| `packages/react-db/package.json` | `^1.5.10` → `^1.5.12` (devDependency) |
| `packages/solid-db/package.json` | `^1.5.10` → `^1.5.12` (devDependency) |
| `packages/vue-db/package.json` | `^1.5.10` → `^1.5.12` (devDependency) |
| `pnpm-lock.yaml` | Lockfile update |
| `.changeset/upgrade-electric-client-1512.md` | Patch changeset for electric-db-collection |

## Verification

```bash
pnpm install
pnpm build
pnpm test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)