### PR TITLE
fix: bump persistence packages to 0.1.3 (fix workspace links)

### DIFF
--- a/.changeset/fix-workspace-links-v2.md
+++ b/.changeset/fix-workspace-links-v2.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/db-sqlite-persistence-core': patch
+'@tanstack/browser-db-sqlite-persistence': patch
+'@tanstack/capacitor-db-sqlite-persistence': patch
+'@tanstack/cloudflare-durable-objects-db-sqlite-persistence': patch
+'@tanstack/electron-db-sqlite-persistence': patch
+'@tanstack/expo-db-sqlite-persistence': patch
+'@tanstack/node-db-sqlite-persistence': patch
+'@tanstack/react-native-db-sqlite-persistence': patch
+'@tanstack/tauri-db-sqlite-persistence': patch
+---
+
+Fix workspace: dependency links that were incorrectly published to npm


### PR DESCRIPTION
## Summary
- The previous release (0.1.2) was already on npm with broken `workspace:*` dependency links, so the Version Packages PR publish was a no-op
- This changeset will bump all 9 persistence packages to 0.1.3 with properly resolved dependencies

## Packages
- `@tanstack/db-sqlite-persistence-core`
- `@tanstack/browser-db-sqlite-persistence`
- `@tanstack/capacitor-db-sqlite-persistence`
- `@tanstack/cloudflare-durable-objects-db-sqlite-persistence`
- `@tanstack/electron-db-sqlite-persistence`
- `@tanstack/expo-db-sqlite-persistence`
- `@tanstack/node-db-sqlite-persistence`
- `@tanstack/react-native-db-sqlite-persistence`
- `@tanstack/tauri-db-sqlite-persistence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)