### PR TITLE
fix(ci): reuse existing open docs PR instead of creating duplicates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,23 +50,28 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
 
-            EXISTING_PR=$(gh pr list --search "docs: regenerate API documentation" --state open --json number,headRefName --jq '.[0]')
+            EXISTING_BRANCH=$(gh pr list --author "app/github-actions" --search "docs: regenerate API documentation in:title" --state open --json headRefName --jq '.[0].headRefName' 2>/dev/null || echo "")
+            CREATE_PR=true
 
-            if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
-              BRANCH=$(echo "$EXISTING_PR" | jq -r '.headRefName')
+            if [ -n "$EXISTING_BRANCH" ] && [ "$EXISTING_BRANCH" != "null" ]; then
+              BRANCH="$EXISTING_BRANCH"
               echo "Found existing docs PR on branch $BRANCH, updating it"
-              git checkout "$BRANCH"
-              git pull origin "$BRANCH"
-              git add docs/
-              git commit -m "docs: regenerate API documentation"
-              git push origin "$BRANCH"
+              git checkout -B "$BRANCH"
+              CREATE_PR=false
             else
               BRANCH="docs/auto-update-$(date +%s)"
               git checkout -b "$BRANCH"
-              git add docs/
-              git commit -m "docs: regenerate API documentation"
-              git push origin "$BRANCH"
+            fi
 
+            git add docs/
+            if git diff --cached --quiet; then
+              echo "No new docs changes to commit"
+              exit 0
+            fi
+            git commit -m "docs: regenerate API documentation"
+            git push --force-with-lease origin "$BRANCH"
+
+            if [ "$CREATE_PR" = true ]; then
               gh pr create \
                 --title "docs: regenerate API documentation" \
                 --body "Automated documentation update from release" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,29 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
 
-            BRANCH="docs/auto-update-$(date +%s)"
-            git checkout -b "$BRANCH"
-            git add docs/
-            git commit -m "docs: regenerate API documentation"
-            git push origin "$BRANCH"
+            EXISTING_PR=$(gh pr list --search "docs: regenerate API documentation" --state open --json number,headRefName --jq '.[0]')
 
-            gh pr create \
-              --title "docs: regenerate API documentation" \
-              --body "Automated documentation update from release" \
-              --base main \
-              --head "$BRANCH"
+            if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+              BRANCH=$(echo "$EXISTING_PR" | jq -r '.headRefName')
+              echo "Found existing docs PR on branch $BRANCH, updating it"
+              git checkout "$BRANCH"
+              git pull origin "$BRANCH"
+              git add docs/
+              git commit -m "docs: regenerate API documentation"
+              git push origin "$BRANCH"
+            else
+              BRANCH="docs/auto-update-$(date +%s)"
+              git checkout -b "$BRANCH"
+              git add docs/
+              git commit -m "docs: regenerate API documentation"
+              git push origin "$BRANCH"
+
+              gh pr create \
+                --title "docs: regenerate API documentation" \
+                --body "Automated documentation update from release" \
+                --base main \
+                --head "$BRANCH"
+            fi
           else
             echo "No changes in generated docs"
           fi


### PR DESCRIPTION
## Summary

The release workflow's "Commit Generated Docs" step now reuses an existing open docs PR instead of creating a duplicate each time packages are published.

## Root Cause

Every release that generated docs changes created a new timestamped branch (`docs/auto-update-{epoch}`) and a new PR. If multiple releases happened before a docs PR was merged, stale duplicates accumulated.

## Approach

Before creating a new branch, the workflow searches for an existing open PR authored by `github-actions[bot]` with the docs regeneration title. If found, it resets that branch to the current `main` (where fresh docs were just generated) and force-pushes. If not found, it creates a new branch and PR as before.

Key implementation details:
- **`git checkout -B "$BRANCH"`** resets the existing branch to current HEAD, keeping the freshly generated docs in the working tree. A plain `git checkout` would fail (dirty working tree conflict) and discard the new docs.
- **`--force-with-lease`** is needed since the branch history is rewritten to always sit on latest `main`.
- **`git diff --cached --quiet`** guard exits cleanly when docs are unchanged, avoiding a `git commit` failure under `set -e`.
- **`--author` + `in:title`** filters narrow the PR search to avoid matching unrelated PRs.
- **`2>/dev/null || echo ""`** on `gh pr list` ensures API failures fall back to creating a new PR.

## Key Invariants

- The docs PR branch always contains a single commit on top of the latest `main` where docs were generated
- A `gh pr list` failure never blocks the docs update — it falls back to creating a new PR
- The workflow exits cleanly (not with an error) when docs are unchanged

## Non-goals

- Closing stale docs PRs — maintainers can handle that manually
- Rebasing or merging `main` into the existing branch — resetting to `main` is simpler and produces a cleaner diff

## Verification

```bash
# Syntax check
actionlint .github/workflows/release.yml
```

Manual verification on next release:
- [ ] When an open docs PR exists, it gets updated (not duplicated)
- [ ] When no open docs PR exists, a new one is created
- [ ] When docs are unchanged, the step exits cleanly

## Files changed

- **`.github/workflows/release.yml`** — Rewrote the "Commit Generated Docs" step to search for and reuse existing open docs PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)