### PR TITLE
test(query-db-collection): add non-e2e remount regression for disjoint live queries

### DIFF
--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -7,6 +7,7 @@ import {
   ilike,
   or,
 } from '@tanstack/db'
+import { createFilterFunctionFromExpression } from '../../db/src/collection/change-events'
 import { queryCollectionOptions } from '../src/query'
 import type { QueryFunctionContext } from '@tanstack/query-core'
 import type {
@@ -28,6 +29,12 @@ interface CategorisedItem {
   id: string
   name: string
   category: string
+}
+
+interface OrderedMessage {
+  id: string
+  sequence: number
+  createdAt: number
 }
 
 const getKey = (item: TestItem) => item.id
@@ -4489,6 +4496,125 @@ describe(`QueryCollection`, () => {
   })
 
   describe(`Cache Persistence on Remount`, () => {
+    it(`should not skip ordered rows after remounting with a smaller window over cached data`, async () => {
+      const PAGE_SIZE = 50
+      const initialRows: Array<OrderedMessage> = Array.from(
+        { length: 200 },
+        (_, index) => ({
+          id: `message-${String(index + 6).padStart(4, `0`)}`,
+          sequence: index + 6,
+          createdAt: 10_000 - index,
+        }),
+      )
+
+      let backendRows = [...initialRows]
+
+      const customQueryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            gcTime: 5 * 60 * 1000,
+            staleTime: Infinity,
+            retry: false,
+          },
+        },
+      })
+
+      const queryFn = vi.fn().mockImplementation((ctx) => {
+        const options = ctx.meta?.loadSubsetOptions ?? {}
+        let rows = [...backendRows].sort(
+          (left, right) =>
+            right.createdAt - left.createdAt || right.id.localeCompare(left.id),
+        )
+
+        if (options.cursor?.whereFrom) {
+          const includeRow = createFilterFunctionFromExpression(
+            options.cursor.whereFrom,
+          )
+          rows = rows.filter(includeRow)
+        }
+
+        if (options.limit !== undefined) {
+          rows = rows.slice(0, options.limit)
+        }
+
+        return Promise.resolve(rows)
+      })
+
+      const config: QueryCollectionConfig<OrderedMessage> = {
+        id: `ordered-remount-gap-test`,
+        queryClient: customQueryClient,
+        queryKey: (opts) => [
+          `ordered-remount-gap-test`,
+          opts.limit ?? null,
+          opts.cursor ? JSON.stringify(opts.cursor.whereFrom) : `initial`,
+        ],
+        queryFn,
+        getKey: (item) => item.id,
+        syncMode: `on-demand`,
+      }
+
+      const source = createCollection(queryCollectionOptions(config))
+
+      const firstQuery = createLiveQueryCollection({
+        query: (q) =>
+          q
+            .from({ message: source })
+            .orderBy(({ message }) => message.createdAt, `desc`)
+            .limit(PAGE_SIZE * 3 + 1),
+      })
+
+      await firstQuery.preload()
+      await vi.waitFor(() => {
+        expect(firstQuery.size).toBe(151)
+      })
+
+      await firstQuery.cleanup()
+      await flushPromises()
+
+      backendRows = [
+        ...Array.from({ length: 5 }, (_, index) => ({
+          id: `message-${String(index + 1).padStart(4, `0`)}`,
+          sequence: index + 1,
+          createdAt: 20_000 - index,
+        })),
+        ...backendRows,
+      ]
+
+      const secondQuery = createLiveQueryCollection({
+        query: (q) =>
+          q
+            .from({ message: source })
+            .orderBy(({ message }) => message.createdAt, `desc`)
+            .limit(PAGE_SIZE + 1),
+      })
+
+      await secondQuery.preload()
+      await vi.waitFor(() => {
+        expect(secondQuery.size).toBe(51)
+      })
+
+      for (const expectedLimit of [101, 151, 201, 251]) {
+        const result = secondQuery.utils.setWindow({
+          offset: 0,
+          limit: expectedLimit,
+        })
+        if (result !== true) {
+          await result
+        }
+      }
+
+      await vi.waitFor(() => {
+        expect(secondQuery.size).toBe(205)
+      })
+
+      expect(secondQuery.toArray.map((row) => row.sequence)).toEqual(
+        Array.from({ length: 205 }, (_, index) => index + 1),
+      )
+
+      await secondQuery.cleanup()
+      customQueryClient.clear()
+    })
+
     it(`should process cached results immediately when QueryObserver resubscribes`, async () => {
       const queryKey = [`remount-cache-test`]
       const items: Array<TestItem> = [
@@ -4766,6 +4892,206 @@ describe(`QueryCollection`, () => {
 
       // Cleanup
       testQueryClient.clear()
+    })
+
+    it(`should preserve rows loaded by a history query when a disjoint after-query returns no rows in the same session`, async () => {
+      type PartitionedMessage = OrderedMessage & {
+        partition: `history` | `after`
+      }
+
+      const rows: Array<PartitionedMessage> = Array.from(
+        { length: 26 },
+        (_, index) => ({
+          id: `message-${String(index + 1).padStart(4, `0`)}`,
+          sequence: index + 1,
+          createdAt: 10_000 - index,
+          partition: `history`,
+        }),
+      )
+
+      const localQueryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            gcTime: 5 * 60 * 1000,
+            staleTime: Infinity,
+            retry: false,
+          },
+        },
+      })
+
+      const queryFn = vi.fn().mockImplementation((ctx) => {
+        const options = ctx.meta?.loadSubsetOptions ?? {}
+        let filteredRows = [...rows]
+
+        if (options.where) {
+          const includeRow = createFilterFunctionFromExpression(options.where)
+          filteredRows = filteredRows.filter(includeRow)
+        }
+
+        return Promise.resolve(filteredRows)
+      })
+
+      const collection = createCollection(
+        queryCollectionOptions<PartitionedMessage>({
+          id: `same-session-disjoint-queries`,
+          queryClient: localQueryClient,
+          queryKey: [`same-session-disjoint-queries`],
+          queryFn,
+          getKey: (item) => item.id,
+          syncMode: `on-demand`,
+        }),
+      )
+
+      const historyQuery = createLiveQueryCollection({
+        query: (q) =>
+          q
+            .from({ message: collection })
+            .where(({ message }) => eq(message.partition, `history`))
+            .select(({ message }) => message),
+      })
+
+      const afterQuery = createLiveQueryCollection({
+        query: (q) =>
+          q
+            .from({ message: collection })
+            .where(({ message }) => eq(message.partition, `after`))
+            .select(({ message }) => message),
+      })
+
+      await historyQuery.preload()
+      await flushPromises()
+
+      expect(historyQuery.size).toBe(rows.length)
+      expect(collection.size).toBe(rows.length)
+
+      await afterQuery.preload()
+      await flushPromises()
+
+      expect(afterQuery.size).toBe(0)
+      expect(historyQuery.size).toBe(rows.length)
+      expect(collection.size).toBe(rows.length)
+      expect(collection._state.syncedData.size).toBe(rows.length)
+
+      await historyQuery.cleanup()
+      await afterQuery.cleanup()
+      localQueryClient.clear()
+    })
+
+    it(`should preserve rows loaded by a history query when a disjoint after-query returns no rows after remount`, async () => {
+      type PartitionedMessage = OrderedMessage & {
+        partition: `history` | `after`
+      }
+
+      const restoredRows: Array<PartitionedMessage> = Array.from(
+        { length: 26 },
+        (_, index) => ({
+          id: `message-${String(index + 1).padStart(4, `0`)}`,
+          sequence: index + 1,
+          createdAt: 10_000 - index,
+          partition: `history`,
+        }),
+      )
+
+      const queryFn = vi.fn().mockImplementation((ctx) => {
+        const options = ctx.meta?.loadSubsetOptions ?? {}
+        let rows = [...restoredRows]
+
+        if (options.where) {
+          const includeRow = createFilterFunctionFromExpression(options.where)
+          rows = rows.filter(includeRow)
+        }
+
+        return Promise.resolve(rows)
+      })
+
+      const warmQueryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            gcTime: 5 * 60 * 1000,
+            staleTime: Infinity,
+            retry: false,
+          },
+        },
+      })
+
+      const config: QueryCollectionConfig<PartitionedMessage> = {
+        id: `restored-synced-rows-empty-query`,
+        queryClient: warmQueryClient,
+        queryKey: [`restored-synced-rows-empty-query`],
+        queryFn,
+        getKey: (item) => item.id,
+        syncMode: `on-demand`,
+      }
+
+      const warmCollection = createCollection(queryCollectionOptions(config))
+
+      const historyQuery = createLiveQueryCollection({
+        query: (q) =>
+          q
+            .from({ message: warmCollection })
+            .where(({ message }) => eq(message.partition, `history`))
+            .select(({ message }) => message),
+      })
+
+      await historyQuery.preload()
+      await flushPromises()
+
+      expect(historyQuery.size).toBe(restoredRows.length)
+      expect(warmCollection.size).toBe(restoredRows.length)
+
+      await historyQuery.cleanup()
+      warmQueryClient.clear()
+
+      const restoredQueryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            gcTime: 5 * 60 * 1000,
+            staleTime: Infinity,
+            retry: false,
+          },
+        },
+      })
+
+      const restoredConfig: QueryCollectionConfig<PartitionedMessage> = {
+        ...config,
+        queryClient: restoredQueryClient,
+      }
+
+      const collection = createCollection(queryCollectionOptions(restoredConfig))
+
+      // Simulate the warm-remount state from the app repro:
+      // the collection already contains history rows from the previous session,
+      // but the new session has not rebuilt per-query row ownership yet.
+      restoredRows.forEach((row) => {
+        collection._state.syncedData.set(row.id, row)
+      })
+      collection._state.size = restoredRows.length
+
+      expect(collection.size).toBe(restoredRows.length)
+      expect(collection._state.syncedData.size).toBe(restoredRows.length)
+      expect([...collection._state.syncedData.values()]).toEqual(restoredRows)
+
+      const afterQuery = createLiveQueryCollection({
+        query: (q) =>
+          q
+            .from({ message: collection })
+            .where(({ message }) => eq(message.partition, `after`))
+            .select(({ message }) => message),
+      })
+
+      await afterQuery.preload()
+      await flushPromises()
+
+      expect(queryFn).toHaveBeenCalled()
+      expect(afterQuery.size).toBe(0)
+
+      // Contract: a disjoint "after" query with no rows must not delete the
+      // non-overlapping history rows that were already present in the collection.
+      expect(collection.size).toBe(restoredRows.length)
+      expect(collection._state.syncedData.size).toBe(restoredRows.length)
+
+      await afterQuery.cleanup()
+      restoredQueryClient.clear()
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

