### PR TITLE
docs: PowerSync Query-driven sync documentation improvements

### DIFF
--- a/docs/collections/powersync-collection.md
+++ b/docs/collections/powersync-collection.md
@@ -610,47 +610,34 @@ In examples 3 and 4, Sync Stream subscription parameters are hardcoded. Examples
 
 In `eager` mode, all data from the SQLite database is synced into the TanStack DB collection. The live query then filters this full dataset to produce the final result. This means the collection holds all rows regardless of whether they match any active query.
 
-```mermaid
-block-beta
-    columns 5
+**SQLite**
 
-    block:SQL
-        columns 2
-        sql_title["SQLite"]:2
-        SQL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        SQL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        SQL3["id: 3\nlist_id: list_2\ncompleted: 0"]
-        SQL4["id: 4\nlist_id: list_2\ncompleted: 1"]
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
+| 3  | list_2  |     0     |
+| 4  | list_2  |     1     |
 
-    space
+*Eager mode syncs all SQLite data to TanStack DB Collection*
 
-    block:COL
-        columns 2
-        col_title["Collection"]:2
-        COL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        COL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        COL3["id: 3\nlist_id: list_2\ncompleted: 0"]
-        COL4["id: 4\nlist_id: list_2\ncompleted: 1"]
-    end
+**Collection**
 
-    space
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
+| 3  | list_2  |     0     |
+| 4  | list_2  |     1     |
 
-    block:RES
-        columns 2
-        res_title["Result"]:2
-        RES1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        RES2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+*TanStack DB Query filters for list_id = 'list_1'*
 
-    SQL -- "Eager mode syncs all SQLite data\nto TanStack DB Collection" --> COL
-    COL -- "TanStack DB Query filters\nfor list_id = 'list_1'" --> RES
+**Result**
 
-    style sql_title fill:none,stroke:none
-    style col_title fill:none,stroke:none
-    style res_title fill:none,stroke:none
-```
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
 ```typescript
 const collection = createCollection(
@@ -679,46 +666,32 @@ const liveQuery = createLiveQueryCollection({
 
 In `on-demand` mode, only data from the SQLite database that satisfies the predicates of active TanStack DB live queries is synced into the TanStack DB collection. This reduces the amount of data held in memory, since the collection only contains rows that are relevant to the queries currently registered against it.
 
-```mermaid
-block-beta
-    columns 5
+**SQLite**
 
-    block:SQL
-        columns 2
-        sql_title["SQLite"]:2
-        SQL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        SQL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        SQL3["id: 3\nlist_id: list_2\ncompleted: 0"]
-        SQL4["id: 4\nlist_id: list_2\ncompleted: 1"]
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
+| 3  | list_2  |     0     |
+| 4  | list_2  |     1     |
 
-    space
+*On-demand mode only syncs data from SQLite to the TanStack DB collection if they satisfy any of the live queries: list_id = 'list_1'*
 
-    block:COL
-        columns 2
-        col_title["Collection"]:2
-        COL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        COL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+**Collection**
 
-    space
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
-    block:RES
-        columns 2
-        res_title["Result"]:2
-        RES1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        RES2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+*TanStack DB Query filters for list_id = 'list_1'*
 
-    SQL -- "On-demand mode only syncs \n data from SQLite to the\n TanStack DB collection if they\nsatisfy any of the live queries:\nlist_id = 'list_1'" --> COL
-    COL -- "TanStack DB Query filters\nfor list_id = 'list_1'" --> RES
+**Result**
 
