### PR TITLE
Fix some small things in the docs

### DIFF
--- a/docs/collections/electric-collection.md
+++ b/docs/collections/electric-collection.md
@@ -311,7 +311,7 @@ Manually wait for a specific transaction ID to be synchronized:
 // Wait for specific txid
 await todosCollection.utils.awaitTxId(12345)
 
-// With custom timeout (default is 30 seconds)
+// With custom timeout (default is 5 seconds)
 await todosCollection.utils.awaitTxId(12345, 10000)
 ```
 

--- a/packages/db/skills/db-core/collection-setup/references/electric-adapter.md
+++ b/packages/db/skills/db-core/collection-setup/references/electric-adapter.md
@@ -78,7 +78,7 @@ onInsert: async ({ transaction }) => {
 
 ## Utility Methods (`collection.utils`)
 
-- `awaitTxId(txid, timeout?)` -- wait for txid in Electric stream; default timeout 30s
+- `awaitTxId(txid, timeout?)` -- wait for txid in Electric stream; default timeout 5s
 - `awaitMatch(matchFn, timeout?)` -- wait for message matching predicate; default timeout 3000ms
 
 ### Helper Exports


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
I was reading the _"Electric Collection"_ docs and spotted some small things that could be fixed. Nothing major.
- the [default timeout of `awaitTxId`](https://github.com/fulopkovacs/db/blob/2c509a1da5c19901f3241239e29aaf20fbc477bd/packages/electric-db-collection/src/electric.ts#L643-L648) is `5000ms`, not `30 seconds`
- one code block was in javascript, but contained types, so I changed it to typescript
- I corrected _"TanStack Starter"_ to _"TanStack Start"_, because it looked appropriate at one place


## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
