### PR TITLE
fix(sqlite): inline JSON paths for expression indexes

### DIFF
--- a/.changeset/fast-pianos-teach.md
+++ b/.changeset/fast-pianos-teach.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/browser-db-sqlite-persistence": patch
+"@tanstack/db-sqlite-persistence-core": patch
+---
+
+Fix SQLite expression-index matching for persisted ref filters by inlining JSON-path literals in runtime SQL compilation while keeping actual filter values bound.

--- a/.changeset/fast-pianos-teach.md
+++ b/.changeset/fast-pianos-teach.md
@@ -1,6 +1,6 @@
 ---
-"@tanstack/browser-db-sqlite-persistence": patch
-"@tanstack/db-sqlite-persistence-core": patch
+'@tanstack/browser-db-sqlite-persistence': patch
+'@tanstack/db-sqlite-persistence-core': patch
 ---
 
 Fix SQLite expression-index matching for persisted ref filters by inlining JSON-path literals in runtime SQL compilation while keeping actual filter values bound.

--- a/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
+++ b/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
@@ -579,6 +579,7 @@ function compileComparisonSql(
 function compileRefExpressionSql(jsonPath: string): CompiledSqlFragment {
   const typePath = `${jsonPath}.${PERSISTED_TYPE_TAG}`
   const taggedValuePath = `${jsonPath}.${PERSISTED_VALUE_TAG}`
+  // Inline JSON paths so SQLite can match runtime refs to expression-index SQL.
   const typePathSql = toSqliteLiteral(typePath)
   const taggedValuePathSql = toSqliteLiteral(taggedValuePath)
   const jsonPathSql = toSqliteLiteral(jsonPath)

--- a/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
+++ b/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
@@ -579,18 +579,21 @@ function compileComparisonSql(
 function compileRefExpressionSql(jsonPath: string): CompiledSqlFragment {
   const typePath = `${jsonPath}.${PERSISTED_TYPE_TAG}`
   const taggedValuePath = `${jsonPath}.${PERSISTED_VALUE_TAG}`
+  const typePathSql = toSqliteLiteral(typePath)
+  const taggedValuePathSql = toSqliteLiteral(taggedValuePath)
+  const jsonPathSql = toSqliteLiteral(jsonPath)
 
   return {
     supported: true,
-    sql: `(CASE json_extract(value, ?)
-      WHEN 'bigint' THEN CAST(json_extract(value, ?) AS NUMERIC)
-      WHEN 'date' THEN json_extract(value, ?)
+    sql: `(CASE json_extract(value, ${typePathSql})
+      WHEN 'bigint' THEN CAST(json_extract(value, ${taggedValuePathSql}) AS NUMERIC)
+      WHEN 'date' THEN json_extract(value, ${taggedValuePathSql})
       WHEN 'nan' THEN NULL
       WHEN 'infinity' THEN NULL
       WHEN '-infinity' THEN NULL
-      ELSE json_extract(value, ?)
+      ELSE json_extract(value, ${jsonPathSql})
     END)`,
-    params: [typePath, taggedValuePath, taggedValuePath, jsonPath],
+    params: [],
     valueKind: `unknown`,
   }
 }

--- a/packages/db-sqlite-persistence-core/tests/sqlite-core-adapter.test.ts
+++ b/packages/db-sqlite-persistence-core/tests/sqlite-core-adapter.test.ts
@@ -249,10 +249,13 @@ function createQueryObservingDriver(
       run: async (sql, params) => driver.run(sql, params),
       transaction: async <T>(
         fn: (transactionDriver: SQLiteDriver) => Promise<T>,
-      ) => driver.transaction((transactionDriver) => fn(wrap(transactionDriver))),
+      ) =>
+        driver.transaction((transactionDriver) => fn(wrap(transactionDriver))),
       transactionWithDriver: transactionWithDriver
         ? async <T>(fn: (transactionDriver: SQLiteDriver) => Promise<T>) =>
-            transactionWithDriver((transactionDriver) => fn(wrap(transactionDriver)))
+            transactionWithDriver((transactionDriver) =>
+              fn(wrap(transactionDriver)),
+            )
         : undefined,
     }
   }

--- a/packages/db-sqlite-persistence-core/tests/sqlite-core-adapter.test.ts
+++ b/packages/db-sqlite-persistence-core/tests/sqlite-core-adapter.test.ts
@@ -230,6 +230,36 @@ function registerHarness(
   return harness
 }
 
+function createQueryObservingDriver(
+  inner: SQLiteDriver,
+  observeQuery: (
+    sql: string,
+    params: ReadonlyArray<unknown>,
+  ) => void | Promise<void>,
+): SQLiteDriver {
+  const wrap = (driver: SQLiteDriver): SQLiteDriver => {
+    const transactionWithDriver = driver.transactionWithDriver
+
+    return {
+      exec: async (sql) => driver.exec(sql),
+      query: async <T>(sql: string, params?: ReadonlyArray<unknown>) => {
+        await observeQuery(sql, params ?? [])
+        return driver.query<T>(sql, params)
+      },
+      run: async (sql, params) => driver.run(sql, params),
+      transaction: async <T>(
+        fn: (transactionDriver: SQLiteDriver) => Promise<T>,
+      ) => driver.transaction((transactionDriver) => fn(wrap(transactionDriver))),
+      transactionWithDriver: transactionWithDriver
+        ? async <T>(fn: (transactionDriver: SQLiteDriver) => Promise<T>) =>
+            transactionWithDriver((transactionDriver) => fn(wrap(transactionDriver)))
+        : undefined,
+    }
+  }
+
+  return wrap(inner)
+}
+
 export type SQLiteCoreAdapterHarnessFactory = (
   options?: Omit<
     ConstructorParameters<typeof SQLiteCorePersistenceAdapter>[0],
@@ -1607,6 +1637,94 @@ export function runSQLiteCoreAdapterContractSuite(
       expect(sqliteMasterRows[0]?.sql).toContain(
         `json_extract(value, '$.title')`,
       )
+    })
+
+    it(`inlines JSON-path refs in runtime subset filters while keeping values bound`, async () => {
+      const baseHarness = registerHarness()
+      const collectionId = `thread-messages`
+      let capturedSubsetSql: string | undefined
+      let capturedSubsetParams: ReadonlyArray<unknown> = []
+
+      const driver = createQueryObservingDriver(
+        baseHarness.driver,
+        (sql, params) => {
+          if (
+            sql.startsWith(`SELECT key, value, metadata, row_version FROM`) &&
+            sql.includes(`WHERE`)
+          ) {
+            capturedSubsetSql = sql
+            capturedSubsetParams = params
+          }
+        },
+      )
+      const adapter = new SQLiteCorePersistenceAdapter({ driver })
+
+      await adapter.applyCommittedTx(collectionId, {
+        txId: `thread-messages-seed`,
+        term: 1,
+        seq: 1,
+        rowVersion: 1,
+        mutations: [
+          {
+            type: `insert`,
+            key: `1`,
+            value: {
+              id: `1`,
+              threadId: `thread-1`,
+              title: `First`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 1,
+            },
+          },
+          {
+            type: `insert`,
+            key: `2`,
+            value: {
+              id: `2`,
+              threadId: `thread-1`,
+              title: `Second`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 2,
+            },
+          },
+          {
+            type: `insert`,
+            key: `3`,
+            value: {
+              id: `3`,
+              threadId: `thread-2`,
+              title: `Other thread`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 3,
+            },
+          },
+        ],
+      })
+
+      await adapter.ensureIndex(collectionId, `thread-id`, {
+        expressionSql: [
+          JSON.stringify({
+            type: `ref`,
+            path: [`threadId`],
+          }),
+        ],
+      })
+
+      const rows = await adapter.loadSubset(collectionId, {
+        where: new IR.Func(`eq`, [
+          new IR.PropRef([`threadId`]),
+          new IR.Value(`thread-1`),
+        ]),
+      })
+
+      expect(rows).toHaveLength(2)
+      expect(rows.map((row) => String(row.key)).sort()).toEqual([`1`, `2`])
+      expect(capturedSubsetSql).toContain(`WHERE`)
+      expect(capturedSubsetSql).toContain(
+        `json_extract(value, '$.threadId.__tanstack_db_persisted_type__')`,
+      )
+      expect(capturedSubsetSql).toContain(`json_extract(value, '$.threadId')`)
+      expect(capturedSubsetParams).toEqual([`thread-1`])
     })
 
     it(`rejects unsafe raw SQL fragments in index specs`, async () => {

--- a/packages/node-db-sqlite-persistence/tests/node-sqlite-core-adapter-contract.test.ts
+++ b/packages/node-db-sqlite-persistence/tests/node-sqlite-core-adapter-contract.test.ts
@@ -1,10 +1,16 @@
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { IR } from '@tanstack/db'
 import { runSQLiteCoreAdapterContractSuite } from '../../db-sqlite-persistence-core/tests/contracts/sqlite-core-adapter-contract'
 import { BetterSqlite3SQLiteDriver } from '../src/node-driver'
-import { SQLiteCorePersistenceAdapter } from '../../db-sqlite-persistence-core/src'
+import {
+  SQLiteCorePersistenceAdapter,
+  createPersistedTableName,
+} from '../../db-sqlite-persistence-core/src'
 import type { SQLiteCoreAdapterHarnessFactory } from '../../db-sqlite-persistence-core/tests/contracts/sqlite-core-adapter-contract'
+import type { SQLiteDriver } from '../../db-sqlite-persistence-core/src'
 
 const createHarness: SQLiteCoreAdapterHarnessFactory = (options) => {
   const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-sqlite-core-`))
@@ -32,3 +38,155 @@ runSQLiteCoreAdapterContractSuite(
   `SQLiteCorePersistenceAdapter (better-sqlite3 node driver)`,
   createHarness,
 )
+
+function createQueryObservingDriver(
+  inner: SQLiteDriver,
+  observeQuery: (
+    sql: string,
+    params: ReadonlyArray<unknown>,
+  ) => void | Promise<void>,
+): SQLiteDriver {
+  const wrap = (driver: SQLiteDriver): SQLiteDriver => {
+    return {
+      exec: async function (sql) {
+        return driver.exec(sql)
+      },
+      query: async function <T>(
+        sql: string,
+        params?: ReadonlyArray<unknown>,
+      ) {
+        await observeQuery(sql, params ?? [])
+        return driver.query<T>(sql, params)
+      },
+      run: async function (sql, params) {
+        return driver.run(sql, params)
+      },
+      transaction: async function <T>(
+        fn: (transactionDriver: SQLiteDriver) => Promise<T>,
+      ) {
+        return driver.transaction((transactionDriver) =>
+          fn(wrap(transactionDriver)),
+        )
+      },
+      transactionWithDriver: driver.transactionWithDriver
+        ? async function <T>(
+            fn: (transactionDriver: SQLiteDriver) => Promise<T>,
+          ) {
+            return driver.transactionWithDriver!((
+              transactionDriver,
+            ) =>
+              fn(wrap(transactionDriver)),
+            )
+          }
+        : undefined,
+    }
+  }
+
+  return wrap(inner)
+}
+
+describe(`SQLiteCorePersistenceAdapter planner behavior (better-sqlite3)`, () => {
+  it(`uses expression indexes for runtime ref filters`, async () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-sqlite-plan-`))
+    const dbPath = join(tempDirectory, `state.sqlite`)
+    const baseDriver = new BetterSqlite3SQLiteDriver({ filename: dbPath })
+    const collectionId = `thread-messages`
+    const tableName = createPersistedTableName(collectionId, `c`)
+    let capturedSubsetSql: string | undefined
+    let capturedSubsetParams: ReadonlyArray<unknown> = []
+
+    const driver = createQueryObservingDriver(baseDriver, (sql, params) => {
+      if (
+        sql.startsWith(`SELECT key, value, metadata, row_version FROM`) &&
+        sql.includes(`WHERE`)
+      ) {
+        capturedSubsetSql = sql
+        capturedSubsetParams = params
+      }
+    })
+    const adapter = new SQLiteCorePersistenceAdapter({ driver })
+
+    try {
+      await adapter.applyCommittedTx(collectionId, {
+        txId: `thread-messages-seed`,
+        term: 1,
+        seq: 1,
+        rowVersion: 1,
+        mutations: [
+          {
+            type: `insert`,
+            key: `1`,
+            value: {
+              id: `1`,
+              threadId: `thread-1`,
+              title: `First`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 1,
+            },
+          },
+          {
+            type: `insert`,
+            key: `2`,
+            value: {
+              id: `2`,
+              threadId: `thread-1`,
+              title: `Second`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 2,
+            },
+          },
+          {
+            type: `insert`,
+            key: `3`,
+            value: {
+              id: `3`,
+              threadId: `thread-2`,
+              title: `Other thread`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 3,
+            },
+          },
+        ],
+      })
+
+      await adapter.ensureIndex(collectionId, `thread-id`, {
+        expressionSql: [
+          JSON.stringify({
+            type: `ref`,
+            path: [`threadId`],
+          }),
+        ],
+      })
+
+      const rows = await adapter.loadSubset(collectionId, {
+        where: new IR.Func(`eq`, [
+          new IR.PropRef([`threadId`]),
+          new IR.Value(`thread-1`),
+        ]),
+      })
+
+      expect(rows).toHaveLength(2)
+      expect(capturedSubsetSql).toContain(`WHERE`)
+      expect(capturedSubsetParams).toEqual([`thread-1`])
+
+      const planRows = baseDriver
+        .getDatabase()
+        .prepare(`EXPLAIN QUERY PLAN ${capturedSubsetSql}`)
+        .all(...capturedSubsetParams) as Array<{ detail: string }>
+      const indexedSearchPattern = new RegExp(
+        `\\bSEARCH ${tableName}\\b.*\\bUSING INDEX\\b`,
+      )
+
+      expect(planRows.map((row) => row.detail).length).toBeGreaterThan(0)
+      expect(
+        planRows.some((row) => indexedSearchPattern.test(row.detail)),
+      ).toBe(true)
+      expect(
+        planRows.some((row) => row.detail.startsWith(`SCAN ${tableName}`)),
+      ).toBe(false)
+    } finally {
+      baseDriver.close()
+      rmSync(tempDirectory, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/node-db-sqlite-persistence/tests/node-sqlite-core-adapter-contract.test.ts
+++ b/packages/node-db-sqlite-persistence/tests/node-sqlite-core-adapter-contract.test.ts
@@ -51,10 +51,7 @@ function createQueryObservingDriver(
       exec: async function (sql) {
         return driver.exec(sql)
       },
-      query: async function <T>(
-        sql: string,
-        params?: ReadonlyArray<unknown>,
-      ) {
+      query: async function <T>(sql: string, params?: ReadonlyArray<unknown>) {
         await observeQuery(sql, params ?? [])
         return driver.query<T>(sql, params)
       },
@@ -72,9 +69,7 @@ function createQueryObservingDriver(
         ? async function <T>(
             fn: (transactionDriver: SQLiteDriver) => Promise<T>,
           ) {
-            return driver.transactionWithDriver!((
-              transactionDriver,
-            ) =>
+            return driver.transactionWithDriver!((transactionDriver) =>
               fn(wrap(transactionDriver)),
             )
           }

--- a/packages/node-db-sqlite-persistence/tests/node-sqlite-core-adapter-contract.test.ts
+++ b/packages/node-db-sqlite-persistence/tests/node-sqlite-core-adapter-contract.test.ts
@@ -34,6 +34,10 @@ const createHarness: SQLiteCoreAdapterHarnessFactory = (options) => {
   }
 }
 
+type QueryPlanRow = {
+  detail: string
+}
+
 runSQLiteCoreAdapterContractSuite(
   `SQLiteCorePersistenceAdapter (better-sqlite3 node driver)`,
   createHarness,
@@ -179,6 +183,132 @@ describe(`SQLiteCorePersistenceAdapter planner behavior (better-sqlite3)`, () =>
       expect(
         planRows.some((row) => row.detail.startsWith(`SCAN ${tableName}`)),
       ).toBe(false)
+    } finally {
+      baseDriver.close()
+      rmSync(tempDirectory, { recursive: true, force: true })
+    }
+  })
+
+  it(`uses expression indexes for filters while sorting composite orderBy`, async () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-sqlite-plan-`))
+    const dbPath = join(tempDirectory, `state.sqlite`)
+    const baseDriver = new BetterSqlite3SQLiteDriver({ filename: dbPath })
+    const collectionId = `thread-messages-composite-order`
+    const tableName = createPersistedTableName(collectionId, `c`)
+    let capturedSubsetSql: string | undefined
+    let capturedSubsetParams: ReadonlyArray<unknown> = []
+
+    const driver = createQueryObservingDriver(baseDriver, (sql, params) => {
+      if (
+        sql.startsWith(`SELECT key, value, metadata, row_version FROM`) &&
+        sql.includes(`WHERE`)
+      ) {
+        capturedSubsetSql = sql
+        capturedSubsetParams = params
+      }
+    })
+    const adapter = new SQLiteCorePersistenceAdapter({ driver })
+
+    try {
+      await adapter.applyCommittedTx(collectionId, {
+        txId: `thread-messages-composite-order-seed`,
+        term: 1,
+        seq: 1,
+        rowVersion: 1,
+        mutations: [
+          {
+            type: `insert`,
+            key: `1`,
+            value: {
+              id: `1`,
+              threadId: `thread-1`,
+              title: `First`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 1,
+            },
+          },
+          {
+            type: `insert`,
+            key: `2`,
+            value: {
+              id: `2`,
+              threadId: `thread-1`,
+              title: `Second`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 2,
+            },
+          },
+          {
+            type: `insert`,
+            key: `3`,
+            value: {
+              id: `3`,
+              threadId: `thread-2`,
+              title: `Other thread`,
+              createdAt: `2026-01-01T00:00:00.000Z`,
+              score: 3,
+            },
+          },
+        ],
+      })
+
+      await adapter.ensureIndex(collectionId, `thread-id`, {
+        expressionSql: [
+          JSON.stringify({
+            type: `ref`,
+            path: [`threadId`],
+          }),
+        ],
+      })
+
+      const rows = await adapter.loadSubset(collectionId, {
+        where: new IR.Func(`eq`, [
+          new IR.PropRef([`threadId`]),
+          new IR.Value(`thread-1`),
+        ]),
+        orderBy: [
+          {
+            expression: new IR.PropRef([`createdAt`]),
+            compareOptions: {
+              direction: `desc`,
+              nulls: `first`,
+            },
+          },
+          {
+            expression: new IR.PropRef([`id`]),
+            compareOptions: {
+              direction: `desc`,
+              nulls: `first`,
+            },
+          },
+        ],
+      })
+
+      if (capturedSubsetSql === undefined) {
+        throw new Error(`Expected subset SQL to be captured`)
+      }
+
+      expect(rows.map((row) => row.key)).toEqual([`2`, `1`])
+      expect(capturedSubsetSql).toContain(`WHERE`)
+      expect(capturedSubsetSql).toContain(`ORDER BY`)
+      expect(capturedSubsetParams).toEqual([`thread-1`])
+
+      const planRows = baseDriver
+        .getDatabase()
+        .prepare<Array<unknown>, QueryPlanRow>(
+          `EXPLAIN QUERY PLAN ${capturedSubsetSql}`,
+        )
+        .all(...capturedSubsetParams)
+      const indexedSearchPattern = new RegExp(
+        `\\bSEARCH ${tableName}\\b.*\\bUSING INDEX\\b`,
+      )
+
+      expect(planRows.length).toBeGreaterThan(0)
+      expect(
+        planRows.some((row) => indexedSearchPattern.test(row.detail)),
+      ).toBe(true)
+      const planDetails = planRows.map((row) => row.detail)
+      expect(planDetails).toContain(`USE TEMP B-TREE FOR ORDER BY`)
     } finally {
       baseDriver.close()
       rmSync(tempDirectory, { recursive: true, force: true })


### PR DESCRIPTION
## 🎯 Changes

Fixes a SQLite planner mismatch in `@tanstack/db-sqlite-persistence-core`.

This came from a real app query against a persisted query collection - `threadMessages`:

```ts
q
  .from({ m: threadMessages })
  .where(({ m }) => eq(m.threadId, threadId))
  .orderBy(({ m }) => m.createdAt, 'desc')
  .orderBy(({ m }) => m.id, 'desc')
```

In the app, we first added the missing persisted filter index:

```ts
collection.createIndex((row) => row.threadId)
```

At that point, we expected SQLite to stop doing a full table scan for the filter.

The important expectation was not just “there is now an index on `threadId`”. It was:

1. the persisted expression index for `threadId` is stored as literal-path SQL
2. the runtime query for `WHERE threadId = ?` should compile to the same expression shape
3. if those shapes match, SQLite should be able to plan `SEARCH ... USING INDEX ...` for the filter

The expected planner outcome after adding that index was:

- `SEARCH ... USING INDEX <threadId expression index>` for the `WHERE threadId = ?` filter
- possibly still `USE TEMP B-TREE FOR ORDER BY`, because the app query also sorts by `createdAt DESC, id DESC` and there is no composite persisted index for `(threadId, createdAt, id)`

What the runtime query was actually compiled into was the full SQL shape below and resulted in a `SCAN` instead of a `SEARCH`:

```sql
SELECT key, value, metadata, row_version
FROM "c_z6sj6b_e"
WHERE ((CASE json_extract(value, ?)
  WHEN 'bigint' THEN CAST(json_extract(value, ?) AS NUMERIC)
  WHEN 'date' THEN json_extract(value, ?)
  WHEN 'nan' THEN NULL
  WHEN 'infinity' THEN NULL
  WHEN '-infinity' THEN NULL
  ELSE json_extract(value, ?)
END) = ?)
ORDER BY (CASE json_extract(value, ?)
  WHEN 'bigint' THEN CAST(json_extract(value, ?) AS NUMERIC)
  WHEN 'date' THEN json_extract(value, ?)
  WHEN 'nan' THEN NULL
  WHEN 'infinity' THEN NULL
  WHEN '-infinity' THEN NULL
  ELSE json_extract(value, ?)
END) DESC NULLS FIRST,
(CASE json_extract(value, ?)
  WHEN 'bigint' THEN CAST(json_extract(value, ?) AS NUMERIC)
  WHEN 'date' THEN json_extract(value, ?)
  WHEN 'nan' THEN NULL
  WHEN 'infinity' THEN NULL
  WHEN '-infinity' THEN NULL
  ELSE json_extract(value, ?)
END) DESC NULLS FIRST,
key ASC
```

with params shaped like:

```ts
[
  '$.threadId.__tanstack_db_persisted_type__',
  '$.threadId.value',
  '$.threadId.value',
  '$.threadId',
  '92ebe40d-e545-40f2-b0fd-bba86c41b86e',
  '$.createdAt.__tanstack_db_persisted_type__',
  '$.createdAt.value',
  '$.createdAt.value',
  '$.createdAt',
  '$.id.__tanstack_db_persisted_type__',
  '$.id.value',
  '$.id.value',
  '$.id',
]
```

The persisted expression index for `threadId` had already been normalized into literal-path SQL such as:

```sql
json_extract(value, '$.threadId')
```

So the runtime query and the persisted index were logically equivalent but not structurally identical from SQLite's perspective. SQLite expression-index matching is shape-sensitive here: `json_extract(value, ?)` is not the same expression as `json_extract(value, '$.threadId')` for planner matching purposes.

That is why adding the missing `threadId` index was necessary but not sufficient: the index existed, but the framework was still compiling the runtime predicate into a form that could not match that index.

What we should have expected the runtime query to look like, in order to leverage the `threadId` expression index, was the full query shape below. The important part is that the `threadId` expression is compiled with literal JSON paths, while the actual thread ID remains bound:

```sql
SELECT key, value, metadata, row_version
FROM "c_z6sj6b_e"
WHERE ((CASE json_extract(value, '$.threadId.__tanstack_db_persisted_type__')
  WHEN 'bigint' THEN CAST(json_extract(value, '$.threadId.value') AS NUMERIC)
  WHEN 'date' THEN json_extract(value, '$.threadId.value')
  WHEN 'nan' THEN NULL
  WHEN 'infinity' THEN NULL
  WHEN '-infinity' THEN NULL
  ELSE json_extract(value, '$.threadId')
END) = ?)
ORDER BY (CASE json_extract(value, '$.createdAt.__tanstack_db_persisted_type__')
  WHEN 'bigint' THEN CAST(json_extract(value, '$.createdAt.value') AS NUMERIC)
  WHEN 'date' THEN json_extract(value, '$.createdAt.value')
  WHEN 'nan' THEN NULL
  WHEN 'infinity' THEN NULL
  WHEN '-infinity' THEN NULL
  ELSE json_extract(value, '$.createdAt')
END) DESC NULLS FIRST,
(CASE json_extract(value, '$.id.__tanstack_db_persisted_type__')
  WHEN 'bigint' THEN CAST(json_extract(value, '$.id.value') AS NUMERIC)
  WHEN 'date' THEN json_extract(value, '$.id.value')
  WHEN 'nan' THEN NULL
  WHEN 'infinity' THEN NULL
  WHEN '-infinity' THEN NULL
  ELSE json_extract(value, '$.id')
END) DESC NULLS FIRST,
key ASC
```

with params shaped like:

```ts
['92ebe40d-e545-40f2-b0fd-bba86c41b86e']
```

That full query shape would let SQLite match the filter expression against the persisted `threadId` expression index. The remaining `ORDER BY` could still require a temp sort, which is fine and expected for this query shape.

This PR fixes that by compiling runtime ref expressions with inlined JSON-path literals in `compileRefExpressionSql(...)`, while still keeping real filter values bound.

After this change, the runtime SQL shape matches the persisted index expression shape, which allows SQLite to use the index for the filter path.

It also adds two regressions:

- core/shared regression: verifies runtime subset SQL inlines JSON paths but keeps actual values bound
- node driver regression: verifies `better-sqlite3` uses the expression index for the emitted runtime SQL via `EXPLAIN QUERY PLAN`

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Verification

Passed on the fixed tree:

- `pnpm exec vitest --run tests/sqlite-core-adapter-cli-runtime.test.ts`
- `pnpm exec vitest --run tests/node-sqlite-core-adapter-contract.test.ts`
- `pnpm --filter @tanstack/db-sqlite-persistence-core test`

Negative verification:

I temporarily reverted only `compileRefExpressionSql(...)` locally and re-ran the targeted regressions.

Without the fix:

- the SQL-shape regression failed because the emitted query contained `json_extract(value, ?)` instead of inlined JSON paths
- the node planner regression failed because the runtime query reintroduced bound JSON-path params (`'$.threadId.__tanstack_db_persisted_type__'`, `'$.threadId.value'`, etc.) instead of keeping only the real filter value bound
