### PR TITLE
chore: consolidate SQLite persistence changesets

### DIFF
--- a/.changeset/cloudflare-do-sqlite-persistence.md
+++ b/.changeset/cloudflare-do-sqlite-persistence.md
@@ -1,5 +1,0 @@
----
-'@tanstack/db-cloudflare-do-sqlite-persisted-collection': patch
----
-
-feat(persistence): add SQLite persistence support for Cloudflare Durable Objects runtime

--- a/.changeset/nasty-clubs-tease.md
+++ b/.changeset/nasty-clubs-tease.md
@@ -1,5 +1,5 @@
 ---
-'@tanstack/angular-db': minor
+'@tanstack/angular-db': patch
 ---
 
 fixing double reactive parameter tracking inside of injectLiveQuery

--- a/.changeset/sqlite-persistence.md
+++ b/.changeset/sqlite-persistence.md
@@ -2,12 +2,18 @@
 '@tanstack/db': patch
 '@tanstack/db-sqlite-persisted-collection-core': patch
 '@tanstack/db-browser-wa-sqlite-persisted-collection': patch
+'@tanstack/db-cloudflare-do-sqlite-persisted-collection': patch
+'@tanstack/db-node-sqlite-persisted-collection': patch
+'@tanstack/db-electron-sqlite-persisted-collection': patch
+'@tanstack/db-expo-sqlite-persisted-collection': patch
 '@tanstack/db-react-native-sqlite-persisted-collection': patch
+'@tanstack/db-capacitor-sqlite-persisted-collection': patch
+'@tanstack/db-tauri-sqlite-persisted-collection': patch
 ---
 
 feat(persistence): add SQLite-based offline persistence for collections
 
-Adds a new persistence layer that durably stores collection data in SQLite, enabling applications to survive page reloads and app restarts.
+Adds a new persistence layer that durably stores collection data in SQLite, enabling applications to survive page reloads and app restarts across browser, Node, mobile, desktop, and edge runtimes.
 
 **Core persistence (`@tanstack/db-sqlite-persisted-collection-core`)**
 
@@ -21,7 +27,31 @@ Adds a new persistence layer that durably stores collection data in SQLite, enab
 - Single-tab persistence with OPFS-based SQLite storage
 - `BrowserCollectionCoordinator` for multi-tab leader-election and cross-tab sync
 
+**Cloudflare Durable Objects (`@tanstack/db-cloudflare-do-sqlite-persisted-collection`)**
+
+- New package for SQLite persistence in Cloudflare Durable Objects runtimes
+
+**Node (`@tanstack/db-node-sqlite-persisted-collection`)**
+
+- New package for Node persistence via SQLite
+
+**Electron (`@tanstack/db-electron-sqlite-persisted-collection`)**
+
+- New package providing Electron main and renderer persistence bridge helpers
+
+**Expo (`@tanstack/db-expo-sqlite-persisted-collection`)**
+
+- New package for Expo persistence via `expo-sqlite`
+
 **React Native (`@tanstack/db-react-native-sqlite-persisted-collection`)**
 
 - New package for React Native persistence via op-sqlite
 - Adapter with transaction deadlock prevention and runtime parity coverage
+
+**Capacitor (`@tanstack/db-capacitor-sqlite-persisted-collection`)**
+
+- New package for Capacitor persistence via `@capacitor-community/sqlite`
+
+**Tauri (`@tanstack/db-tauri-sqlite-persisted-collection`)**
+
+- New package for Tauri persistence via `@tauri-apps/plugin-sql`


### PR DESCRIPTION
## Summary
- consolidate the SQLite persistence first-release notes into `.changeset/sqlite-persistence.md`
- remove the redundant standalone Cloudflare persistence changeset
- change the Angular changeset from `minor` to `patch` so all pending changesets are patch-only

## Test plan
- [x] `pnpm changeset status`

Made with [Cursor](https://cursor.com)