-    style sql_title fill:none,stroke:none
-    style col_title fill:none,stroke:none
-    style res_title fill:none,stroke:none
-```
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
 ```typescript
 const collection = createCollection(
@@ -767,58 +740,40 @@ The hook can optionally return a cleanup function where you can unsubscribe from
 
 This example starts with 4 todos in the PowerSync Service, only 2 of which get synced via the Sync Stream to the SQLite database. Because it's eager mode, both get synced from the SQLite database to the collection. Finally the TanStack DB query only returns the single todo that matches the live query predicate.
 
-```mermaid
-block-beta
-    columns 7
+**PS Service**
 
-    block:PS
-        columns 2
-        ps_title["PS Service"]:2
-        PS1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        PS2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        PS3["id: 3\nlist_id: list_2\ncompleted: 0"]
-        PS4["id: 4\nlist_id: list_2\ncompleted: 1"]
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
+| 3  | list_2  |     0     |
+| 4  | list_2  |     1     |
 
-    space
+*Subscribe to Sync Stream, only sync where list_id = 'list_1'*
 
-    block:SQL
-        columns 2
-        sql_title["SQLite"]:2
-        SQL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        SQL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+**SQLite**
 
-    space
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
-    block:COL
-        columns 2
-        col_title["Collection"]:2
-        COL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        COL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+*Eager mode syncs all SQLite data to TanStack DB Collection*
 
-    space
+**Collection**
 
-    block:RES
-        columns 2
-        res_title["Result"]:2
-        RES1["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space
-        space space
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
-    PS -- "Subscribe to Sync Stream,\nonly sync where list_id = 'list_1'" --> SQL
-    SQL -- "Eager mode syncs all SQLite data\nto TanStack DB Collection" --> COL
-    COL -- "TanStack DB Query filters\nfor completed = 1" --> RES
+*TanStack DB Query filters for completed = 1*
 
-    style ps_title fill:none,stroke:none
-    style sql_title fill:none,stroke:none
-    style col_title fill:none,stroke:none
-    style res_title fill:none,stroke:none
-```
+**Result**
+
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 2  | list_1  |     1     |
 
 ```typescript
 const collection = createCollection(
@@ -862,58 +817,39 @@ The hook can optionally return a cleanup function where you can unsubscribe from
 
 This example starts with 4 todos in the PowerSync Service, only 2 of which get synced via the Sync Stream to the SQLite database. Because it's on-demand mode, only 1 todo matches gets synced from the SQLite database to the collection. Finally the TanStack DB query only returns the single todo that matches the live query predicate.
 
-```mermaid
-block-beta
-    columns 7
+**PS Service**
 
-    block:PS
-        columns 2
-        ps_title["PS Service"]:2
-        PS1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        PS2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        PS3["id: 3\nlist_id: list_2\ncompleted: 0"]
-        PS4["id: 4\nlist_id: list_2\ncompleted: 1"]
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
+| 3  | list_2  |     0     |
+| 4  | list_2  |     1     |
 
-    space
+*Subscribe to Sync Stream, only sync where list_id = 'list_1'*
 
-    block:SQL
-        columns 2
-        sql_title["SQLite"]:2
-        SQL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        SQL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+**SQLite**
 
-    space
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
-    block:COL
-        columns 2
-        col_title["Collection"]:2
-        COL1["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space
-        space space
-    end
+*On-demand mode only syncs data from SQLite to the TanStack DB collection if they satisfy any of the live queries: completed = 1*
 
-    space
+**Collection**
 
-    block:RES
-        columns 2
-        res_title["Result"]:2
-        RES1["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space
-        space space
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 2  | list_1  |     1     |
 
-    PS -- "Subscribe to Sync Stream,\nonly sync where list_id = 'list_1'" --> SQL
-    SQL -- "On-demand mode only syncs \n data from SQLite to the\n TanStack DB collection if they\nsatisfy any of the live queries:\ncompleted = 1" --> COL
-    COL -- "TanStack DB Query filters\nfor completed = 1" --> RES
+*TanStack DB Query filters for completed = 1*
 
-    style ps_title fill:none,stroke:none
-    style sql_title fill:none,stroke:none
-    style col_title fill:none,stroke:none
-    style res_title fill:none,stroke:none
-```
+**Result**
+
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 2  | list_1  |     1     |
 
 ```typescript
 const collection = createCollection(
@@ -967,58 +903,41 @@ Note: This example slightly differs from the previous two as it aims to illustra
 
 This example starts with 4 todos in the PowerSync Service, the Sync Stream subscription criteria (`list_id = "list_1"`) is derived from the live query registered against the collection. Only 2 todos get synced via the Sync Stream to the SQLite database. Two todos get synced from the SQLite database to the collection. Finally the TanStack DB query returns both todos as they both match `eq(todo.list_id, 'list_id')`.
 
-```mermaid
-block-beta
-    columns 7
+**PS Service**
 
-    block:PS
-        columns 2
-        ps_title["PS Service"]:2
-        PS1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        PS2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        PS3["id: 3\nlist_id: list_2\ncompleted: 0"]
-        PS4["id: 4\nlist_id: list_2\ncompleted: 1"]
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
+| 3  | list_2  |     0     |
+| 4  | list_2  |     1     |
 
-    space
+*Derive the list_id criteria from live query, subscribe to Sync Stream, only sync where list = 'list_1'*
 
-    block:SQL
-        columns 2
-        sql_title["SQLite"]:2
-        SQL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        SQL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+**SQLite**
 
-    space
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
-    block:COL
-        columns 2
-        col_title["Collection"]:2
-        COL1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        COL2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+*On-demand mode only syncs data from SQLite to the TanStack DB collection if they satisfy any of the live queries: list_id = 'list_1'*
 
-    space
+**Collection**
 
-    block:RES
-        columns 2
-        res_title["Result"]:2
-        RES1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        RES2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space space
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
-    PS -- "Derive the list_id criteria from \n live query, subscribe to sync\n stream, only sync \n where list = 'list_1'" --> SQL
-    SQL -- "On-demand mode only syncs\n data from SQLite to the\n TanStack DB collection if they\nsatisfy any of the live queries:\nlist_id = 'list_1'" --> COL
-    COL -- "TanStack DB Query filters\nfor list_id = 'list_1'" --> RES
+*TanStack DB Query filters for list_id = 'list_1'*
 
-    style ps_title fill:none,stroke:none
-    style sql_title fill:none,stroke:none
-    style col_title fill:none,stroke:none
-    style res_title fill:none,stroke:none
-```
+**Result**
+
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
 
 ```typescript
 const collection = createCollection(
@@ -1086,58 +1005,38 @@ The `list` parameter name is kept as-is (consistent with most examples), but mus
 
 This example starts with 4 todos in the PowerSync Service, the Sync Stream subscription criteria (`list_id = "list_1" and completed = 1`) is derived from the live query registered against the collection. Only 1 todo gets synced via the Sync Stream to the SQLite database. One todo gets synced from the SQLite database to the collection. Finally the TanStack DB query returns 1 todo that matches `eq(todo.list_id, 'list_id') and eq(todo.completed, 1)`.
 
-```mermaid
-block-beta 
-    columns 7
+**PS Service**
 
-    block:PS
-        columns 2
-        ps_title["PS Service"]:2
-        PS1["id: 1\nlist_id: list_1\ncompleted: 0"]
-        PS2["id: 2\nlist_id: list_1\ncompleted: 1"]
-        PS3["id: 3\nlist_id: list_2\ncompleted: 0"]
-        PS4["id: 4\nlist_id: list_2\ncompleted: 1"]
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 1  | list_1  |     0     |
+| 2  | list_1  |     1     |
+| 3  | list_2  |     0     |
+| 4  | list_2  |     1     |
 
-    space
+*Derive the list_id and completed criteria from live query, subscribe to Sync Stream where list = 'list_1' AND completed = 1*
 
-    block:SQL
-        columns 2
-        sql_title["SQLite"]:2
-        SQL1["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space
-        space space
-    end
+**SQLite**
 
-    space
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 2  | list_1  |     1     |
 
-    block:COL
-        columns 2
-        col_title["Collection"]:2
-        COL1["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space
-        space space
-    end
+*On-demand mode only syncs data from SQLite to the TanStack DB collection if they satisfy any of the live queries: list = 'list_1' AND completed = 1*
 
-    space
+**Collection**
 
-    block:RES
-        columns 2
-        res_title["Result"]:2
-        RES1["id: 2\nlist_id: list_1\ncompleted: 1"]
-        space
-        space space
-    end
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 2  | list_1  |     1     |
 
-    PS -- "Derive the list_id criteria and \n completed from live query,\n subscribe to Sync Stream\nwhere\n list = 'list_1' AND completed = 1" --> SQL
-    SQL -- "On-demand mode only syncs\n data from SQLite to the TanStack DB\n collection if they\nsatisfy any of the live queries:\nlist = 'list_1' AND completed = 1" --> COL
-    COL -- "TanStack DB Query filters for\nlist = 'list_1' AND completed = 1" --> RES
+*TanStack DB Query filters for list = 'list_1' AND completed = 1*
 
-    style ps_title fill:none,stroke:none
-    style sql_title fill:none,stroke:none
-    style col_title fill:none,stroke:none
-    style res_title fill:none,stroke:none
-```
+**Result**
+
+| id | list_id | completed |
+|:--:|:-------:|:---------:|
+| 2  | list_1  |     1     |
 
 ```typescript
 const collection = createCollection(


### PR DESCRIPTION
## 🎯 Changes

There were some wording improvements and issues with the mermaid block diagrams (opted to use markdown tables instead).

## ✅ Checklist

- [x] I have tested this the docs locally with a local tanstack.com project.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).
