### PR TITLE
docs(react-db): add CRITICAL common mistakes to skill

### DIFF
--- a/packages/react-db/skills/react-db/SKILL.md
+++ b/packages/react-db/skills/react-db/SKILL.md
@@ -307,8 +307,11 @@ See meta-framework/SKILL.md for full preloading patterns.
 Wrong — throws `InvalidWhereExpressionError` at runtime:
 
 ```tsx
-const { data } = useLiveQuery((q) =>
-  q.from({ todo: todoCollection }).where(({ todo }) => todo.completed === true),
+const { data } = useLiveQuery(
+  (q) =>
+    q
+      .from({ todo: todoCollection })
+      .where(({ todo }) => todo.completed === true),
   [],
 )
 ```
@@ -318,8 +321,11 @@ Correct — use expression functions from `@tanstack/react-db`:
 ```tsx
 import { useLiveQuery, eq } from '@tanstack/react-db'
 
-const { data } = useLiveQuery((q) =>
-  q.from({ todo: todoCollection }).where(({ todo }) => eq(todo.completed, true)),
+const { data } = useLiveQuery(
+  (q) =>
+    q
+      .from({ todo: todoCollection })
+      .where(({ todo }) => eq(todo.completed, true)),
   [],
 )
 ```
@@ -332,14 +338,17 @@ Wrong — crashes with "map is not a function":
 
 ```tsx
 const todos = useLiveQuery((q) => q.from({ todo: todoCollection }), [])
-return todos.map(t => <li>{t.text}</li>)  // TypeError: todos.map is not a function
+return todos.map((t) => <li>{t.text}</li>) // TypeError: todos.map is not a function
 ```
 
 Correct — destructure `{ data }` with a default:
 
 ```tsx
-const { data: todos = [] } = useLiveQuery((q) => q.from({ todo: todoCollection }), [])
-return todos.map(t => <li key={t.id}>{t.text}</li>)
+const { data: todos = [] } = useLiveQuery(
+  (q) => q.from({ todo: todoCollection }),
+  [],
+)
+return todos.map((t) => <li key={t.id}>{t.text}</li>)
 ```
 
 `useLiveQuery` returns an object `{ data, isLoading, status, ... }`, not the array directly.

--- a/packages/react-db/skills/react-db/SKILL.md
+++ b/packages/react-db/skills/react-db/SKILL.md
@@ -302,6 +302,48 @@ See meta-framework/SKILL.md for full preloading patterns.
 
 ## Common Mistakes
 
+### CRITICAL Using === instead of eq() in .where()
+
+Wrong — throws `InvalidWhereExpressionError` at runtime:
+
+```tsx
+const { data } = useLiveQuery((q) =>
+  q.from({ todo: todoCollection }).where(({ todo }) => todo.completed === true),
+  [],
+)
+```
+
+Correct — use expression functions from `@tanstack/react-db`:
+
+```tsx
+import { useLiveQuery, eq } from '@tanstack/react-db'
+
+const { data } = useLiveQuery((q) =>
+  q.from({ todo: todoCollection }).where(({ todo }) => eq(todo.completed, true)),
+  [],
+)
+```
+
+JavaScript `===`, `!==`, `<`, `>` return a boolean, not a query expression. Always use `eq`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `not`, `like`, `ilike`, `isNull`, `isUndefined`, `inArray`. See db-core/live-queries/SKILL.md for the full operator reference.
+
+### CRITICAL Assigning useLiveQuery result directly instead of destructuring
+
+Wrong — crashes with "map is not a function":
+
+```tsx
+const todos = useLiveQuery((q) => q.from({ todo: todoCollection }), [])
+return todos.map(t => <li>{t.text}</li>)  // TypeError: todos.map is not a function
+```
+
+Correct — destructure `{ data }` with a default:
+
+```tsx
+const { data: todos = [] } = useLiveQuery((q) => q.from({ todo: todoCollection }), [])
+return todos.map(t => <li key={t.id}>{t.text}</li>)
+```
+
+`useLiveQuery` returns an object `{ data, isLoading, status, ... }`, not the array directly.
+
 ### CRITICAL Missing external values in dependency array
 
 Wrong:


### PR DESCRIPTION
## Summary
- Add two CRITICAL common mistakes to the `react-db` skill that AI agents hit frequently
- **Using `===` instead of `eq()` in `.where()`** — throws `InvalidWhereExpressionError` at runtime
- **Assigning `useLiveQuery()` directly instead of destructuring `{ data }`** — causes "map is not a function"

Both are documented in `db-core/live-queries` but agents typically only read the `react-db` skill. Adding the warnings where they'll be seen.

## Context
These are the two most common runtime errors we see when AI agents build TanStack DB apps. The `live-queries` sub-skill documents them, but agents read `react-db/SKILL.md` as their primary reference and miss the sub-skill cross-references.

## Test plan
- [ ] Verify skill renders correctly
- [ ] Run agent session building a CRUD app — confirm correct `eq()` usage and `{ data }` destructuring

Generated with [Claude Code](https://claude.com/claude-code)