### PR TITLE
fix: add changeset for persistence packages with workspace links

### DIFF
--- a/.changeset/fix-workspace-links.md
+++ b/.changeset/fix-workspace-links.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/db-sqlite-persistence-core': patch
+'@tanstack/browser-db-sqlite-persistence': patch
+'@tanstack/capacitor-db-sqlite-persistence': patch
+'@tanstack/cloudflare-durable-objects-db-sqlite-persistence': patch
+'@tanstack/electron-db-sqlite-persistence': patch
+'@tanstack/expo-db-sqlite-persistence': patch
+'@tanstack/node-db-sqlite-persistence': patch
+'@tanstack/react-native-db-sqlite-persistence': patch
+'@tanstack/tauri-db-sqlite-persistence': patch
+---
+
+Fix workspace: dependency links that were incorrectly published to npm


### PR DESCRIPTION
## Summary
- Adds a changeset to trigger a patch release for all 9 persistence packages that were published with unresolved `workspace:*` dependency links

## Packages
- `@tanstack/db-sqlite-persistence-core`
- `@tanstack/browser-db-sqlite-persistence`
- `@tanstack/capacitor-db-sqlite-persistence`
- `@tanstack/cloudflare-durable-objects-db-sqlite-persistence`
- `@tanstack/electron-db-sqlite-persistence`
- `@tanstack/expo-db-sqlite-persistence`
- `@tanstack/node-db-sqlite-persistence`
- `@tanstack/react-native-db-sqlite-persistence`
- `@tanstack/tauri-db-sqlite-persistence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)