### PR TITLE
fix(react-db): use collection.status instead of snapshot in useLiveSuspenseQuery to avoid infinite fallback loops

### DIFF
--- a/.changeset/tame-dolls-move.md
+++ b/.changeset/tame-dolls-move.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-db': patch
+---
+
+Fix stale status mismatch in useLiveSuspenseQuery causing infinite suspense fallback.

--- a/packages/react-db/src/useLiveSuspenseQuery.ts
+++ b/packages/react-db/src/useLiveSuspenseQuery.ts
@@ -170,12 +170,6 @@ export function useLiveSuspenseQuery(
     hasBeenReadyRef.current = false
   }
 
-  // Track when we reach ready state
-  if (result.status === `ready`) {
-    hasBeenReadyRef.current = true
-    promiseRef.current = null
-  }
-
   // SUSPENSE LOGIC: Throw promise or error based on collection status
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!result.isEnabled) {
@@ -189,16 +183,26 @@ export function useLiveSuspenseQuery(
     )
   }
 
+  // It’s not recommended to suspend a render based on a store value returned by useSyncExternalStore.
+  // result.status is the snapshot from syncExternalStore. We read the fresh status from the collection reference instead.
+  const collectionStatus = result.collection.status
+
+  // Track when we reach ready state
+  if (collectionStatus === `ready`) {
+    hasBeenReadyRef.current = true
+    promiseRef.current = null
+  }
+
   // Only throw errors during initial load (before first ready)
   // After success, errors surface as stale data (matches TanStack Query behavior)
-  if (result.status === `error` && !hasBeenReadyRef.current) {
+  if (collectionStatus === `error` && !hasBeenReadyRef.current) {
     promiseRef.current = null
     // TODO: Once collections hold a reference to their last error object (#671),
     // we should rethrow that actual error instead of creating a generic message
     throw new Error(`Collection "${result.collection.id}" failed to load`)
   }
 
-  if (result.status === `loading` || result.status === `idle`) {
+  if (collectionStatus === `loading` || collectionStatus === `idle`) {
     // Create or reuse promise for current collection
     if (!promiseRef.current) {
       promiseRef.current = result.collection.preload()


### PR DESCRIPTION
Fixes #1418

In [useLiveSuspenseQuery.ts](https://github.com/TanStack/db/blob/main/packages/react-db/src/useLiveSuspenseQuery.ts)
`result.status` comes from [the snapshot in useLiveQuery.ts](https://github.com/TanStack/db/blob/8b7fb1a18522b8d1c2adb46f5917305c7d99fc4a/packages/react-db/src/useLiveQuery.ts#L539)
`result.collection.status` is a live reference

This may cause an inconsistent render where:
- result.status === "loading"
- result.collection.status === "ready"

The [react documentation](https://react.dev/reference/react/useSyncExternalStore#:~:text=It%E2%80%99s%20not%20recommended%20to%20suspend%20a%20render%20based%20on%20a%20store%20value%20returned%20by%20useSyncExternalStore) says "It’s not recommended to suspend a render based on a store value returned by useSyncExternalStore." so reading the fresh status from the mutable collection seems correct here. 

Switching to result.collection.status ensures Suspense uses the latest state and prevents infinite fallback loops.


```diff
-    if (result.status === `loading` || result.status === `idle`) {
+    if (result.collection.status === `loading` || result.collection.status === `idle`) {
        // Create or reuse promise for current collection
        if (!promiseRef.current) {
            promiseRef.current = result.collection.preload()
        }
        // THROW PROMISE - React Suspense catches this (React 18+ required)
        // Note: We don't check React version here. In React <18, this will be caught
        // by an Error Boundary, which provides a reasonable failure mode.
        throw promiseRef.current
    }
```

## Demo
I could not add a reliable RTL/jsdom test for this React 19 Suspense scenario, as it appears to hit the limitation discussed in testing-library/react-testing-library#1375.

As a fallback, I added a small demo showing the fix in action:

[StackBlitz](https://stackblitz.com/~/github.com/calcari/tanstack-suspense-repro)
- Open tab n°4 (fix)
- Click Next

## 🎯 Changes

- introduce collectionStatus variable
- replace all status checks (loading, idle, error, ready) with collectionStatus
- move isEnabled check before accessing result.collection

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset]
- [ ] This change is docs/CI/dev-only (no release).
