### PR TITLE
feat: reconcile persisted SQLite indexes asynchronously

### DIFF
--- a/.changeset/swift-needles-laugh.md
+++ b/.changeset/swift-needles-laugh.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db-sqlite-persistence-core': minor
+---
+
+Reconcile persisted SQLite indexes in the background so startup does not block on index creation, and drop stale persisted indexes by definition instead of by name.

--- a/packages/db-sqlite-persistence-core/src/persisted.ts
+++ b/packages/db-sqlite-persistence-core/src/persisted.ts
@@ -178,6 +178,12 @@ export interface PersistedIndexSpec {
   readonly metadata?: Readonly<Record<string, unknown>>
 }
 
+export type PersistedIndexState = {
+  readonly signature: string
+  readonly expressionSql: ReadonlyArray<string>
+  readonly whereSql?: string
+}
+
 export type PersistedRowMetadataMutation<
   TKey extends string | number = string | number,
 > = { type: `set`; key: TKey; value: unknown } | { type: `delete`; key: TKey }
@@ -261,6 +267,7 @@ export interface PersistenceAdapter {
     collectionId: string,
     options?: PersistedRowScanOptions,
   ) => Promise<Array<PersistedScannedRow>>
+  listIndexes?: (collectionId: string) => Promise<Array<PersistedIndexState>>
   ensureIndex: (
     collectionId: string,
     signature: string,
@@ -696,6 +703,33 @@ function stableSerialize(value: unknown): string {
   return JSON.stringify(toStableSerializable(value) ?? null)
 }
 
+function toPersistedIndexState(
+  signature: string,
+  spec: Pick<PersistedIndexSpec, `expressionSql` | `whereSql`>,
+): PersistedIndexState {
+  return {
+    signature,
+    expressionSql: [...spec.expressionSql],
+    ...(spec.whereSql === undefined ? {} : { whereSql: spec.whereSql }),
+  }
+}
+
+function arePersistedIndexStatesEqual(
+  left: Pick<PersistedIndexState, `expressionSql` | `whereSql`>,
+  right: Pick<PersistedIndexState, `expressionSql` | `whereSql`>,
+): boolean {
+  return (
+    stableSerialize({
+      expressionSql: left.expressionSql,
+      whereSql: left.whereSql ?? null,
+    }) ===
+    stableSerialize({
+      expressionSql: right.expressionSql,
+      whereSql: right.whereSql ?? null,
+    })
+  )
+}
+
 function normalizeSubsetOptionsForKey(
   options: LoadSubsetOptions,
 ): Record<string, unknown> {
@@ -811,6 +845,7 @@ class PersistedCollectionRuntime<
   private indexAddedUnsubscribe: (() => void) | null = null
   private indexRemovedUnsubscribe: (() => void) | null = null
   private remoteEnsureRetryTimer: ReturnType<typeof setTimeout> | null = null
+  private persistedIndexWork: Promise<void> = Promise.resolve()
   private nextSubscriptionId = 0
 
   private latestTerm = 0
@@ -897,7 +932,9 @@ class PersistedCollectionRuntime<
 
     const indexBootstrapSnapshot = this.collection?.getIndexMetadata() ?? []
     this.attachIndexLifecycleListeners()
-    await this.bootstrapPersistedIndexes(indexBootstrapSnapshot)
+    this.enqueuePersistedIndexWork(() =>
+      this.reconcilePersistedIndexes(indexBootstrapSnapshot),
+    )
 
     if (this.syncMode !== `on-demand`) {
       this.activeSubsets.set(this.getSubsetKey({}), {})
@@ -2109,17 +2146,27 @@ class PersistedCollectionRuntime<
     }
 
     this.indexAddedUnsubscribe = this.collection.on(`index:added`, (event) => {
-      void this.ensurePersistedIndex(event.index)
+      this.enqueuePersistedIndexWork(() =>
+        this.ensurePersistedIndex(event.index),
+      )
     })
     this.indexRemovedUnsubscribe = this.collection.on(
       `index:removed`,
       (event) => {
-        void this.markIndexRemoved(event.index)
+        this.enqueuePersistedIndexWork(() => this.markIndexRemoved(event.index))
       },
     )
   }
 
-  private async bootstrapPersistedIndexes(
+  private enqueuePersistedIndexWork(task: () => Promise<void>): void {
+    const queuedTask = this.persistedIndexWork.then(task, task)
+    this.persistedIndexWork = queuedTask.then(
+      () => undefined,
+      () => undefined,
+    )
+  }
+
+  private async reconcilePersistedIndexes(
     indexMetadataSnapshot?: Array<CollectionIndexMetadata>,
   ): Promise<void> {
     const collection = this.collection
@@ -2127,10 +2174,57 @@ class PersistedCollectionRuntime<
       return
     }
 
-    const indexMetadata =
-      indexMetadataSnapshot ?? collection?.getIndexMetadata() ?? []
-    for (const metadata of indexMetadata) {
-      await this.ensurePersistedIndex(metadata)
+    const desiredIndexes = new Map<string, PersistedIndexState>()
+    for (const metadata of indexMetadataSnapshot ??
+      collection?.getIndexMetadata() ??
+      []) {
+      desiredIndexes.set(
+        metadata.signature,
+        toPersistedIndexState(
+          metadata.signature,
+          this.buildPersistedIndexSpec(metadata),
+        ),
+      )
+    }
+
+    const listIndexes = this.persistence.adapter.listIndexes
+    if (!listIndexes) {
+      for (const [signature, desiredIndex] of desiredIndexes) {
+        await this.ensurePersistedIndexState(signature, desiredIndex)
+      }
+      return
+    }
+
+    const actualIndexes = await listIndexes(this.collectionId)
+    const actualIndexMap = new Map(
+      actualIndexes.map((indexState) => [indexState.signature, indexState]),
+    )
+
+    for (const [signature, actualIndex] of actualIndexMap) {
+      const desiredIndex = desiredIndexes.get(signature)
+      if (!desiredIndex) {
+        await this.markPersistedIndexRemoved(signature)
+        continue
+      }
+
+      if (!arePersistedIndexStatesEqual(actualIndex, desiredIndex)) {
+        const removed = await this.markPersistedIndexRemoved(signature)
+        if (removed) {
+          actualIndexMap.delete(signature)
+        }
+      }
+    }
+
+    for (const [signature, desiredIndex] of desiredIndexes) {
+      const actualIndex = actualIndexMap.get(signature)
+      if (
+        actualIndex &&
+        arePersistedIndexStatesEqual(actualIndex, desiredIndex)
+      ) {
+        continue
+      }
+
+      await this.ensurePersistedIndexState(signature, desiredIndex)
     }
   }
 
@@ -2150,25 +2244,43 @@ class PersistedCollectionRuntime<
   private async ensurePersistedIndex(
     indexMetadata: CollectionIndexMetadata,
   ): Promise<void> {
-    const spec = this.buildPersistedIndexSpec(indexMetadata)
+    await this.ensurePersistedIndexState(
+      indexMetadata.signature,
+      toPersistedIndexState(
+        indexMetadata.signature,
+        this.buildPersistedIndexSpec(indexMetadata),
+      ),
+    )
+  }
+
+  private async ensurePersistedIndexState(
+    signature: string,
+    indexState: PersistedIndexState,
+  ): Promise<void> {
+    const spec: PersistedIndexSpec = {
+      expressionSql: indexState.expressionSql,
+      ...(indexState.whereSql === undefined
+        ? {}
+        : { whereSql: indexState.whereSql }),
+    }
 
     try {
       await this.persistence.adapter.ensureIndex(
         this.collectionId,
-        indexMetadata.signature,
+        signature,
         spec,
       )
-    } catch (error) {
+    } catch (error: unknown) {
       console.warn(`Failed to ensure persisted index in adapter:`, error)
     }
 
     try {
       await this.persistence.coordinator.requestEnsurePersistedIndex(
         this.collectionId,
-        indexMetadata.signature,
+        signature,
         spec,
       )
-    } catch (error) {
+    } catch (error: unknown) {
       console.warn(
         `Failed to ensure persisted index through coordinator:`,
         error,
@@ -2179,17 +2291,23 @@ class PersistedCollectionRuntime<
   private async markIndexRemoved(
     indexMetadata: CollectionIndexMetadata,
   ): Promise<void> {
+    await this.markPersistedIndexRemoved(indexMetadata.signature)
+  }
+
+  private async markPersistedIndexRemoved(signature: string): Promise<boolean> {
     if (!this.persistence.adapter.markIndexRemoved) {
-      return
+      return false
     }
 
     try {
       await this.persistence.adapter.markIndexRemoved(
         this.collectionId,
-        indexMetadata.signature,
+        signature,
       )
-    } catch (error) {
+      return true
+    } catch (error: unknown) {
       console.warn(`Failed to mark persisted index removed:`, error)
+      return false
     }
   }
 }

--- a/packages/db-sqlite-persistence-core/src/persisted.ts
+++ b/packages/db-sqlite-persistence-core/src/persisted.ts
@@ -2199,6 +2199,7 @@ class PersistedCollectionRuntime<
     const actualIndexMap = new Map(
       actualIndexes.map((indexState) => [indexState.signature, indexState]),
     )
+    const blockedSignatures = new Set<string>()
 
     for (const [signature, actualIndex] of actualIndexMap) {
       const desiredIndex = desiredIndexes.get(signature)
@@ -2209,13 +2210,20 @@ class PersistedCollectionRuntime<
 
       if (!arePersistedIndexStatesEqual(actualIndex, desiredIndex)) {
         const removed = await this.markPersistedIndexRemoved(signature)
-        if (removed) {
-          actualIndexMap.delete(signature)
+        if (!removed) {
+          blockedSignatures.add(signature)
+          continue
         }
+
+        actualIndexMap.delete(signature)
       }
     }
 
     for (const [signature, desiredIndex] of desiredIndexes) {
+      if (blockedSignatures.has(signature)) {
+        continue
+      }
+
       const actualIndex = actualIndexMap.get(signature)
       if (
         actualIndex &&

--- a/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
+++ b/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
@@ -15,6 +15,7 @@ import {
 import type { LoadSubsetOptions } from '@tanstack/db'
 import type {
   PersistedIndexSpec,
+  PersistedIndexState,
   PersistedRowScanOptions,
   PersistedScannedRow,
   PersistedTx,
@@ -987,6 +988,20 @@ function normalizeIndexSqlFragment(fragment: string): string {
   return sanitizeExpressionSqlFragment(fragment)
 }
 
+function parsePersistedIndexExpressionSql(serialized: string): Array<string> {
+  const parsedValue: unknown = JSON.parse(serialized)
+  if (
+    Array.isArray(parsedValue) &&
+    parsedValue.every((entry) => typeof entry === `string`)
+  ) {
+    return [...parsedValue]
+  }
+
+  throw new InvalidPersistedCollectionConfigError(
+    `Persisted index registry contains invalid expression SQL`,
+  )
+}
+
 function mergeObjectRows<T extends object>(existing: unknown, incoming: T): T {
   if (typeof existing === `object` && existing !== null) {
     return Object.assign({}, existing as Record<string, unknown>, incoming) as T
@@ -1461,6 +1476,28 @@ export class SQLiteCorePersistenceAdapter implements PersistenceAdapter {
            ON ${collectionTableSql} (${expressionSql})`
       await transactionDriver.exec(createIndexSql)
     })
+  }
+
+  async listIndexes(collectionId: string): Promise<Array<PersistedIndexState>> {
+    await this.ensureCollectionReady(collectionId)
+
+    const rows = await this.driver.query<{
+      signature: string
+      expression_sql: string
+      where_sql: string | null
+    }>(
+      `SELECT signature, expression_sql, where_sql
+       FROM persisted_index_registry
+       WHERE collection_id = ? AND removed = 0
+       ORDER BY signature ASC`,
+      [collectionId],
+    )
+
+    return rows.map((row) => ({
+      signature: row.signature,
+      expressionSql: parsePersistedIndexExpressionSql(row.expression_sql),
+      ...(row.where_sql === null ? {} : { whereSql: row.where_sql }),
+    }))
   }
 
   async markIndexRemoved(

--- a/packages/db-sqlite-persistence-core/tests/persisted.test.ts
+++ b/packages/db-sqlite-persistence-core/tests/persisted.test.ts
@@ -19,6 +19,7 @@ import {
 import type {
   PersistedCollectionCoordinator,
   PersistedCollectionPersistence,
+  PersistedIndexState,
   PersistedSyncWrappedOptions,
   PersistenceAdapter,
   ProtocolEnvelope,
@@ -57,10 +58,12 @@ type RecordingAdapter = PersistenceAdapter & {
   rows: Map<string, Todo>
   rowMetadata: Map<string, unknown>
   collectionMetadata: Map<string, unknown>
+  persistedIndexes: Map<string, PersistedIndexState>
 }
 
 function createRecordingAdapter(
   initialRows: Array<Todo> = [],
+  initialIndexes: Array<PersistedIndexState> = [],
 ): RecordingAdapter {
   const rows = new Map(initialRows.map((row) => [row.id, row]))
   const rowMetadata = new Map<string, unknown>()
@@ -74,6 +77,9 @@ function createRecordingAdapter(
     markIndexRemovedCalls: [],
     loadSubsetCalls: [],
     loadCollectionMetadataCalls: [],
+    persistedIndexes: new Map(
+      initialIndexes.map((indexState) => [indexState.signature, indexState]),
+    ),
     loadSubset: (collectionId, options, ctx) => {
       adapter.loadSubsetCalls.push({
         collectionId,
@@ -105,6 +111,16 @@ function createRecordingAdapter(
           key: value.id,
           value,
           metadata: rowMetadata.get(value.id),
+        })),
+      ),
+    listIndexes: () =>
+      Promise.resolve(
+        Array.from(adapter.persistedIndexes.values()).map((indexState) => ({
+          signature: indexState.signature,
+          expressionSql: [...indexState.expressionSql],
+          ...(indexState.whereSql === undefined
+            ? {}
+            : { whereSql: indexState.whereSql }),
         })),
       ),
     applyCommittedTx: (collectionId, tx) => {
@@ -160,12 +176,18 @@ function createRecordingAdapter(
       }
       return Promise.resolve()
     },
-    ensureIndex: (collectionId, signature) => {
+    ensureIndex: (collectionId, signature, spec) => {
       adapter.ensureIndexCalls.push({ collectionId, signature })
+      adapter.persistedIndexes.set(signature, {
+        signature,
+        expressionSql: [...spec.expressionSql],
+        ...(spec.whereSql === undefined ? {} : { whereSql: spec.whereSql }),
+      })
       return Promise.resolve()
     },
     markIndexRemoved: (collectionId, signature) => {
       adapter.markIndexRemovedCalls.push({ collectionId, signature })
+      adapter.persistedIndexes.delete(signature)
       return Promise.resolve()
     },
   }
@@ -894,6 +916,160 @@ describe(`persistedCollectionOptions`, () => {
       adapter.markIndexRemovedCalls.some(
         (call) => call.signature === expectedPreSyncSignature,
       ),
+    ).toBe(true)
+  })
+
+  it(`does not block preload on persisted index reconciliation`, async () => {
+    const adapter = createRecordingAdapter()
+    let resolveEnsureIndex: (() => void) | undefined
+
+    adapter.ensureIndex = (collectionId, signature, spec) => {
+      adapter.ensureIndexCalls.push({ collectionId, signature })
+      return new Promise<void>((resolve) => {
+        resolveEnsureIndex = () => {
+          adapter.persistedIndexes.set(signature, {
+            signature,
+            expressionSql: [...spec.expressionSql],
+            ...(spec.whereSql === undefined ? {} : { whereSql: spec.whereSql }),
+          })
+          resolve()
+        }
+      })
+    }
+
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present-non-blocking-indexes`,
+        getKey: (item) => item.id,
+        defaultIndexType: BasicIndex,
+        sync: {
+          sync: ({ markReady }) => {
+            markReady()
+          },
+        },
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    collection.createIndex((row) => row.title, {
+      name: `preload-title`,
+    })
+
+    const preloadPromise = collection.preload()
+    await flushAsyncWork()
+
+    const preloadResult = await Promise.race([
+      preloadPromise.then(() => `loaded` as const),
+      new Promise<`pending`>((resolve) => {
+        setTimeout(() => resolve(`pending`), 10)
+      }),
+    ])
+
+    expect(preloadResult).toBe(`loaded`)
+    expect(resolveEnsureIndex).toBeDefined()
+
+    resolveEnsureIndex?.()
+    await flushAsyncWork()
+  })
+
+  it(`removes stale persisted indexes on restart before ensuring current ones`, async () => {
+    const staleSignature = `stale-signature`
+    const adapter = createRecordingAdapter(
+      [],
+      [
+        {
+          signature: staleSignature,
+          expressionSql: [`{"type":"ref","path":["legacy"]}`],
+        },
+      ],
+    )
+
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present-index-reconcile`,
+        getKey: (item) => item.id,
+        defaultIndexType: BasicIndex,
+        sync: {
+          sync: ({ markReady }) => {
+            markReady()
+          },
+        },
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    collection.createIndex((row) => row.title, {
+      name: `current-title`,
+    })
+    const desiredSignature = collection.getIndexMetadata()[0]?.signature
+
+    await collection.preload()
+    await flushAsyncWork()
+
+    expect(desiredSignature).toBeDefined()
+    expect(
+      adapter.markIndexRemovedCalls.some(
+        (call) => call.signature === staleSignature,
+      ),
+    ).toBe(true)
+    expect(
+      adapter.ensureIndexCalls.some(
+        (call) => call.signature === desiredSignature,
+      ),
+    ).toBe(true)
+    expect(Array.from(adapter.persistedIndexes.keys())).toEqual([
+      desiredSignature,
+    ])
+  })
+
+  it(`recreates a persisted index when the stored definition mismatches the signature`, async () => {
+    const adapter = createRecordingAdapter()
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present-index-definition-mismatch`,
+        getKey: (item) => item.id,
+        defaultIndexType: BasicIndex,
+        sync: {
+          sync: ({ markReady }) => {
+            markReady()
+          },
+        },
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    const index = collection.createIndex((row) => row.title, {
+      name: `title-index`,
+    })
+    const signature = collection
+      .getIndexMetadata()
+      .find((metadata) => metadata.indexId === index.id)?.signature
+
+    if (!signature) {
+      throw new Error(`Expected a signature for the title index`)
+    }
+
+    adapter.persistedIndexes.set(signature, {
+      signature,
+      expressionSql: [`{"type":"ref","path":["otherField"]}`],
+    })
+
+    await collection.preload()
+    await flushAsyncWork()
+
+    expect(
+      adapter.markIndexRemovedCalls.some(
+        (call) => call.signature === signature,
+      ),
+    ).toBe(true)
+    expect(
+      adapter.ensureIndexCalls.some((call) => call.signature === signature),
     ).toBe(true)
   })
 

--- a/packages/db-sqlite-persistence-core/tests/persisted.test.ts
+++ b/packages/db-sqlite-persistence-core/tests/persisted.test.ts
@@ -1073,6 +1073,64 @@ describe(`persistedCollectionOptions`, () => {
     ).toBe(true)
   })
 
+  it(`does not rewrite a mismatched persisted index when removal fails`, async () => {
+    const adapter = createRecordingAdapter()
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present-index-definition-removal-failure`,
+        getKey: (item) => item.id,
+        defaultIndexType: BasicIndex,
+        sync: {
+          sync: ({ markReady }) => {
+            markReady()
+          },
+        },
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    const index = collection.createIndex((row) => row.title, {
+      name: `title-index`,
+    })
+    const signature = collection
+      .getIndexMetadata()
+      .find((metadata) => metadata.indexId === index.id)?.signature
+
+    if (!signature) {
+      throw new Error(`Expected a signature for the title index`)
+    }
+
+    adapter.persistedIndexes.set(signature, {
+      signature,
+      expressionSql: [`{"type":"ref","path":["otherField"]}`],
+    })
+    adapter.markIndexRemoved = async (collectionId, staleSignature) => {
+      adapter.markIndexRemovedCalls.push({
+        collectionId,
+        signature: staleSignature,
+      })
+      throw new Error(`drop failed`)
+    }
+
+    await collection.preload()
+    await flushAsyncWork()
+
+    expect(
+      adapter.markIndexRemovedCalls.some(
+        (call) => call.signature === signature,
+      ),
+    ).toBe(true)
+    expect(
+      adapter.ensureIndexCalls.some((call) => call.signature === signature),
+    ).toBe(false)
+    expect(adapter.persistedIndexes.get(signature)).toEqual({
+      signature,
+      expressionSql: [`{"type":"ref","path":["otherField"]}`],
+    })
+  })
+
   it(`queues remote sync writes that arrive during hydration`, async () => {
     const adapter = createRecordingAdapter([
       {

--- a/packages/db-sqlite-persistence-core/tests/sqlite-core-adapter.test.ts
+++ b/packages/db-sqlite-persistence-core/tests/sqlite-core-adapter.test.ts
@@ -964,6 +964,44 @@ export function runSQLiteCoreAdapterContractSuite(
       expect(sqliteMasterAfter).toHaveLength(0)
     })
 
+    it(`lists active persisted indexes from the registry`, async () => {
+      const { adapter } = registerContractHarness()
+      const collectionId = `todos`
+
+      await adapter.ensureIndex(collectionId, `idx-title`, {
+        expressionSql: [`json_extract(value, '$.title')`],
+      })
+      await adapter.ensureIndex(collectionId, `idx-score`, {
+        expressionSql: [`json_extract(value, '$.score')`],
+        whereSql: `json_extract(value, '$.score') IS NOT NULL`,
+      })
+
+      if (!adapter.markIndexRemoved) {
+        throw new Error(
+          `Adapter must implement markIndexRemoved for this contract suite`,
+        )
+      }
+      await adapter.markIndexRemoved(collectionId, `idx-title`)
+
+      if (
+        !(`listIndexes` in adapter) ||
+        typeof adapter.listIndexes !== `function`
+      ) {
+        throw new Error(
+          `Adapter must implement listIndexes for this contract suite`,
+        )
+      }
+
+      const indexes = await adapter.listIndexes(collectionId)
+      expect(indexes).toEqual([
+        {
+          signature: `idx-score`,
+          expressionSql: [`json_extract(value, '$.score')`],
+          whereSql: `json_extract(value, '$.score') IS NOT NULL`,
+        },
+      ])
+    })
+
     it(`enforces schema mismatch policies`, async () => {
       const baseHarness = registerContractHarness({
         schemaVersion: 1,


### PR DESCRIPTION
## 🎯 Changes

This PR fixes 2 things in persisted SQLite index handling:

1. Stale persisted indexes are now removed when current collection code no longer wants them.
2. Collection startup no longer blocks on persisted index DDL.

### 1: stale index cleanup across versions

```ts
// v1
collection.createIndex((row) => row.otherField, { name: 'title-index' })

// v2
collection.createIndex((row) => row.title, { name: 'title-index' })
```

Before this PR, startup would:
1. see `sig_title` in current code
2. create/ensure `sqlite_idx_sig_title`
3. never inspect old persisted indexes to remove `sig_otherField`

So after restart SQLite could contain both:

```text
sqlite_master:
- sqlite_idx_sig_otherField ON ...otherField
- sqlite_idx_sig_title      ON ...title
```

After this PR, startup instead:
1. reads desired signatures from current code
2. reads actual persisted signatures from SQLite
3. drops `sqlite_idx_sig_otherField` because it is no longer desired
4. creates/ensures `sqlite_idx_sig_title` if needed

So after restart SQLite ends up with only:

```text
sqlite_master:
- sqlite_idx_sig_title ON ...title
```

### 2: startup no longer blocks on persisted index DDL
- Before this PR, collection startup awaited persisted index bootstrap.
- After this PR, persisted index reconciliation runs in the background, so collection startup is no longer blocked on index creation.

## ✅ Checklist

- [ ] I have tested this code locally with `pnpm test`.

Focused tests run locally:
- `pnpm --filter @tanstack/db-sqlite-persistence-core test`
- `pnpm --filter @tanstack/node-db-sqlite-persistence test`

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
