### PR TITLE
fix: normalize schema generic in PersistedSyncOptionsResult

### DIFF
--- a/packages/db-sqlite-persistence-core/src/persisted.ts
+++ b/packages/db-sqlite-persistence-core/src/persisted.ts
@@ -374,14 +374,23 @@ export type PersistedLocalOnlyOptions<
   schemaVersion?: number
 }
 
+type NormalizeSchema<TSchema extends StandardSchemaV1> =
+  [TSchema] extends [never]
+    ? never
+    : [TSchema] extends [StandardSchemaV1<unknown, unknown>]
+      ? never
+      : TSchema
+
 type PersistedSyncOptionsResult<
   T extends object,
   TKey extends string | number,
   TSchema extends StandardSchemaV1,
   TUtils extends UtilsRecord,
-> = CollectionConfig<T, TKey, TSchema, TUtils> & {
+> = CollectionConfig<T, TKey, NormalizeSchema<TSchema>, TUtils> & {
   persistence: PersistedResolvedPersistence<T, TKey>
-}
+} & ([NormalizeSchema<TSchema>] extends [never]
+  ? { schema?: never }
+  : { schema: NormalizeSchema<TSchema> })
 
 type PersistedLocalOnlyOptionsResult<
   T extends object,


### PR DESCRIPTION
> Sorry, my clanker got a little over zealous in actually submitting this PR. This is a real issue when pairing queryCollectionOptions and persistedCollectionOptions. This fix did work for me when patched locally.

> Also, there seems to be no contribution docs for this repo? I would like to keep contributing as I find things in my prototype but dont want to be burdensom

## Summary

`persistedCollectionOptions()` wrapping `queryCollectionOptions()` produces a `PersistedSyncOptionsResult` whose `TSchema` generic doesn't match any `createCollection` overload, causing a type error when composing persisted + query-synced collections.

**Repro** — both of these fail:
```ts
// With schema
const queryOpts = queryCollectionOptions({ schema: todoSchema, ... })
createCollection(persistedCollectionOptions({ ...queryOpts, persistence, schemaVersion: 1 }))
// Error: schema?: ZodObject | undefined is not assignable to undefined

// Without schema
const queryOpts = queryCollectionOptions({ ... })
createCollection(persistedCollectionOptions({ ...queryOpts, persistence, schemaVersion: 1 }))
// Error: StandardSchemaV1<unknown, unknown> is not assignable to undefined

// Current Workaround
const queryOpts = queryCollectionOptions({
  ...,
  schema: todoSchema // Pass schema here
});

// 5. Compose: query sync wrapped in persisted collection
const collection = createCollection({
  ...persistedCollectionOptions({
    ...queryOpts,
    persistence,
    schemaVersion: 1,
  }),
  schema: todoSchema // pass again here after spreading persisted opts
});
```

**Root cause**: `PersistedSyncOptionsResult` passes `TSchema` through to `CollectionConfig` as-is. But `createCollection` has two overload groups:
- "with schema": requires `{ schema: T }` (required) + `CollectionConfig<..., T, ...>` where `T extends StandardSchemaV1`
- "without schema": requires `{ schema?: never }` + `CollectionConfig<..., never, ...>`

When `TSchema` is a concrete schema (ZodObject), the result has `schema?: TSchema | undefined` (optional from CollectionConfig) — matching neither overload. When `TSchema` is the default `StandardSchemaV1<unknown, unknown>`, it also fails the `never` check.

**Fix**: Add a `NormalizeSchema<TSchema>` helper that collapses both `never` and the default `StandardSchemaV1<unknown, unknown>` to `never`, then use it in both the `CollectionConfig` generic parameter and a conditional intersection that makes `schema` required or absent.

## Test plan

- [ ] `persistedCollectionOptions({ ...queryCollectionOptions({ schema }), persistence })` passed to `createCollection` compiles
- [ ] `persistedCollectionOptions({ ...queryCollectionOptions({ /* no schema */ }), persistence })` passed to `createCollection` compiles
- [ ] `persistedCollectionOptions({ /* local-only, no sync */ })` still compiles
- [ ] Existing tests pass