### PR TITLE
fix(db-sqlite-persistence-core): add schema-aware overloads to persistedCollectionOptions

### DIFF
--- a/.changeset/calm-toes-approve.md
+++ b/.changeset/calm-toes-approve.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db-sqlite-persistence-core': patch
+---
+
+Add schema-aware overloads to `persistedCollectionOptions` so schema-based calls infer the correct types and remain compatible with `createCollection`.

--- a/packages/db-sqlite-persistence-core/src/persisted.ts
+++ b/packages/db-sqlite-persistence-core/src/persisted.ts
@@ -14,6 +14,7 @@ import type {
   CollectionConfig,
   CollectionIndexMetadata,
   DeleteMutationFnParams,
+  InferSchemaOutput,
   InsertMutationFnParams,
   LoadSubsetOptions,
   PendingMutation,
@@ -2572,22 +2573,76 @@ function createLoopbackSyncConfig<
   }
 }
 
+// Overload for when schema is provided and sync is present
+export function persistedCollectionOptions<
+  TSchema extends StandardSchemaV1,
+  TKey extends string | number,
+  TUtils extends UtilsRecord = UtilsRecord,
+>(
+  options: PersistedSyncWrappedOptions<
+    InferSchemaOutput<TSchema>,
+    TKey,
+    TSchema,
+    TUtils
+  > & {
+    schema: TSchema
+  },
+): PersistedSyncOptionsResult<
+  InferSchemaOutput<TSchema>,
+  TKey,
+  TSchema,
+  TUtils
+> & {
+  schema: TSchema
+}
+
+// Overload for when schema is provided and sync is absent
+export function persistedCollectionOptions<
+  TSchema extends StandardSchemaV1,
+  TKey extends string | number,
+  TUtils extends UtilsRecord = UtilsRecord,
+>(
+  options: PersistedLocalOnlyOptions<
+    InferSchemaOutput<TSchema>,
+    TKey,
+    TSchema,
+    TUtils
+  > & {
+    schema: TSchema
+  },
+): PersistedLocalOnlyOptionsResult<
+  InferSchemaOutput<TSchema>,
+  TKey,
+  TSchema,
+  TUtils
+> & {
+  schema: TSchema
+}
+
+// Overload for when no schema is provided and sync is present
+// the type T needs to be passed explicitly unless it can be inferred from the getKey function in the config
 export function persistedCollectionOptions<
   T extends object,
   TKey extends string | number,
   TSchema extends StandardSchemaV1 = never,
   TUtils extends UtilsRecord = UtilsRecord,
 >(
-  options: PersistedSyncWrappedOptions<T, TKey, TSchema, TUtils>,
+  options: PersistedSyncWrappedOptions<T, TKey, TSchema, TUtils> & {
+    schema?: never // prohibit schema
+  },
 ): PersistedSyncOptionsResult<T, TKey, TSchema, TUtils>
 
+// Overload for when no schema is provided and sync is absent
+// the type T needs to be passed explicitly unless it can be inferred from the getKey function in the config
 export function persistedCollectionOptions<
   T extends object,
   TKey extends string | number,
   TSchema extends StandardSchemaV1 = never,
   TUtils extends UtilsRecord = UtilsRecord,
 >(
-  options: PersistedLocalOnlyOptions<T, TKey, TSchema, TUtils>,
+  options: PersistedLocalOnlyOptions<T, TKey, TSchema, TUtils> & {
+    schema?: never // prohibit schema
+  },
 ): PersistedLocalOnlyOptionsResult<T, TKey, TSchema, TUtils>
 
 export function persistedCollectionOptions<

--- a/packages/db-sqlite-persistence-core/tests/persisted.test-d.ts
+++ b/packages/db-sqlite-persistence-core/tests/persisted.test-d.ts
@@ -1,8 +1,16 @@
 import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
 import { createCollection } from '@tanstack/db'
 import { persistedCollectionOptions } from '../src'
 import type { PersistedCollectionUtils, PersistenceAdapter } from '../src'
