### PR TITLE
fix(electric-db-collection): guard markReady against post-cleanup onError race

### DIFF
--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -1422,7 +1422,11 @@ function createElectricSync<T extends Row<unknown>>(
           // Note that Electric sends a 409 error on a `must-refetch` message, but the
           // ShapeStream handled this and it will not reach this handler, therefor
           // this markReady will not be triggers by a `must-refetch`.
-          markReady()
+          // Guard against the race condition where collection.cleanup() aborts
+          // the stream but onError fires before the ShapeStream observes the
+          // abort signal. Calling markReady() on a cleaned-up collection throws
+          // CollectionStateError ("cleaned-up" → "ready" is invalid).
+          if (!abortController.signal.aborted) markReady()
 
           if (shapeOptions.onError) {
             return shapeOptions.onError(errorParams)

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -1917,6 +1917,46 @@ describe(`Electric Integration`, () => {
       expect(mockAbortController.abort).toHaveBeenCalledTimes(1)
     })
 
+    it(`should not throw CollectionStateError when onError fires after cleanup`, async () => {
+      // Regression test: cleanup() aborts the stream, but onError can still fire
+      // before the ShapeStream observes the abort signal. Without the guard,
+      // calling markReady() on a cleaned-up collection throws CollectionStateError
+      // ("cleaned-up" → "ready" is an invalid lifecycle transition).
+      const realAbortController = new AbortController()
+      mockAbortController = {
+        abort: vi.fn(() => realAbortController.abort()),
+        signal: realAbortController.signal,
+      }
+      global.AbortController = vi.fn().mockImplementation(() => mockAbortController)
+
+      let capturedOnError: ((params: unknown) => void) | undefined
+      const { ShapeStream } = await import(`@electric-sql/client`)
+      vi.mocked(ShapeStream).mockImplementation((options: any) => {
+        capturedOnError = options.onError
+        return mockStream as any
+      })
+
+      const config = {
+        id: `on-error-after-cleanup-test`,
+        shapeOptions: {
+          url: `http://test-url`,
+          params: { table: `test_table` },
+        },
+        getKey: (item: Row) => item.id as number,
+        startSync: true,
+      }
+
+      const testCollection = createCollection(electricCollectionOptions(config))
+      expect(capturedOnError).toBeDefined()
+
+      // Simulate cleanup (this aborts the controller)
+      await testCollection.cleanup()
+      expect(testCollection.status).toBe(`cleaned-up`)
+
+      // Simulate onError firing after cleanup — should not throw CollectionStateError
+      expect(() => capturedOnError!({ status: 500, json: {} })).not.toThrow()
+    })
+
     it(`should restart stream when collection is accessed after cleanup`, async () => {
       const config = {
         id: `restart-stream-test`,


### PR DESCRIPTION
## Problem

When `collection.cleanup()` is called (e.g. on logout or team switch), the `AbortController` is signalled to stop the `ShapeStream`. However, there is a race condition: `onError` can fire **after** `cleanup()` has run but **before** the `ShapeStream` observes the abort signal.

The `onError` handler unconditionally calls `markReady()`, which throws:

```
CollectionStateError: Invalid collection status transition from "cleaned-up" to "ready"
```

This surfaces as an unhandled exception in applications and pollutes error tracking dashboards (e.g. PostHog, Sentry) with noise that has no actionable fix from the application side.

## Root cause

In `packages/electric-db-collection/src/electric.ts`:

```typescript
onError: (errorParams) => {
  markReady()  // ← unconditional; throws if collection is already cleaned-up
  ...
}
```

`abortController` is already in scope here — its `abort()` is already called during `cleanup()` — but there was no guard before calling `markReady()`.

## Fix

```typescript
// Before
markReady()

// After
if (!abortController.signal.aborted) markReady()
```

One-liner. Zero new imports or complexity.

## Test

Added regression test: *"should not throw CollectionStateError when onError fires after cleanup"*

The test wires a real `AbortController` into the mock, calls `cleanup()`, then fires `onError` and asserts no exception is thrown.

## Relation to PR #1174

PR #1174 fixed the same class of abort-race issue for `requestSnapshot` / `fetchSnapshot` (in-flight network calls suppressed on abort). This PR covers the remaining `onError → markReady()` path that #1174 did not address.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.
- [x] This change affects published code, and I have generated a changeset (if required).