### PR TITLE
fix: ignore mobile runtime config artifacts in lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,10 @@ export default [
       `**/traildepot/**`,
       `examples/angular/**`,
       `packages/db-collection-e2e/vite.config.ts`,
+      `packages/db-capacitor-sqlite-persisted-collection/e2e/app/android/**`,
+      `packages/db-capacitor-sqlite-persisted-collection/e2e/app/ios/**`,
+      // Expo expects Metro config in CommonJS format.
+      `packages/db-expo-sqlite-persisted-collection/e2e/expo-runtime-app/metro.config.js`,
     ],
   },
   {


### PR DESCRIPTION
## Summary
- ignore the Expo runtime Metro config that must remain CommonJS
- ignore generated Capacitor `android/` and `ios/` app outputs that should not be type-checked by ESLint
- keep workspace lint focused on source files so CI no longer fails on mobile runtime artifacts

## Test plan
- [x] `pnpm --filter @tanstack/db-expo-sqlite-persisted-collection lint`
- [x] `pnpm --filter @tanstack/db-capacitor-sqlite-persisted-collection lint`
- [x] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] `pnpm run test`

Made with [Cursor](https://cursor.com)