This PR adds a regression reproducer for a warm-path bug in `query-db-collection`.

**Problem**

When two disjoint live queries share the same query-backed collection:
- a `history` query loads rows that belong to the historical range
- an `after` query loads rows after that range

The expected contract is:
- if the `after` query returns `[]`, it should not affect rows already loaded by the `history` query, because the two result sets do not overlap.

## Sequence of events

### Cold path

1. app starts with no restored local rows
2. history query runs
3. history rows are inserted
4. ownership metadata is built normally
5. live/after query runs
6. because ownership is present, the two disjoint queries coexist correctly

Outcome:
- stable

### Warm path

1. app starts and restores rows from persistence
2. those restored rows are already sitting in the shared collection
3. but the in-memory ownership metadata has not been rebuilt yet
4. live/after query runs and returns `[]`
5. reconciliation looks at the collection and sees rows that appear unowned
6. it removes them
7. then the history query repopulates them later

Outcome:
- unstable
- you see `25 -> 0 -> 1/13 -> 25`

What `1/13` means:
- across runs, the intermediate partial recovery step was not always the same size
- sometimes it showed `1`
- sometimes it showed `13`

Why `13` is interesting:
- in the app case that motivated this reproducer, there were `38` total historical rows
- the intended initial visible page was `25`
- `38 - 25 = 13`
- so the `13` likely represents the remainder of the historical set briefly surfacing during the bad warm-path transition

## What this PR adds

Two paired tests in `packages/query-db-collection/tests/query.test.ts`:
- `should preserve rows loaded by a history query when a disjoint after-query returns no rows in the same session`
- `should preserve rows loaded by a history query when a disjoint after-query returns no rows after remount`

These tests map directly to the walkthrough above:
- same session / cold path: passes
- after remount / warm path: fails

This PR is a reproducer for review, not a fix.

## ✅ Checklist

- [ ] I have tested this code locally with `pnpm test`.
  - I ran targeted verification with `pnpm --filter @tanstack/query-db-collection test -- --runInBand -t "disjoint after-query returns no rows"`.
  - Current result: the same-session test passes, and the remount test fails on `expected 26, received 0`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
