### PR TITLE
fix: re-publish persistence packages (fix npm auth)

### DIFF
--- a/.changeset/fix-workspace-links-v3.md
+++ b/.changeset/fix-workspace-links-v3.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/db-sqlite-persistence-core': patch
+'@tanstack/browser-db-sqlite-persistence': patch
+'@tanstack/capacitor-db-sqlite-persistence': patch
+'@tanstack/cloudflare-durable-objects-db-sqlite-persistence': patch
+'@tanstack/electron-db-sqlite-persistence': patch
+'@tanstack/expo-db-sqlite-persistence': patch
+'@tanstack/node-db-sqlite-persistence': patch
+'@tanstack/react-native-db-sqlite-persistence': patch
+'@tanstack/tauri-db-sqlite-persistence': patch
+---
+
+Fix workspace: dependency links that were incorrectly published to npm


### PR DESCRIPTION
## Summary
- Previous publishes failed due to npm trusted publisher org name case mismatch (`tanstack` vs `TanStack`)
- This changeset bumps all 9 persistence packages to 0.1.4 to trigger a new publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)