-import type { SyncConfig, UtilsRecord } from '@tanstack/db'
+import type { SyncConfig, UtilsRecord, WithVirtualProps } from '@tanstack/db'
+
+type OutputWithVirtual<
+  T extends object,
+  TKey extends string | number = string | number,
+> = WithVirtualProps<T, TKey>
+
+type ItemOf<T> = T extends Array<infer U> ? U : T
 
 type Todo = {
   id: string
@@ -90,6 +98,11 @@ describe(`persisted collection types`, () => {
     // @ts-expect-error persistedCollectionOptions requires a persistence config
     persistedCollectionOptions({
       getKey: (item: Todo) => item.id,
+    })
+
+    persistedCollectionOptions({
+      getKey: (item: Todo) => item.id,
+      // @ts-expect-error persistedCollectionOptions requires a persistence config when sync is provided
       sync: {
         sync: ({ markReady }: { markReady: () => void }) => {
           markReady()
@@ -106,6 +119,184 @@ describe(`persisted collection types`, () => {
       persistence: {
         adapter,
       },
+    })
+  })
+
+  it(`should work with schema and infer correct types when saved to a variable in sync-absent mode`, () => {
+    const testSchema = z.object({
+      id: z.string(),
+      title: z.string(),
+      createdAt: z.date().optional().default(new Date()),
+    })
+
+    type ExpectedType = z.infer<typeof testSchema>
+    type ExpectedInput = z.input<typeof testSchema>
+
+    const schemaAdapter: PersistenceAdapter<ExpectedType, string> = {
+      loadSubset: () => Promise.resolve([]),
+      applyCommittedTx: () => Promise.resolve(),
+      ensureIndex: () => Promise.resolve(),
+    }
+
+    const options = persistedCollectionOptions({
+      id: `test-local-schema`,
+      schema: testSchema,
+      schemaVersion: 1,
+      getKey: (item) => item.id,
+      persistence: { adapter: schemaAdapter },
+    })
+
+    expectTypeOf(options.schema).toEqualTypeOf<typeof testSchema>()
+
+    const collection = createCollection(options)
+
+    // Test that the collection has the correct inferred type from schema
+    expectTypeOf(collection.toArray).toEqualTypeOf<
+      Array<OutputWithVirtual<ExpectedType, string>>
+    >()
+
+    // Test insert parameter type
+    type InsertParam = Parameters<typeof collection.insert>[0]
+    expectTypeOf<ItemOf<InsertParam>>().toEqualTypeOf<ExpectedInput>()
+
+    // Check that the update method accepts the expected input type
+    collection.update(`1`, (draft) => {
+      expectTypeOf(draft).toEqualTypeOf<ExpectedInput>()
+    })
+  })
+
+  it(`should work with schema and infer correct types when nested in createCollection in sync-absent mode`, () => {
+    const testSchema = z.object({
+      id: z.string(),
+      title: z.string(),
+      createdAt: z.date().optional().default(new Date()),
+    })
+
+    type ExpectedType = z.infer<typeof testSchema>
+    type ExpectedInput = z.input<typeof testSchema>
+
+    const schemaAdapter: PersistenceAdapter<ExpectedType, string> = {
+      loadSubset: () => Promise.resolve([]),
+      applyCommittedTx: () => Promise.resolve(),
+      ensureIndex: () => Promise.resolve(),
+    }
+
+    const collection = createCollection(
+      persistedCollectionOptions({
+        id: `test-local-schema-nested`,
+        schema: testSchema,
+        schemaVersion: 1,
+        getKey: (item) => item.id,
+        persistence: { adapter: schemaAdapter },
+      }),
+    )
+
+    // Test that the collection has the correct inferred type from schema
+    expectTypeOf(collection.toArray).toEqualTypeOf<
+      Array<OutputWithVirtual<ExpectedType, string>>
+    >()
+
+    // Test insert parameter type
+    type InsertParam = Parameters<typeof collection.insert>[0]
+    expectTypeOf<ItemOf<InsertParam>>().toEqualTypeOf<ExpectedInput>()
+
+    // Check that the update method accepts the expected input type
+    collection.update(`1`, (draft) => {
+      expectTypeOf(draft).toEqualTypeOf<ExpectedInput>()
+    })
+  })
+
+  it(`should work with schema and infer correct types when saved to a variable in sync-present mode`, () => {
+    const testSchema = z.object({
+      id: z.string(),
+      title: z.string(),
+      createdAt: z.date().optional().default(new Date()),
+    })
+
+    type ExpectedType = z.infer<typeof testSchema>
+    type ExpectedInput = z.input<typeof testSchema>
+
+    const schemaAdapter: PersistenceAdapter<ExpectedType, string> = {
+      loadSubset: () => Promise.resolve([]),
+      applyCommittedTx: () => Promise.resolve(),
+      ensureIndex: () => Promise.resolve(),
+    }
+
+    const options = persistedCollectionOptions({
+      id: `test-sync-schema`,
+      schema: testSchema,
+      schemaVersion: 1,
+      getKey: (item) => item.id,
+      sync: {
+        sync: ({ markReady }) => {
+          markReady()
+        },
+      },
+      persistence: { adapter: schemaAdapter },
+    })
+
+    expectTypeOf(options.schema).toEqualTypeOf<typeof testSchema>()
+
+    const collection = createCollection(options)
+
+    // Test that the collection has the correct inferred type from schema
+    expectTypeOf(collection.toArray).toEqualTypeOf<
+      Array<OutputWithVirtual<ExpectedType, string>>
+    >()
+
+    // Test insert parameter type
+    type InsertParam = Parameters<typeof collection.insert>[0]
+    expectTypeOf<ItemOf<InsertParam>>().toEqualTypeOf<ExpectedInput>()
+
+    // Check that the update method accepts the expected input type
+    collection.update(`1`, (draft) => {
+      expectTypeOf(draft).toEqualTypeOf<ExpectedInput>()
+    })
+  })
+
+  it(`should work with schema and infer correct types when nested in createCollection in sync-present mode`, () => {
+    const testSchema = z.object({
+      id: z.string(),
+      title: z.string(),
+      createdAt: z.date().optional().default(new Date()),
+    })
+
+    type ExpectedType = z.infer<typeof testSchema>
+    type ExpectedInput = z.input<typeof testSchema>
+
+    const schemaAdapter: PersistenceAdapter<ExpectedType, string> = {
+      loadSubset: () => Promise.resolve([]),
+      applyCommittedTx: () => Promise.resolve(),
+      ensureIndex: () => Promise.resolve(),
+    }
+
+    const collection = createCollection(
+      persistedCollectionOptions({
+        id: `test-sync-schema-nested`,
+        schema: testSchema,
+        schemaVersion: 1,
+        getKey: (item) => item.id,
+        sync: {
+          sync: ({ markReady }) => {
+            markReady()
+          },
+        },
+        persistence: { adapter: schemaAdapter },
+      }),
+    )
+
+    // Test that the collection has the correct inferred type from schema
+    expectTypeOf(collection.toArray).toEqualTypeOf<
+      Array<OutputWithVirtual<ExpectedType, string>>
+    >()
+
+    // Test insert parameter type
+    type InsertParam = Parameters<typeof collection.insert>[0]
+    expectTypeOf<ItemOf<InsertParam>>().toEqualTypeOf<ExpectedInput>()
+
+    // Check that the update method accepts the expected input type
+    collection.update(`1`, (draft) => {
+      expectTypeOf(draft).toEqualTypeOf<ExpectedInput>()
     })
   })
 })

--- a/packages/db-sqlite-persistence-core/tests/persisted.test-d.ts
+++ b/packages/db-sqlite-persistence-core/tests/persisted.test-d.ts
@@ -2,7 +2,8 @@ import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import { createCollection } from '@tanstack/db'
 import { persistedCollectionOptions } from '../src'
-import type { PersistedCollectionUtils, PersistenceAdapter } from '../src'
+import type { PersistedCollectionUtils } from '../src'
+import type { PersistenceAdapter } from '../src/persisted'
 import type { SyncConfig, UtilsRecord, WithVirtualProps } from '@tanstack/db'
 
 type OutputWithVirtual<


### PR DESCRIPTION
Closes #1452

## Summary

- persistedCollectionOptions was missing schema-aware overloads, so TSchema defaulted to never when a schema was passed, making the result incompatible with createCollection
- Added four schema/no-schema overloads matching the pattern used by localOnlyCollectionOptions and localStorageCollectionOptions
- Added type tests covering schema inference and createCollection compatibility for both sync-present and sync-absent modes

## Note on error messages

Adding schema-aware overloads changes the order TypeScript evaluates overloads when a call is invalid. Previously, calling persistedCollectionOptions without persistence in sync-present mode would report the error on the function call itself. Now TypeScript reports it on the sync property inside the object literal, since the last overload it tries is the sync-absent one (which Omits sync). The type safety is unchanged - the call still fails to compile without persistence - only the error location and message differ. This is the same behavior seen in createCollection, which has 8 overloads.

## Test plan

- [x] npx tsc --noEmit passes with zero errors
- [x] npx vitest run --typecheck passes (8 type tests in persisted.test-d.ts)
- [x] Existing tests unchanged and passing
- [x] Verified no breakage in other packages using persistedCollectionOptions with 2 or 4 explicit type args