### PR TITLE
fix(db): reject preload() promise when collection errors so ErrorBoundary is reached

### DIFF
--- a/.changeset/xtjpqj-ah-fix.md
+++ b/.changeset/xtjpqj-ah-fix.md
@@ -1,0 +1,19 @@
+---
+"@tanstack/db": patch
+"@tanstack/react-db": patch
+---
+
+fix(db): reject preload() promise when collection transitions to error state
+
+Previously, `preload()` only resolved when the collection became ready. If
+the collection transitioned to the `error` state while the promise was pending
+(e.g. because the `queryFn` threw), the promise would hang forever, keeping
+any `<Suspense>` boundary suspended indefinitely and preventing the error from
+reaching an `<ErrorBoundary>`.
+
+Now `preload()` subscribes to `status:change` events and rejects the promise
+when the collection enters the `error` state. `useLiveSuspenseQuery` is also
+updated to re-throw the actual error from `collection.utils?.lastError` instead
+of a generic fallback message, so `<ErrorBoundary>` receives the original error.
+
+Fixes #1343

--- a/.changeset/xtjpqj-ah-fix.md
+++ b/.changeset/xtjpqj-ah-fix.md
@@ -1,6 +1,6 @@
 ---
-"@tanstack/db": patch
-"@tanstack/react-db": patch
+'@tanstack/db': patch
+'@tanstack/react-db': patch
 ---
 
 fix(db): reject preload() promise when collection transitions to error state

--- a/packages/db/src/collection/sync.ts
+++ b/packages/db/src/collection/sync.ts
@@ -271,8 +271,20 @@ export class CollectionSyncManager<
         return
       }
 
+      // Subscribe to status changes to reject the promise when collection errors.
+      // This is necessary because onFirstReady only fires on success, but if the
+      // collection transitions to 'error' while the promise is pending it would
+      // hang forever and keep the Suspense boundary suspended indefinitely.
+      const unsubscribeError = this._events.on(`status:change`, (event) => {
+        if (event.status === `error`) {
+          unsubscribeError()
+          reject(new CollectionIsInErrorStateError())
+        }
+      })
+
       // Register callback BEFORE starting sync to avoid race condition
       this.lifecycle.onFirstReady(() => {
+        unsubscribeError()
         resolve()
       })
 

--- a/packages/react-db/src/useLiveSuspenseQuery.ts
+++ b/packages/react-db/src/useLiveSuspenseQuery.ts
@@ -199,9 +199,7 @@ export function useLiveSuspenseQuery(
     const lastError = (result.collection as any).utils?.lastError
     throw lastError instanceof Error
       ? lastError
-      : new Error(
-          `Collection "${result.collection.id}" failed to load`,
-        )
+      : new Error(`Collection "${result.collection.id}" failed to load`)
   }
 
   if (result.status === `loading` || result.status === `idle`) {

--- a/packages/react-db/src/useLiveSuspenseQuery.ts
+++ b/packages/react-db/src/useLiveSuspenseQuery.ts
@@ -193,9 +193,15 @@ export function useLiveSuspenseQuery(
   // After success, errors surface as stale data (matches TanStack Query behavior)
   if (result.status === `error` && !hasBeenReadyRef.current) {
     promiseRef.current = null
-    // TODO: Once collections hold a reference to their last error object (#671),
-    // we should rethrow that actual error instead of creating a generic message
-    throw new Error(`Collection "${result.collection.id}" failed to load`)
+    // Re-throw the actual error from the collection if available (e.g. from
+    // query-db-collection's utils.lastError), otherwise fall back to a generic
+    // message. Throwing here propagates the error to the nearest ErrorBoundary.
+    const lastError = (result.collection as any).utils?.lastError
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(
+          `Collection "${result.collection.id}" failed to load`,
+        )
   }
 
   if (result.status === `loading` || result.status === `idle`) {


### PR DESCRIPTION
## Summary

Fixes #1343

`useLiveSuspenseQuery` was not propagating collection errors to `<ErrorBoundary>` because `preload()` would hang forever when the collection transitioned to the `error` state.

## Root Cause

In `packages/db/src/collection/sync.ts`, `preload()` registers an `onFirstReady` callback that resolves the promise when the collection becomes ready. However, if the collection transitions to `error` while the promise is pending (e.g. because `queryFn` throws), the promise was **never settled** — neither resolved nor rejected. This left any `<Suspense>` boundary in a permanently suspended state and prevented the error from bubbling to an `<ErrorBoundary>`.

## Fix

Two changes:

### 1. `packages/db/src/collection/sync.ts`
Subscribe to `status:change` events inside `preload()`. If the collection enters the `error` state while the promise is pending, reject the promise immediately with a `CollectionIsInErrorStateError`.

### 2. `packages/react-db/src/useLiveSuspenseQuery.ts`
Re-throw the actual error from `collection.utils?.lastError` (available via `query-db-collection`) instead of a generic fallback message, so `<ErrorBoundary>` receives the original error object.

## Testing

All existing tests pass (`@tanstack/db` and `@tanstack/react-db`). The bug is also repro-able with the StackBlitz sandbox in the issue — after this fix the `<ErrorBoundary>` catches the error and renders its fallback.