### PR TITLE
feat(db): expose tracked source record subscriptions

### DIFF
--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -3,6 +3,7 @@ import {
   CollectionRequiresConfigError,
   CollectionRequiresSyncConfigError,
 } from '../errors'
+import { getBuilderFromConfig } from '../query/live/collection-registry.js'
 import { currentStateAsChanges } from './change-events'
 import { TrackedSourceRecordsManager } from './tracked-source-records.js'
 
@@ -47,6 +48,14 @@ import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { WithVirtualProps } from '../virtual-props.js'
 
 export type { CollectionIndexMetadata } from './events.js'
+
+type LiveQueryTrackedSourceView = {
+  snapshot: () => Array<TrackedSourceRecord>
+  subscribe: (
+    callback: (change: TrackedSourceRecordsChange) => void,
+    options?: SubscribeTrackedSourceRecordsOptions,
+  ) => () => void
+}
 
 /**
  * Enhanced Collection interface that includes both data type T and utilities TUtils
@@ -314,17 +323,8 @@ export class CollectionImpl<
   // can push deltas in.
   public _trackedSourceRecords: TrackedSourceRecordsManager<TKey>
   // For live-query collections only: a live-query-local view of "source
-  // records this query is currently using." Set by the live-query path
-  // during construction; undefined on base collections. When present, the
-  // public `getTrackedSourceRecords` / `subscribeTrackedSourceRecords`
-  // methods route to this view instead of `_trackedSourceRecords`.
-  public _liveQueryTrackedSourceView?: {
-    snapshot: () => Array<TrackedSourceRecord>
-    subscribe: (
-      callback: (change: TrackedSourceRecordsChange) => void,
-      options?: SubscribeTrackedSourceRecordsOptions,
-    ) => () => void
-  }
+  // records this query is currently using." Undefined on base collections.
+  private readonly _liveQueryTrackedSourceView?: LiveQueryTrackedSourceView
 
   /**
    * When set, collection consumers should defer processing incoming data
@@ -381,6 +381,8 @@ export class CollectionImpl<
     this._state = new CollectionStateManager(config)
     this._sync = new CollectionSyncManager(config, this.id)
     this._trackedSourceRecords = new TrackedSourceRecordsManager<TKey>(this.id)
+    this._liveQueryTrackedSourceView =
+      getBuilderFromConfig(config)?.liveQueryTrackedSourceView
 
     this.comparisonOpts = buildCompareOptionsFromConfig(config)
 

--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -4,6 +4,7 @@ import {
   CollectionRequiresSyncConfigError,
 } from '../errors'
 import { currentStateAsChanges } from './change-events'
+import { TrackedSourceRecordsManager } from './tracked-source-records.js'
 
 import { CollectionStateManager } from './state'
 import { CollectionChangesManager } from './changes'
@@ -24,8 +25,8 @@ import type {
   ChangeMessage,
   CollectionConfig,
   CollectionStatus,
+  CollectionUtils,
   CurrentStateAsChangesOptions,
-  Fn,
   InferSchemaInput,
   InferSchemaOutput,
   InsertConfig,
@@ -34,6 +35,8 @@ import type {
   SingleResult,
   StringCollationConfig,
   SubscribeChangesOptions,
+  SubscribeTrackedSourceRecordsOptions,
+  TrackedSourceRecordsChange,
   Transaction as TransactionType,
   UtilsRecord,
   WritableDeep,
@@ -58,7 +61,7 @@ export interface Collection<
   TSchema extends StandardSchemaV1 = StandardSchemaV1,
   TInsertInput extends object = T,
 > extends CollectionImpl<T, TKey, TUtils, TSchema, TInsertInput> {
-  readonly utils: TUtils
+  readonly utils: CollectionUtils<TUtils>
   readonly singleResult?: true
 }
 
@@ -255,18 +258,9 @@ export function createCollection(
     schema?: StandardSchemaV1
   },
 ): Collection<any, string | number, UtilsRecord, any, any> {
-  const collection = new CollectionImpl<any, string | number, any, any, any>(
+  return new CollectionImpl<any, string | number, any, any, any>(
     options,
-  )
-
-  // Attach utils to collection
-  if (options.utils) {
-    collection.utils = options.utils
-  } else {
-    collection.utils = {}
-  }
-
-  return collection
+  ) as unknown as Collection<any, string | number, UtilsRecord, any, any>
 }
 
 export class CollectionImpl<
@@ -279,9 +273,10 @@ export class CollectionImpl<
   public id: string
   public config: CollectionConfig<TOutput, TKey, TSchema>
 
-  // Utilities namespace
-  // This is populated by createCollection
-  public utils: Record<string, Fn> = {}
+  // Utilities namespace. Initialized in the constructor from config.utils
+  // (if provided) with tracked-source helpers attached idempotently. Reference
+  // identity on user-supplied utils objects is preserved — we mutate in place.
+  public utils: CollectionUtils<TUtils>
 
   // Managers
   private _events: CollectionEventsManager
@@ -299,6 +294,10 @@ export class CollectionImpl<
   // The core state of the collection is "public" so that is accessible in tests
   // and for debugging
   public _state: CollectionStateManager<TOutput, TKey, TSchema, TInput>
+  // Aggregated view of source-records currently being used by active live
+  // queries that depend on this collection. Public so live-query aggregators
+  // can push deltas in.
+  public _trackedSourceRecords: TrackedSourceRecordsManager<TKey>
 
   /**
    * When set, collection consumers should defer processing incoming data
@@ -354,6 +353,23 @@ export class CollectionImpl<
     this._mutations = new CollectionMutationsManager(config, this.id)
     this._state = new CollectionStateManager(config)
     this._sync = new CollectionSyncManager(config, this.id)
+    this._trackedSourceRecords = new TrackedSourceRecordsManager<TKey>(this.id)
+
+    // Attach tracked-source helpers to the provided utils in place, so user
+    // class instances keep reference identity. Idempotent: if a helper is
+    // already set (e.g. a live query installed a query-local variant via
+    // `liveQueryCollectionOptions`), it is left alone.
+    const utils = config.utils ?? {}
+    if (typeof utils.getTrackedSourceRecords !== `function`) {
+      utils.getTrackedSourceRecords = () => this._trackedSourceRecords.get()
+    }
+    if (typeof utils.subscribeTrackedSourceRecords !== `function`) {
+      utils.subscribeTrackedSourceRecords = (
+        callback: (change: TrackedSourceRecordsChange) => void,
+        options?: SubscribeTrackedSourceRecordsOptions,
+      ) => this._trackedSourceRecords.subscribe(callback, options)
+    }
+    this.utils = utils as CollectionUtils<TUtils>
 
     this.comparisonOpts = buildCompareOptionsFromConfig(config)
 

--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -269,9 +269,7 @@ export function createCollection(
     schema?: StandardSchemaV1
   },
 ): Collection<any, string | number, UtilsRecord, any, any> {
-  const collection = new CollectionImpl<any, string | number, any, any, any>(
-    options,
-  )
+  const collection = new CollectionImpl(options)
 
   // Attach utils to collection
   if (options.utils) {
@@ -280,13 +278,7 @@ export function createCollection(
     collection.utils = {}
   }
 
-  return collection as unknown as Collection<
-    any,
-    string | number,
-    UtilsRecord,
-    any,
-    any
-  >
+  return collection
 }
 
 export class CollectionImpl<

--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -25,8 +25,8 @@ import type {
   ChangeMessage,
   CollectionConfig,
   CollectionStatus,
-  CollectionUtils,
   CurrentStateAsChangesOptions,
+  Fn,
   InferSchemaInput,
   InferSchemaOutput,
   InsertConfig,
@@ -36,6 +36,7 @@ import type {
   StringCollationConfig,
   SubscribeChangesOptions,
   SubscribeTrackedSourceRecordsOptions,
+  TrackedSourceRecord,
   TrackedSourceRecordsChange,
   Transaction as TransactionType,
   UtilsRecord,
@@ -61,7 +62,7 @@ export interface Collection<
   TSchema extends StandardSchemaV1 = StandardSchemaV1,
   TInsertInput extends object = T,
 > extends CollectionImpl<T, TKey, TUtils, TSchema, TInsertInput> {
-  readonly utils: CollectionUtils<TUtils>
+  readonly utils: TUtils
   readonly singleResult?: true
 }
 
@@ -258,9 +259,24 @@ export function createCollection(
     schema?: StandardSchemaV1
   },
 ): Collection<any, string | number, UtilsRecord, any, any> {
-  return new CollectionImpl<any, string | number, any, any, any>(
+  const collection = new CollectionImpl<any, string | number, any, any, any>(
     options,
-  ) as unknown as Collection<any, string | number, UtilsRecord, any, any>
+  )
+
+  // Attach utils to collection
+  if (options.utils) {
+    collection.utils = options.utils
+  } else {
+    collection.utils = {}
+  }
+
+  return collection as unknown as Collection<
+    any,
+    string | number,
+    UtilsRecord,
+    any,
+    any
+  >
 }
 
 export class CollectionImpl<
@@ -273,10 +289,9 @@ export class CollectionImpl<
   public id: string
   public config: CollectionConfig<TOutput, TKey, TSchema>
 
-  // Utilities namespace. Initialized in the constructor from config.utils
-  // (if provided) with tracked-source helpers attached idempotently. Reference
-  // identity on user-supplied utils objects is preserved — we mutate in place.
-  public utils: CollectionUtils<TUtils>
+  // Utilities namespace
+  // This is populated by createCollection
+  public utils: Record<string, Fn> = {}
 
   // Managers
   private _events: CollectionEventsManager
@@ -298,6 +313,18 @@ export class CollectionImpl<
   // queries that depend on this collection. Public so live-query aggregators
   // can push deltas in.
   public _trackedSourceRecords: TrackedSourceRecordsManager<TKey>
+  // For live-query collections only: a live-query-local view of "source
+  // records this query is currently using." Set by the live-query path
+  // during construction; undefined on base collections. When present, the
+  // public `getTrackedSourceRecords` / `subscribeTrackedSourceRecords`
+  // methods route to this view instead of `_trackedSourceRecords`.
+  public _liveQueryTrackedSourceView?: {
+    snapshot: () => Array<TrackedSourceRecord>
+    subscribe: (
+      callback: (change: TrackedSourceRecordsChange) => void,
+      options?: SubscribeTrackedSourceRecordsOptions,
+    ) => () => void
+  }
 
   /**
    * When set, collection consumers should defer processing incoming data
@@ -354,22 +381,6 @@ export class CollectionImpl<
     this._state = new CollectionStateManager(config)
     this._sync = new CollectionSyncManager(config, this.id)
     this._trackedSourceRecords = new TrackedSourceRecordsManager<TKey>(this.id)
-
-    // Attach tracked-source helpers to the provided utils in place, so user
-    // class instances keep reference identity. Idempotent: if a helper is
-    // already set (e.g. a live query installed a query-local variant via
-    // `liveQueryCollectionOptions`), it is left alone.
-    const utils = config.utils ?? {}
-    if (typeof utils.getTrackedSourceRecords !== `function`) {
-      utils.getTrackedSourceRecords = () => this._trackedSourceRecords.get()
-    }
-    if (typeof utils.subscribeTrackedSourceRecords !== `function`) {
-      utils.subscribeTrackedSourceRecords = (
-        callback: (change: TrackedSourceRecordsChange) => void,
-        options?: SubscribeTrackedSourceRecordsOptions,
-      ) => this._trackedSourceRecords.subscribe(callback, options)
-    }
-    this.utils = utils as CollectionUtils<TUtils>
 
     this.comparisonOpts = buildCompareOptionsFromConfig(config)
 
@@ -955,6 +966,42 @@ export class CollectionImpl<
     options: SubscribeChangesOptions<TOutput, TKey> = {},
   ): CollectionSubscription {
     return this._changes.subscribeChanges(callback, options)
+  }
+
+  /**
+   * Snapshot of source records currently being tracked through this
+   * collection's data flow.
+   *
+   * On a base collection: the union of records OF this collection being
+   * used by any active live query. Each record appears once regardless
+   * of how many queries reference it.
+   *
+   * On a live query collection: the records FROM this query's source
+   * collections that the query is currently using.
+   *
+   * Both views answer "what source records are currently flowing through
+   * me," from opposite ends of the data-flow graph.
+   */
+  public getTrackedSourceRecords(): Array<TrackedSourceRecord> {
+    return (
+      this._liveQueryTrackedSourceView?.snapshot() ??
+      this._trackedSourceRecords.get()
+    )
+  }
+
+  /**
+   * Subscribe to changes in the set of source records tracked through this
+   * collection's data flow. See `getTrackedSourceRecords` for the per-
+   * collection-type semantics.
+   */
+  public subscribeTrackedSourceRecords(
+    callback: (change: TrackedSourceRecordsChange) => void,
+    options?: SubscribeTrackedSourceRecordsOptions,
+  ): () => void {
+    if (this._liveQueryTrackedSourceView) {
+      return this._liveQueryTrackedSourceView.subscribe(callback, options)
+    }
+    return this._trackedSourceRecords.subscribe(callback, options)
   }
 
   /**

--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -6,6 +6,7 @@ import {
 import { getBuilderFromConfig } from '../query/live/collection-registry.js'
 import { currentStateAsChanges } from './change-events'
 import { TrackedSourceRecordsManager } from './tracked-source-records.js'
+import { registerTrackedSourceRecordsManager } from './tracked-source-records-store.js'
 
 import { CollectionStateManager } from './state'
 import { CollectionChangesManager } from './changes'
@@ -319,9 +320,8 @@ export class CollectionImpl<
   // and for debugging
   public _state: CollectionStateManager<TOutput, TKey, TSchema, TInput>
   // Aggregated view of source-records currently being used by active live
-  // queries that depend on this collection. Public so live-query aggregators
-  // can push deltas in.
-  public _trackedSourceRecords: TrackedSourceRecordsManager<TKey>
+  // queries that depend on this collection.
+  private readonly _trackedSourceRecords: TrackedSourceRecordsManager<TKey>
   // For live-query collections only: a live-query-local view of "source
   // records this query is currently using." Undefined on base collections.
   private readonly _liveQueryTrackedSourceView?: LiveQueryTrackedSourceView
@@ -381,6 +381,7 @@ export class CollectionImpl<
     this._state = new CollectionStateManager(config)
     this._sync = new CollectionSyncManager(config, this.id)
     this._trackedSourceRecords = new TrackedSourceRecordsManager<TKey>(this.id)
+    registerTrackedSourceRecordsManager(this, this._trackedSourceRecords)
     this._liveQueryTrackedSourceView =
       getBuilderFromConfig(config)?.liveQueryTrackedSourceView
 

--- a/packages/db/src/collection/tracked-source-records-store.ts
+++ b/packages/db/src/collection/tracked-source-records-store.ts
@@ -1,0 +1,22 @@
+import type { TrackedSourceRecordsManager } from './tracked-source-records.js'
+
+const trackedSourceRecordsManagers = new WeakMap<
+  object,
+  TrackedSourceRecordsManager
+>()
+
+export function registerTrackedSourceRecordsManager(
+  collection: object,
+  manager: TrackedSourceRecordsManager,
+): void {
+  trackedSourceRecordsManagers.set(collection, manager)
+}
+
+export function applyTrackedSourceRecordDelta(
+  collection: object | undefined,
+  added: Iterable<string | number>,
+  removed: Iterable<string | number>,
+): void {
+  if (!collection) return
+  trackedSourceRecordsManagers.get(collection)?.apply(added, removed)
+}

--- a/packages/db/src/collection/tracked-source-records.ts
+++ b/packages/db/src/collection/tracked-source-records.ts
@@ -26,27 +26,43 @@ export class TrackedSourceRecordsManager<
   constructor(private readonly collectionId: string) {}
 
   apply(added: Iterable<TKey>, removed: Iterable<TKey>): void {
+    const keyDeltas = new Map<TKey, number>()
+    for (const key of added) {
+      const currentDelta = keyDeltas.get(key) ?? 0
+      keyDeltas.set(key, currentDelta + 1)
+    }
+    for (const key of removed) {
+      const currentDelta = keyDeltas.get(key) ?? 0
+      keyDeltas.set(key, currentDelta - 1)
+    }
+
     const netAdded: Array<TKey> = []
     const netRemoved: Array<TKey> = []
 
-    for (const key of added) {
+    for (const [key, delta] of keyDeltas) {
+      if (delta === 0) continue
       const existing = this.entries.get(key)
-      if (existing) {
-        existing.refCount++
-      } else {
-        this.entries.set(key, { key, refCount: 1 })
-        netAdded.push(key)
-      }
-    }
 
-    for (const key of removed) {
-      const existing = this.entries.get(key)
-      if (!existing) continue
-      if (existing.refCount === 1) {
+      if (delta > 0) {
+        if (existing) {
+          existing.refCount += delta
+        } else {
+          this.entries.set(key, { key, refCount: delta })
+          netAdded.push(key)
+        }
+        continue
+      }
+
+      if (!existing) {
+        continue
+      }
+
+      const nextRefCount = existing.refCount + delta
+      if (nextRefCount <= 0) {
         this.entries.delete(key)
         netRemoved.push(existing.key)
       } else {
-        existing.refCount--
+        existing.refCount = nextRefCount
       }
     }
 

--- a/packages/db/src/collection/tracked-source-records.ts
+++ b/packages/db/src/collection/tracked-source-records.ts
@@ -1,0 +1,82 @@
+import type {
+  SubscribeTrackedSourceRecordsOptions,
+  TrackedSourceRecord,
+  TrackedSourceRecordsChange,
+} from '../types.js'
+
+type Entry<TKey> = { key: TKey; refCount: number }
+
+/**
+ * Per-base-collection tracked source records manager.
+ *
+ * Refcounts over active live queries that depend on this collection. Each
+ * live query's aggregator pushes its net alias-level transitions here; this
+ * manager dedupes across queries and emits to subscribers only on true 0↔1
+ * transitions.
+ */
+export class TrackedSourceRecordsManager<
+  TKey extends string | number = string | number,
+> {
+  // Keys are primitives; use them directly as the Map key. No serialization.
+  private readonly entries = new Map<TKey, Entry<TKey>>()
+  private readonly listeners = new Set<
+    (change: TrackedSourceRecordsChange) => void
+  >()
+
+  constructor(private readonly collectionId: string) {}
+
+  apply(added: Iterable<TKey>, removed: Iterable<TKey>): void {
+    const netAdded: Array<TKey> = []
+    const netRemoved: Array<TKey> = []
+
+    for (const key of added) {
+      const existing = this.entries.get(key)
+      if (existing) {
+        existing.refCount++
+      } else {
+        this.entries.set(key, { key, refCount: 1 })
+        netAdded.push(key)
+      }
+    }
+
+    for (const key of removed) {
+      const existing = this.entries.get(key)
+      if (!existing) continue
+      if (existing.refCount === 1) {
+        this.entries.delete(key)
+        netRemoved.push(existing.key)
+      } else {
+        existing.refCount--
+      }
+    }
+
+    if (netAdded.length === 0 && netRemoved.length === 0) return
+    if (this.listeners.size === 0) return
+    const change: TrackedSourceRecordsChange = {
+      added: netAdded.map((key) => this.toRecord(key)),
+      removed: netRemoved.map((key) => this.toRecord(key)),
+    }
+    for (const listener of this.listeners) listener(change)
+  }
+
+  get(): Array<TrackedSourceRecord> {
+    return Array.from(this.entries.values(), ({ key }) => this.toRecord(key))
+  }
+
+  subscribe(
+    callback: (change: TrackedSourceRecordsChange) => void,
+    options?: SubscribeTrackedSourceRecordsOptions,
+  ): () => void {
+    this.listeners.add(callback)
+    if (options?.includeInitialState && this.entries.size > 0) {
+      callback({ added: this.get(), removed: [] })
+    }
+    return () => {
+      this.listeners.delete(callback)
+    }
+  }
+
+  private toRecord(key: TKey): TrackedSourceRecord {
+    return { collectionId: this.collectionId, key }
+  }
+}

--- a/packages/db/src/query/index.ts
+++ b/packages/db/src/query/index.ts
@@ -84,8 +84,13 @@ export {
 // One-shot query execution
 export { queryOnce, type QueryOnceConfig } from './query-once.js'
 
-export { type LiveQueryCollectionConfig } from './live/types.js'
-export { type LiveQueryCollectionUtils } from './live/collection-config-builder.js'
+export type {
+  SubscribeTrackedSourceRecordsOptions,
+  TrackedSourceRecord,
+  TrackedSourceRecordsChange,
+} from '../types.js'
+export type { LiveQueryCollectionConfig } from './live/types.js'
+export { type LiveQueryCollectionUtils } from './live-query-collection.js'
 
 // Predicate utilities for predicate push-down
 export {

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -214,21 +214,15 @@ export function createLiveQueryCollection<
 function bridgeToCreateCollection<TResult extends object>(
   options: CollectionConfig<TResult> & { utils: LiveQueryBuiltInUtils },
 ): Collection<TResult, string | number, LiveQueryBuiltInUtils> {
+  const builder = getBuilderFromConfig(options)
   const collection = createCollection(options as any) as unknown as Collection<
     TResult,
     string | number,
     LiveQueryBuiltInUtils
   >
 
-  const builder = getBuilderFromConfig(options)
   if (builder) {
     registerCollectionBuilder(collection, builder)
-    // Route the Collection's tracked-source-records public methods through
-    // the live-query-local view (the source-records this query is using),
-    // not the base-collection refcount manager (which is "consumers of mine").
-    // The adapter is stable across sync sessions; the underlying aggregator
-    // is replaced each session.
-    collection._liveQueryTrackedSourceView = builder.liveQueryTrackedSourceView
   }
 
   return collection

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -4,10 +4,7 @@ import {
   getBuilderFromConfig,
   registerCollectionBuilder,
 } from './live/collection-registry.js'
-import type {
-  LiveQueryBuiltInUtils,
-  LiveQueryCollectionUtils,
-} from './live/collection-config-builder.js'
+import type { LiveQueryCollectionUtils } from './live/collection-config-builder.js'
 import type { LiveQueryCollectionConfig } from './live/types.js'
 import type {
   ExtractContext,
@@ -83,7 +80,7 @@ export function liveQueryCollectionOptions<
     query: RootQueryFn<TQuery> | RootQueryBuilder<TQuery>
   },
 ): CollectionConfigForContext<TContext, TResult> & {
-  utils: LiveQueryBuiltInUtils
+  utils: LiveQueryCollectionUtils
 } {
   const collectionConfigBuilder = new CollectionConfigBuilder<
     TContext,
@@ -92,7 +89,7 @@ export function liveQueryCollectionOptions<
   return collectionConfigBuilder.getConfig() as CollectionConfigForContext<
     TContext,
     TResult
-  > & { utils: LiveQueryBuiltInUtils }
+  > & { utils: LiveQueryCollectionUtils }
 }
 
 /**

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -196,14 +196,9 @@ export function createLiveQueryCollection<
   > & { utils?: TUtils }
   const options = liveQueryCollectionOptions(config as any)
 
+  // Merge custom utils if provided, preserving the getBuilder() method for dependency tracking
   if (config.utils) {
-    // Merge the built-in live-query utils into the user's utils object in
-    // place so `liveQuery.utils === config.utils` (reference identity).
-    // createCollection will then idempotently attach the base tracked-source
-    // helpers on top — the query-local variants installed above win because
-    // the attach is a "only set if missing" check.
-    Object.assign(config.utils, options.utils)
-    options.utils = config.utils as unknown as LiveQueryBuiltInUtils
+    options.utils = { ...options.utils, ...config.utils }
   }
 
   return bridgeToCreateCollection(options) as CollectionForContext<
@@ -228,6 +223,12 @@ function bridgeToCreateCollection<TResult extends object>(
   const builder = getBuilderFromConfig(options)
   if (builder) {
     registerCollectionBuilder(collection, builder)
+    // Route the Collection's tracked-source-records public methods through
+    // the live-query-local view (the source-records this query is using),
+    // not the base-collection refcount manager (which is "consumers of mine").
+    // The adapter is stable across sync sessions; the underlying aggregator
+    // is replaced each session.
+    collection._liveQueryTrackedSourceView = builder.liveQueryTrackedSourceView
   }
 
   return collection

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -153,7 +153,7 @@ export function createLiveQueryCollection<
     utils?: TUtils
   },
 ): CollectionForContext<TContext, RootQueryResult<TContext>> & {
-  utils: LiveQueryCollectionUtils<TUtils>
+  utils: LiveQueryCollectionUtils & TUtils
 }
 
 // Implementation
@@ -168,7 +168,7 @@ export function createLiveQueryCollection<
         q: InitialQueryBuilder,
       ) => QueryBuilder<TContext> & RootObjectResultConstraint<TContext>),
 ): CollectionForContext<TContext, TResult> & {
-  utils: LiveQueryCollectionUtils<TUtils>
+  utils: LiveQueryCollectionUtils & TUtils
 } {
   // Determine if the argument is a function (query) or a config object
   if (typeof configOrQuery === `function`) {
@@ -184,7 +184,7 @@ export function createLiveQueryCollection<
     return bridgeToCreateCollection(options) as CollectionForContext<
       TContext,
       TResult
-    > & { utils: LiveQueryCollectionUtils<TUtils> }
+    > & { utils: LiveQueryCollectionUtils & TUtils }
   }
 
   // Config object case. Same overload implementation limitation as above:
@@ -204,7 +204,7 @@ export function createLiveQueryCollection<
   return bridgeToCreateCollection(options) as CollectionForContext<
     TContext,
     TResult
-  > & { utils: LiveQueryCollectionUtils<TUtils> }
+  > & { utils: LiveQueryCollectionUtils & TUtils }
 }
 
 /**

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -4,7 +4,10 @@ import {
   getBuilderFromConfig,
   registerCollectionBuilder,
 } from './live/collection-registry.js'
-import type { LiveQueryCollectionUtils } from './live/collection-config-builder.js'
+import type {
+  LiveQueryBuiltInUtils,
+  LiveQueryCollectionUtils,
+} from './live/collection-config-builder.js'
 import type { LiveQueryCollectionConfig } from './live/types.js'
 import type {
   ExtractContext,
@@ -26,6 +29,8 @@ import type {
   RootQueryFn,
   RootQueryResult,
 } from './builder/types.js'
+
+export type { LiveQueryCollectionUtils } from './live/collection-config-builder.js'
 
 type CollectionConfigForContext<
   TContext extends Context,
@@ -78,7 +83,7 @@ export function liveQueryCollectionOptions<
     query: RootQueryFn<TQuery> | RootQueryBuilder<TQuery>
   },
 ): CollectionConfigForContext<TContext, TResult> & {
-  utils: LiveQueryCollectionUtils
+  utils: LiveQueryBuiltInUtils
 } {
   const collectionConfigBuilder = new CollectionConfigBuilder<
     TContext,
@@ -87,7 +92,7 @@ export function liveQueryCollectionOptions<
   return collectionConfigBuilder.getConfig() as CollectionConfigForContext<
     TContext,
     TResult
-  > & { utils: LiveQueryCollectionUtils }
+  > & { utils: LiveQueryBuiltInUtils }
 }
 
 /**
@@ -148,7 +153,7 @@ export function createLiveQueryCollection<
     utils?: TUtils
   },
 ): CollectionForContext<TContext, RootQueryResult<TContext>> & {
-  utils: LiveQueryCollectionUtils & TUtils
+  utils: LiveQueryCollectionUtils<TUtils>
 }
 
 // Implementation
@@ -163,7 +168,7 @@ export function createLiveQueryCollection<
         q: InitialQueryBuilder,
       ) => QueryBuilder<TContext> & RootObjectResultConstraint<TContext>),
 ): CollectionForContext<TContext, TResult> & {
-  utils: LiveQueryCollectionUtils & TUtils
+  utils: LiveQueryCollectionUtils<TUtils>
 } {
   // Determine if the argument is a function (query) or a config object
   if (typeof configOrQuery === `function`) {
@@ -179,43 +184,45 @@ export function createLiveQueryCollection<
     return bridgeToCreateCollection(options) as CollectionForContext<
       TContext,
       TResult
-    > & { utils: LiveQueryCollectionUtils & TUtils }
-  } else {
-    // Config object case
-    const config = configOrQuery as LiveQueryCollectionConfig<
-      TContext,
-      TResult
-    > & { utils?: TUtils }
-    // Same overload implementation limitation as above: the config has already
-    // been validated by the public signatures, but the branch loses that precision.
-    const options = liveQueryCollectionOptions(config as any)
-
-    // Merge custom utils if provided, preserving the getBuilder() method for dependency tracking
-    if (config.utils) {
-      options.utils = { ...options.utils, ...config.utils }
-    }
-
-    return bridgeToCreateCollection(options) as CollectionForContext<
-      TContext,
-      TResult
-    > & { utils: LiveQueryCollectionUtils & TUtils }
+    > & { utils: LiveQueryCollectionUtils<TUtils> }
   }
+
+  // Config object case. Same overload implementation limitation as above:
+  // the config has already been validated by the public signatures, but the
+  // branch loses that precision.
+  const config = configOrQuery as LiveQueryCollectionConfig<
+    TContext,
+    TResult
+  > & { utils?: TUtils }
+  const options = liveQueryCollectionOptions(config as any)
+
+  if (config.utils) {
+    // Merge the built-in live-query utils into the user's utils object in
+    // place so `liveQuery.utils === config.utils` (reference identity).
+    // createCollection will then idempotently attach the base tracked-source
+    // helpers on top — the query-local variants installed above win because
+    // the attach is a "only set if missing" check.
+    Object.assign(config.utils, options.utils)
+    options.utils = config.utils as unknown as LiveQueryBuiltInUtils
+  }
+
+  return bridgeToCreateCollection(options) as CollectionForContext<
+    TContext,
+    TResult
+  > & { utils: LiveQueryCollectionUtils<TUtils> }
 }
 
 /**
  * Bridge function that handles the type compatibility between query2's TResult
  * and core collection's output type without exposing ugly type assertions to users
  */
-function bridgeToCreateCollection<
-  TResult extends object,
-  TUtils extends UtilsRecord = {},
->(
-  options: CollectionConfig<TResult> & { utils: TUtils },
-): Collection<TResult, string | number, TUtils> {
+function bridgeToCreateCollection<TResult extends object>(
+  options: CollectionConfig<TResult> & { utils: LiveQueryBuiltInUtils },
+): Collection<TResult, string | number, LiveQueryBuiltInUtils> {
   const collection = createCollection(options as any) as unknown as Collection<
     TResult,
     string | number,
-    LiveQueryCollectionUtils
+    LiveQueryBuiltInUtils
   >
 
   const builder = getBuilderFromConfig(options)
@@ -223,5 +230,5 @@ function bridgeToCreateCollection<
     registerCollectionBuilder(collection, builder)
   }
 
-  return collection as unknown as Collection<TResult, string | number, TUtils>
+  return collection
 }

--- a/packages/db/src/query/live-query-collection.ts
+++ b/packages/db/src/query/live-query-collection.ts
@@ -211,19 +211,22 @@ export function createLiveQueryCollection<
  * Bridge function that handles the type compatibility between query2's TResult
  * and core collection's output type without exposing ugly type assertions to users
  */
-function bridgeToCreateCollection<TResult extends object>(
-  options: CollectionConfig<TResult> & { utils: LiveQueryBuiltInUtils },
-): Collection<TResult, string | number, LiveQueryBuiltInUtils> {
+function bridgeToCreateCollection<
+  TResult extends object,
+  TUtils extends UtilsRecord = {},
+>(
+  options: CollectionConfig<TResult> & { utils: TUtils },
+): Collection<TResult, string | number, TUtils> {
   const builder = getBuilderFromConfig(options)
   const collection = createCollection(options as any) as unknown as Collection<
     TResult,
     string | number,
-    LiveQueryBuiltInUtils
+    LiveQueryCollectionUtils
   >
 
   if (builder) {
     registerCollectionBuilder(collection, builder)
   }
 
-  return collection
+  return collection as unknown as Collection<TResult, string | number, TUtils>
 }

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -55,7 +55,7 @@ import type {
 } from './types.js'
 import type { AllCollectionEvents } from '../../collection/events.js'
 
-export type LiveQueryBuiltInUtils = {
+export type LiveQueryCollectionUtils = UtilsRecord & {
   getRunCount: () => number
   /**
    * Sets the offset and limit of an ordered query.
@@ -72,8 +72,6 @@ export type LiveQueryBuiltInUtils = {
   getWindow: () => { offset: number; limit: number } | undefined
   [LIVE_QUERY_INTERNAL]: LiveQueryInternalUtils
 }
-
-export type LiveQueryCollectionUtils = UtilsRecord & LiveQueryBuiltInUtils
 
 type PendingGraphRun = {
   loadCallbacks: Set<() => boolean>
@@ -257,7 +255,7 @@ export class CollectionConfigBuilder<
   }
 
   getConfig(): CollectionConfigSingleRowOption<TResult> & {
-    utils: LiveQueryBuiltInUtils
+    utils: LiveQueryCollectionUtils
   } {
     return {
       id: this.id,

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -35,7 +35,6 @@ import type {
   StringCollationConfig,
   SubscribeTrackedSourceRecordsOptions,
   SyncConfig,
-  TrackedSourceCollectionUtils,
   TrackedSourceRecord,
   TrackedSourceRecordsChange,
   UtilsRecord,
@@ -56,7 +55,7 @@ import type {
 } from './types.js'
 import type { AllCollectionEvents } from '../../collection/events.js'
 
-export type LiveQueryBuiltInUtils = TrackedSourceCollectionUtils & {
+export type LiveQueryBuiltInUtils = {
   getRunCount: () => number
   /**
    * Sets the offset and limit of an ordered query.
@@ -147,12 +146,36 @@ export class CollectionConfigBuilder<
     PendingGraphRun
   >()
 
-  // Long-lived listeners for the live-query's tracked-source-records view.
-  // Survives sync sessions: we attach subscribers here, and each sync session
-  // hooks its aggregator up to forward events to this list.
+  // Long-lived listeners for the live-query-local tracked-source view.
+  // Survives sync sessions: each new session's aggregator reads this set
+  // by reference, so external subscribers don't need to re-attach across
+  // start/stop cycles.
   private readonly trackedSourceRecordListeners = new Set<
     (change: TrackedSourceRecordsChange) => void
   >()
+
+  // Adapter the live-query Collection's `_liveQueryTrackedSourceView` field
+  // points to. Routes through the current sync session's aggregator (which
+  // can come and go) but the adapter itself is stable across sessions.
+  public readonly liveQueryTrackedSourceView = {
+    snapshot: (): Array<TrackedSourceRecord> =>
+      this.currentSyncState?.trackedSourceRecordsAggregator.snapshot() ?? [],
+    subscribe: (
+      callback: (change: TrackedSourceRecordsChange) => void,
+      options?: SubscribeTrackedSourceRecordsOptions,
+    ): (() => void) => {
+      this.trackedSourceRecordListeners.add(callback)
+      if (options?.includeInitialState) {
+        const added =
+          this.currentSyncState?.trackedSourceRecordsAggregator.snapshot() ??
+          []
+        if (added.length > 0) callback({ added, removed: [] })
+      }
+      return () => {
+        this.trackedSourceRecordListeners.delete(callback)
+      }
+    },
+  }
 
   // Unsubscribe function for scheduler's onClear listener
   // Registered when sync starts, unregistered when sync stops
@@ -256,9 +279,6 @@ export class CollectionConfigBuilder<
       singleResult: this.query.singleResult,
       utils: {
         getRunCount: this.getRunCount.bind(this),
-        getTrackedSourceRecords: this.getTrackedSourceRecords.bind(this),
-        subscribeTrackedSourceRecords:
-          this.subscribeTrackedSourceRecords.bind(this),
         setWindow: this.setWindow.bind(this),
         getWindow: this.getWindow.bind(this),
         [LIVE_QUERY_INTERNAL]: {
@@ -595,34 +615,6 @@ export class CollectionConfigBuilder<
     return this.runCount
   }
 
-  /**
-   * Source records from the query's source collections that this live query
-   * is currently using. Delegates to the sync session's aggregator; returns
-   * `[]` when there's no active sync session or the live query has no
-   * subscribers.
-   */
-  getTrackedSourceRecords(): Array<TrackedSourceRecord> {
-    return (
-      this.currentSyncState?.trackedSourceRecordsAggregator.snapshot() ?? []
-    )
-  }
-
-  subscribeTrackedSourceRecords(
-    callback: (changes: TrackedSourceRecordsChange) => void,
-    options?: SubscribeTrackedSourceRecordsOptions,
-  ): () => void {
-    this.trackedSourceRecordListeners.add(callback)
-
-    if (options?.includeInitialState) {
-      const added = this.getTrackedSourceRecords()
-      if (added.length > 0) callback({ added, removed: [] })
-    }
-
-    return () => {
-      this.trackedSourceRecordListeners.delete(callback)
-    }
-  }
-
   private syncFn(config: SyncMethods<TResult>) {
     // Store reference to the live query collection for error state transitions
     this.liveQueryCollection = config.collection
@@ -630,10 +622,12 @@ export class CollectionConfigBuilder<
     this.currentSyncConfig = config
 
     // Session-scoped aggregator that dedupes tracked source records across
-    // aliases and fans net transitions out to (a) the builder's long-lived
-    // listeners and (b) each source collection's tracked-source manager.
-    // The listener set is passed by reference so the aggregator can iterate
-    // it directly and skip allocation when no one is listening.
+    // aliases (handles self-joins), propagates net transitions to each
+    // source collection's _trackedSourceRecords manager, and fans out to
+    // the builder's long-lived listener Set (so external subscribers reach
+    // the per-query view via the live-query Collection's
+    // `_liveQueryTrackedSourceView` adapter). Lives only for this sync
+    // session.
     const trackedSourceRecordsAggregator =
       new LiveQueryTrackedSourceRecordsAggregator(
         this.collections,

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -73,8 +73,7 @@ export type LiveQueryBuiltInUtils = {
   [LIVE_QUERY_INTERNAL]: LiveQueryInternalUtils
 }
 
-export type LiveQueryCollectionUtils<TUtils extends UtilsRecord = {}> = TUtils &
-  LiveQueryBuiltInUtils
+export type LiveQueryCollectionUtils = UtilsRecord & LiveQueryBuiltInUtils
 
 type PendingGraphRun = {
   loadCallbacks: Set<() => boolean>

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -167,8 +167,7 @@ export class CollectionConfigBuilder<
       this.trackedSourceRecordListeners.add(callback)
       if (options?.includeInitialState) {
         const added =
-          this.currentSyncState?.trackedSourceRecordsAggregator.snapshot() ??
-          []
+          this.currentSyncState?.trackedSourceRecordsAggregator.snapshot() ?? []
         if (added.length > 0) callback({ added, removed: [] })
       }
       return () => {

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -10,6 +10,7 @@ import { getActiveTransaction } from '../../transactions.js'
 import { CollectionSubscriber } from './collection-subscriber.js'
 import { getCollectionBuilder } from './collection-registry.js'
 import { LIVE_QUERY_INTERNAL } from './internal.js'
+import { LiveQueryTrackedSourceRecordsAggregator } from './tracked-source-records-aggregator.js'
 import {
   buildQueryFromConfig,
   extractCollectionAliases,
@@ -32,7 +33,11 @@ import type {
   KeyedStream,
   ResultStream,
   StringCollationConfig,
+  SubscribeTrackedSourceRecordsOptions,
   SyncConfig,
+  TrackedSourceCollectionUtils,
+  TrackedSourceRecord,
+  TrackedSourceRecordsChange,
   UtilsRecord,
 } from '../../types.js'
 import type { Context, GetResult } from '../builder/types.js'
@@ -51,7 +56,7 @@ import type {
 } from './types.js'
 import type { AllCollectionEvents } from '../../collection/events.js'
 
-export type LiveQueryCollectionUtils = UtilsRecord & {
+export type LiveQueryBuiltInUtils = TrackedSourceCollectionUtils & {
   getRunCount: () => number
   /**
    * Sets the offset and limit of an ordered query.
@@ -68,6 +73,9 @@ export type LiveQueryCollectionUtils = UtilsRecord & {
   getWindow: () => { offset: number; limit: number } | undefined
   [LIVE_QUERY_INTERNAL]: LiveQueryInternalUtils
 }
+
+export type LiveQueryCollectionUtils<TUtils extends UtilsRecord = {}> = TUtils &
+  LiveQueryBuiltInUtils
 
 type PendingGraphRun = {
   loadCallbacks: Set<() => boolean>
@@ -137,6 +145,13 @@ export class CollectionConfigBuilder<
   private readonly pendingGraphRuns = new Map<
     SchedulerContextId,
     PendingGraphRun
+  >()
+
+  // Long-lived listeners for the live-query's tracked-source-records view.
+  // Survives sync sessions: we attach subscribers here, and each sync session
+  // hooks its aggregator up to forward events to this list.
+  private readonly trackedSourceRecordListeners = new Set<
+    (change: TrackedSourceRecordsChange) => void
   >()
 
   // Unsubscribe function for scheduler's onClear listener
@@ -221,7 +236,7 @@ export class CollectionConfigBuilder<
   }
 
   getConfig(): CollectionConfigSingleRowOption<TResult> & {
-    utils: LiveQueryCollectionUtils
+    utils: LiveQueryBuiltInUtils
   } {
     return {
       id: this.id,
@@ -241,6 +256,9 @@ export class CollectionConfigBuilder<
       singleResult: this.query.singleResult,
       utils: {
         getRunCount: this.getRunCount.bind(this),
+        getTrackedSourceRecords: this.getTrackedSourceRecords.bind(this),
+        subscribeTrackedSourceRecords:
+          this.subscribeTrackedSourceRecords.bind(this),
         setWindow: this.setWindow.bind(this),
         getWindow: this.getWindow.bind(this),
         [LIVE_QUERY_INTERNAL]: {
@@ -577,16 +595,55 @@ export class CollectionConfigBuilder<
     return this.runCount
   }
 
+  /**
+   * Source records from the query's source collections that this live query
+   * is currently using. Delegates to the sync session's aggregator; returns
+   * `[]` when there's no active sync session or the live query has no
+   * subscribers.
+   */
+  getTrackedSourceRecords(): Array<TrackedSourceRecord> {
+    return (
+      this.currentSyncState?.trackedSourceRecordsAggregator.snapshot() ?? []
+    )
+  }
+
+  subscribeTrackedSourceRecords(
+    callback: (changes: TrackedSourceRecordsChange) => void,
+    options?: SubscribeTrackedSourceRecordsOptions,
+  ): () => void {
+    this.trackedSourceRecordListeners.add(callback)
+
+    if (options?.includeInitialState) {
+      const added = this.getTrackedSourceRecords()
+      if (added.length > 0) callback({ added, removed: [] })
+    }
+
+    return () => {
+      this.trackedSourceRecordListeners.delete(callback)
+    }
+  }
+
   private syncFn(config: SyncMethods<TResult>) {
     // Store reference to the live query collection for error state transitions
     this.liveQueryCollection = config.collection
     // Store config and syncState as instance properties for the duration of this sync session
     this.currentSyncConfig = config
 
+    // Session-scoped aggregator that dedupes tracked source records across
+    // aliases and fans net transitions out to (a) the builder's long-lived
+    // listeners and (b) each source collection's tracked-source manager.
+    // The listener set is passed by reference so the aggregator can iterate
+    // it directly and skip allocation when no one is listening.
+    const trackedSourceRecordsAggregator =
+      new LiveQueryTrackedSourceRecordsAggregator(
+        this.collections,
+        this.trackedSourceRecordListeners,
+      )
     const syncState: SyncState = {
       messagesCount: 0,
       subscribedToAllCollections: false,
       unsubscribeCallbacks: new Set<() => void>(),
+      trackedSourceRecordsAggregator,
     }
 
     // Extend the pipeline such that it applies the incoming changes to the collection
@@ -618,6 +675,17 @@ export class CollectionConfigBuilder<
       },
     )
     syncState.unsubscribeCallbacks.add(loadingSubsetUnsubscribe)
+
+    // Expose tracked source records only while the live query has active
+    // subscribers. The aggregator replays snapshot-as-added on 0→1 and
+    // snapshot-as-removed on 1→0.
+    const trackedSubscribersUnsubscribe = config.collection.on(
+      `subscribers:change`,
+      (event) => {
+        trackedSourceRecordsAggregator.setExposed(event.subscriberCount > 0)
+      },
+    )
+    syncState.unsubscribeCallbacks.add(trackedSubscribersUnsubscribe)
 
     const loadSubsetDataCallbacks = this.subscribeToAllCollections(
       config,
@@ -1067,6 +1135,18 @@ export class CollectionConfigBuilder<
         collection,
         this,
       )
+
+      // Forward net membership changes from this subscriber into the
+      // per-live-query aggregator. One subscriber per alias — self-joins
+      // emit independently and the aggregator dedupes. Direct assignment
+      // (not a listener list) since this is 1:1.
+      collectionSubscriber.onTrackedKeysChange = ({ added, removed }) => {
+        syncState.trackedSourceRecordsAggregator.apply(
+          collectionId,
+          added,
+          removed,
+        )
+      }
 
       // Subscribe to status changes for status flow
       const statusUnsubscribe = collection.on(`status:change`, (event) => {

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -621,7 +621,7 @@ export class CollectionConfigBuilder<
 
     // Session-scoped aggregator that dedupes tracked source records across
     // aliases (handles self-joins), propagates net transitions to each
-    // source collection's _trackedSourceRecords manager, and fans out to
+    // source collection's tracked-source-records manager, and fans out to
     // the builder's long-lived listener Set (so external subscribers reach
     // the per-query view via the live-query Collection). Lives only for this
     // sync session.

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -153,8 +153,8 @@ export class CollectionConfigBuilder<
     (change: TrackedSourceRecordsChange) => void
   >()
 
-  // Adapter the live-query Collection's `_liveQueryTrackedSourceView` field
-  // points to. Routes through the current sync session's aggregator (which
+  // Adapter the live-query Collection routes through for its tracked-source
+  // record view. Routes through the current sync session's aggregator (which
   // can come and go) but the adapter itself is stable across sessions.
   public readonly liveQueryTrackedSourceView = {
     snapshot: (): Array<TrackedSourceRecord> =>
@@ -623,9 +623,8 @@ export class CollectionConfigBuilder<
     // aliases (handles self-joins), propagates net transitions to each
     // source collection's _trackedSourceRecords manager, and fans out to
     // the builder's long-lived listener Set (so external subscribers reach
-    // the per-query view via the live-query Collection's
-    // `_liveQueryTrackedSourceView` adapter). Lives only for this sync
-    // session.
+    // the per-query view via the live-query Collection). Lives only for this
+    // sync session.
     const trackedSourceRecordsAggregator =
       new LiveQueryTrackedSourceRecordsAggregator(
         this.collections,

--- a/packages/db/src/query/live/collection-subscriber.ts
+++ b/packages/db/src/query/live/collection-subscriber.ts
@@ -53,6 +53,18 @@ export class CollectionSubscriber<
   private orderedLoadSubsetResult?: (result: Promise<void> | true) => void
   private pendingOrderedLoadPromise: Promise<void> | undefined
 
+  /**
+   * Callback invoked with net membership changes in this subscriber's
+   * tracked-key set (i.e. transitions of `sentToD2Keys`). The builder wires
+   * this to the per-live-query aggregator. A stable-membership ordered
+   * update — where split delete+insert leaves `sentToD2Keys` unchanged —
+   * emits nothing.
+   */
+  public onTrackedKeysChange?: (change: {
+    added: Array<string | number>
+    removed: Array<string | number>
+  }) => void
+
   constructor(
     private alias: string,
     private collectionId: string,
@@ -131,6 +143,10 @@ export class CollectionSubscriber<
       this.ensureLoadingPromise(subscription)
     }
 
+    subscription.on(`unsubscribed`, () => {
+      this.clearTrackedSourceKeys()
+    })
+
     const unsubscribe = () => {
       // If subscription has a pending promise, resolve it before unsubscribing
       const deferred = this.subscriptionLoadingPromises.get(subscription)
@@ -168,6 +184,7 @@ export class CollectionSubscriber<
       filteredChanges,
       this.collection.config.getKey,
     )
+    this.emitTrackedKeyDelta(filteredChanges)
 
     // Do not provide the callback that loads more data
     // if there's no more data to load
@@ -282,7 +299,6 @@ export class CollectionSubscriber<
       this.biggest = undefined
       this.lastLoadRequestKey = undefined
       this.pendingOrderedLoadPromise = undefined
-      this.sentToD2Keys.clear()
     })
 
     // Clean up truncate listener when subscription is unsubscribed
@@ -466,5 +482,46 @@ export class CollectionSubscriber<
     this.collectionConfigBuilder.liveQueryCollection!._sync.trackLoadPromise(
       promise,
     )
+  }
+
+  /**
+   * Derive the net transitions of `sentToD2Keys` from the post-filter change
+   * stream. `filterDuplicateInserts` has already mutated `sentToD2Keys`:
+   * every surviving insert is a 0→1 transition for its key, every surviving
+   * delete is a 1→0 transition. We count insert/delete per key so that a
+   * stable-membership ordered update (where `splitUpdates` emits
+   * `delete K + insert K`) nets to zero and emits nothing. Cost is
+   * O(|changes|) — no dependency on the size of `sentToD2Keys`.
+   */
+  private emitTrackedKeyDelta(
+    changes: ReadonlyArray<ChangeMessage<any, string | number>>,
+  ): void {
+    if (!this.onTrackedKeysChange) return
+
+    const net = new Map<string | number, number>()
+    for (const change of changes) {
+      if (change.type === `insert`) {
+        net.set(change.key, (net.get(change.key) ?? 0) + 1)
+      } else if (change.type === `delete`) {
+        net.set(change.key, (net.get(change.key) ?? 0) - 1)
+      }
+    }
+
+    const added: Array<string | number> = []
+    const removed: Array<string | number> = []
+    for (const [key, delta] of net) {
+      if (delta > 0) added.push(key)
+      else if (delta < 0) removed.push(key)
+    }
+
+    if (added.length === 0 && removed.length === 0) return
+    this.onTrackedKeysChange({ added, removed })
+  }
+
+  private clearTrackedSourceKeys() {
+    if (this.sentToD2Keys.size === 0) return
+    const removed = Array.from(this.sentToD2Keys)
+    this.sentToD2Keys.clear()
+    this.onTrackedKeysChange?.({ added: [], removed })
   }
 }

--- a/packages/db/src/query/live/collection-subscriber.ts
+++ b/packages/db/src/query/live/collection-subscriber.ts
@@ -48,6 +48,9 @@ export class CollectionSubscriber<
   // can potentially send the same item to D2 multiple times.
   private sentToD2Keys = new Set<string | number>()
 
+  // Track keys currently reported as tracked source records for this subscriber.
+  private trackedSourceKeys = new Set<string | number>()
+
   // Direct load tracking callback for ordered path (set during subscribeToOrderedChanges,
   // used by loadNextItems for subsequent requestLimitedSnapshot calls)
   private orderedLoadSubsetResult?: (result: Promise<void> | true) => void
@@ -55,9 +58,9 @@ export class CollectionSubscriber<
 
   /**
    * Callback invoked with net membership changes in this subscriber's
-   * tracked-key set (i.e. transitions of `sentToD2Keys`). The builder wires
+   * tracked-source-key set. The builder wires
    * this to the per-live-query aggregator. A stable-membership ordered
-   * update — where split delete+insert leaves `sentToD2Keys` unchanged —
+   * update where split delete+insert leaves `trackedSourceKeys` unchanged
    * emits nothing.
    */
   public onTrackedKeysChange?: (change: {
@@ -184,7 +187,7 @@ export class CollectionSubscriber<
       filteredChanges,
       this.collection.config.getKey,
     )
-    this.emitTrackedKeyDelta(filteredChanges)
+    this.emitTrackedSourceKeyDelta(filteredChanges)
 
     // Do not provide the callback that loads more data
     // if there's no more data to load
@@ -292,17 +295,15 @@ export class CollectionSubscriber<
     })
     subscriptionHolder.current = subscription
 
-    // Reset cursor-tracking state on truncate so a must-refetch doesn't use
-    // stale cursor data. We don't clear sentToD2Keys here: the truncate
-    // emits delete events for every visible key, which drain sentToD2Keys
-    // through filterDuplicateInserts, and the merged delete + re-insert
-    // batch nets to zero — clearing eagerly would cause spurious tracked-
-    // source removed/added churn for keys that stay tracked across the
-    // refetch.
+    // Reset cursor/D2 duplicate state on truncate. Tracked-source membership
+    // is tracked separately in trackedSourceKeys and updated from the buffered
+    // delete/refetch change batch, so unsubscribe cleanup still has the right
+    // membership snapshot while truncate is in flight.
     const truncateUnsubscribe = this.collection.on(`truncate`, () => {
       this.biggest = undefined
       this.lastLoadRequestKey = undefined
       this.pendingOrderedLoadPromise = undefined
+      this.sentToD2Keys.clear()
     })
 
     // Clean up truncate listener when subscription is unsubscribed
@@ -488,34 +489,37 @@ export class CollectionSubscriber<
     )
   }
 
-  /**
-   * Derive the net transitions of `sentToD2Keys` from the post-filter change
-   * stream. `filterDuplicateInserts` has already mutated `sentToD2Keys`:
-   * every surviving insert is a 0→1 transition for its key, every surviving
-   * delete is a 1→0 transition. We count insert/delete per key so that a
-   * stable-membership ordered update (where `splitUpdates` emits
-   * `delete K + insert K`) nets to zero and emits nothing. Cost is
-   * O(|changes|) — no dependency on the size of `sentToD2Keys`.
-   */
-  private emitTrackedKeyDelta(
+  private emitTrackedSourceKeyDelta(
     changes: ReadonlyArray<ChangeMessage<any, string | number>>,
   ): void {
-    if (!this.onTrackedKeysChange) return
-
-    const net = new Map<string | number, number>()
+    const wasTracked = new Map<string | number, boolean>()
     for (const change of changes) {
+      if (change.type !== `insert` && change.type !== `delete`) {
+        continue
+      }
+
+      if (!wasTracked.has(change.key)) {
+        wasTracked.set(change.key, this.trackedSourceKeys.has(change.key))
+      }
+
       if (change.type === `insert`) {
-        net.set(change.key, (net.get(change.key) ?? 0) + 1)
-      } else if (change.type === `delete`) {
-        net.set(change.key, (net.get(change.key) ?? 0) - 1)
+        this.trackedSourceKeys.add(change.key)
+      } else {
+        this.trackedSourceKeys.delete(change.key)
       }
     }
 
+    if (!this.onTrackedKeysChange) return
+
     const added: Array<string | number> = []
     const removed: Array<string | number> = []
-    for (const [key, delta] of net) {
-      if (delta > 0) added.push(key)
-      else if (delta < 0) removed.push(key)
+    for (const [key, before] of wasTracked) {
+      const after = this.trackedSourceKeys.has(key)
+      if (!before && after) {
+        added.push(key)
+      } else if (before && !after) {
+        removed.push(key)
+      }
     }
 
     if (added.length === 0 && removed.length === 0) return
@@ -523,9 +527,10 @@ export class CollectionSubscriber<
   }
 
   private clearTrackedSourceKeys() {
-    if (this.sentToD2Keys.size === 0) return
-    const removed = Array.from(this.sentToD2Keys)
+    const removed = Array.from(this.trackedSourceKeys)
+    this.trackedSourceKeys.clear()
     this.sentToD2Keys.clear()
+    if (removed.length === 0) return
     this.onTrackedKeysChange?.({ added: [], removed })
   }
 }

--- a/packages/db/src/query/live/collection-subscriber.ts
+++ b/packages/db/src/query/live/collection-subscriber.ts
@@ -292,9 +292,13 @@ export class CollectionSubscriber<
     })
     subscriptionHolder.current = subscription
 
-    // Listen for truncate events to reset cursor tracking state and sentToD2Keys
-    // This ensures that after a must-refetch/truncate, we don't use stale cursor data
-    // and allow re-inserts of previously sent keys
+    // Reset cursor-tracking state on truncate so a must-refetch doesn't use
+    // stale cursor data. We don't clear sentToD2Keys here: the truncate
+    // emits delete events for every visible key, which drain sentToD2Keys
+    // through filterDuplicateInserts, and the merged delete + re-insert
+    // batch nets to zero — clearing eagerly would cause spurious tracked-
+    // source removed/added churn for keys that stay tracked across the
+    // refetch.
     const truncateUnsubscribe = this.collection.on(`truncate`, () => {
       this.biggest = undefined
       this.lastLoadRequestKey = undefined

--- a/packages/db/src/query/live/tracked-source-records-aggregator.ts
+++ b/packages/db/src/query/live/tracked-source-records-aggregator.ts
@@ -1,3 +1,4 @@
+import { applyTrackedSourceRecordDelta } from '../../collection/tracked-source-records-store.js'
 import type { Collection } from '../../collection/index.js'
 import type {
   TrackedSourceRecord,
@@ -13,7 +14,7 @@ type Entry = { refCount: number }
  * within one query (a self-join references the same base collection under
  * multiple aliases, so the same (collectionId, key) pair can be added
  * multiple times). Net 0↔1 transitions are:
- *   1. propagated to each source collection's `_trackedSourceRecords`
+ *   1. propagated to each source collection's tracked-source-records
  *      manager (so consumers reading the base-collection view see them)
  *   2. fanned out to `listeners` (so consumers reading the per-query view
  *      via `liveQuery.subscribeTrackedSourceRecords` see them)
@@ -108,7 +109,8 @@ export class LiveQueryTrackedSourceRecordsAggregator {
     if (!this.exposed) return
     if (netAdded.length === 0 && netRemoved.length === 0) return
 
-    this.sourceCollections[collectionId]?._trackedSourceRecords.apply(
+    applyTrackedSourceRecordDelta(
+      this.sourceCollections[collectionId],
       netAdded,
       netRemoved,
     )
@@ -132,12 +134,12 @@ export class LiveQueryTrackedSourceRecordsAggregator {
       const keys = Array.from(byKey.keys())
       const collection = this.sourceCollections[collectionId]
       if (exposed) {
-        collection?._trackedSourceRecords.apply(keys, [])
+        applyTrackedSourceRecordDelta(collection, keys, [])
         if (hasListeners) {
           for (const key of keys) added.push({ collectionId, key })
         }
       } else {
-        collection?._trackedSourceRecords.apply([], keys)
+        applyTrackedSourceRecordDelta(collection, [], keys)
         if (hasListeners) {
           for (const key of keys) removed.push({ collectionId, key })
         }

--- a/packages/db/src/query/live/tracked-source-records-aggregator.ts
+++ b/packages/db/src/query/live/tracked-source-records-aggregator.ts
@@ -1,0 +1,142 @@
+import type { Collection } from '../../collection/index.js'
+import type {
+  TrackedSourceRecord,
+  TrackedSourceRecordsChange,
+} from '../../types.js'
+
+type Entry = { refCount: number }
+
+/**
+ * Per-live-query aggregator for tracked source records.
+ *
+ * Lives on a single sync session — dies with it. Refcounts over aliases
+ * within one query (a self-join references the same base collection under
+ * multiple aliases, so the same (collectionId, key) pair can be added
+ * multiple times).
+ *
+ * `exposed` gates whether net 0↔1 transitions are visible to the outside:
+ * we only propagate to source collections and fan out to listeners while
+ * the live query has subscribers. Flipping `exposed` replays the current
+ * snapshot as added/removed so downstream views stay consistent.
+ */
+export class LiveQueryTrackedSourceRecordsAggregator {
+  // Nested map avoids serializing (collectionId, key) composites. Outer key
+  // is collectionId; inner key is the source record's key (primitive).
+  private readonly entries = new Map<string, Map<string | number, Entry>>()
+  private exposed = false
+
+  /**
+   * `listeners` is the live-query's long-lived external-subscriber set
+   * owned by CollectionConfigBuilder. Held by reference so the aggregator
+   * can (a) check `size` to skip allocation when nobody is listening and
+   * (b) iterate directly without an extra callback hop.
+   */
+  constructor(
+    private readonly sourceCollections: Record<
+      string,
+      Collection<any, any, any>
+    >,
+    private readonly listeners: ReadonlySet<
+      (change: TrackedSourceRecordsChange) => void
+    >,
+  ) {}
+
+  /**
+   * Record a membership change from one `CollectionSubscriber`. All keys in
+   * a single call share the same collectionId, so propagation to the source
+   * collection's manager is a direct call — no grouping needed.
+   */
+  apply(
+    collectionId: string,
+    added: Iterable<string | number>,
+    removed: Iterable<string | number>,
+  ): void {
+    let byKey = this.entries.get(collectionId)
+    if (!byKey) {
+      byKey = new Map()
+      this.entries.set(collectionId, byKey)
+    }
+
+    const netAdded: Array<string | number> = []
+    const netRemoved: Array<string | number> = []
+
+    for (const key of added) {
+      const existing = byKey.get(key)
+      if (existing) {
+        existing.refCount++
+      } else {
+        byKey.set(key, { refCount: 1 })
+        netAdded.push(key)
+      }
+    }
+
+    for (const key of removed) {
+      const existing = byKey.get(key)
+      if (!existing) continue
+      if (existing.refCount === 1) {
+        byKey.delete(key)
+        netRemoved.push(key)
+      } else {
+        existing.refCount--
+      }
+    }
+
+    // Drop an emptied bucket so `entries.size === 0` correctly reflects
+    // "nothing tracked" for setExposed.
+    if (byKey.size === 0) {
+      this.entries.delete(collectionId)
+    }
+
+    if (!this.exposed) return
+    if (netAdded.length === 0 && netRemoved.length === 0) return
+
+    this.sourceCollections[collectionId]?._trackedSourceRecords.apply(
+      netAdded,
+      netRemoved,
+    )
+    if (this.listeners.size === 0) return
+    const change: TrackedSourceRecordsChange = {
+      added: netAdded.map((key) => ({ collectionId, key })),
+      removed: netRemoved.map((key) => ({ collectionId, key })),
+    }
+    for (const listener of this.listeners) listener(change)
+  }
+
+  setExposed(exposed: boolean): void {
+    if (this.exposed === exposed) return
+    this.exposed = exposed
+    if (this.entries.size === 0) return
+
+    const hasListeners = this.listeners.size > 0
+    const added: Array<TrackedSourceRecord> = []
+    const removed: Array<TrackedSourceRecord> = []
+    for (const [collectionId, byKey] of this.entries) {
+      const keys = Array.from(byKey.keys())
+      const collection = this.sourceCollections[collectionId]
+      if (exposed) {
+        collection?._trackedSourceRecords.apply(keys, [])
+        if (hasListeners) {
+          for (const key of keys) added.push({ collectionId, key })
+        }
+      } else {
+        collection?._trackedSourceRecords.apply([], keys)
+        if (hasListeners) {
+          for (const key of keys) removed.push({ collectionId, key })
+        }
+      }
+    }
+
+    if (!hasListeners) return
+    const change: TrackedSourceRecordsChange = { added, removed }
+    for (const listener of this.listeners) listener(change)
+  }
+
+  snapshot(): Array<TrackedSourceRecord> {
+    if (!this.exposed) return []
+    const records: Array<TrackedSourceRecord> = []
+    for (const [collectionId, byKey] of this.entries) {
+      for (const key of byKey.keys()) records.push({ collectionId, key })
+    }
+    return records
+  }
+}

--- a/packages/db/src/query/live/tracked-source-records-aggregator.ts
+++ b/packages/db/src/query/live/tracked-source-records-aggregator.ts
@@ -12,12 +12,20 @@ type Entry = { refCount: number }
  * Lives on a single sync session — dies with it. Refcounts over aliases
  * within one query (a self-join references the same base collection under
  * multiple aliases, so the same (collectionId, key) pair can be added
- * multiple times).
+ * multiple times). Net 0↔1 transitions are:
+ *   1. propagated to each source collection's `_trackedSourceRecords`
+ *      manager (so consumers reading the base-collection view see them)
+ *   2. fanned out to `listeners` (so consumers reading the per-query view
+ *      via `liveQuery.subscribeTrackedSourceRecords` see them)
  *
- * `exposed` gates whether net 0↔1 transitions are visible to the outside:
- * we only propagate to source collections and fan out to listeners while
- * the live query has subscribers. Flipping `exposed` replays the current
- * snapshot as added/removed so downstream views stay consistent.
+ * `listeners` is held by reference. The builder owns a long-lived listener
+ * Set that survives sync sessions; aggregator instances come and go but the
+ * Set persists, so external subscribers don't need to re-attach across
+ * session boundaries.
+ *
+ * `exposed` gates both propagation and listener fan-out: only emit while
+ * the live query has active subscribers. Flipping `exposed` replays the
+ * current snapshot as added/removed so downstream views stay consistent.
  */
 export class LiveQueryTrackedSourceRecordsAggregator {
   // Nested map avoids serializing (collectionId, key) composites. Outer key
@@ -25,12 +33,6 @@ export class LiveQueryTrackedSourceRecordsAggregator {
   private readonly entries = new Map<string, Map<string | number, Entry>>()
   private exposed = false
 
-  /**
-   * `listeners` is the live-query's long-lived external-subscriber set
-   * owned by CollectionConfigBuilder. Held by reference so the aggregator
-   * can (a) check `size` to skip allocation when nobody is listening and
-   * (b) iterate directly without an extra callback hop.
-   */
   constructor(
     private readonly sourceCollections: Record<
       string,

--- a/packages/db/src/query/live/tracked-source-records-aggregator.ts
+++ b/packages/db/src/query/live/tracked-source-records-aggregator.ts
@@ -53,6 +53,16 @@ export class LiveQueryTrackedSourceRecordsAggregator {
     added: Iterable<string | number>,
     removed: Iterable<string | number>,
   ): void {
+    const keyDeltas = new Map<string | number, number>()
+    for (const key of added) {
+      const currentDelta = keyDeltas.get(key) ?? 0
+      keyDeltas.set(key, currentDelta + 1)
+    }
+    for (const key of removed) {
+      const currentDelta = keyDeltas.get(key) ?? 0
+      keyDeltas.set(key, currentDelta - 1)
+    }
+
     let byKey = this.entries.get(collectionId)
     if (!byKey) {
       byKey = new Map()
@@ -62,24 +72,30 @@ export class LiveQueryTrackedSourceRecordsAggregator {
     const netAdded: Array<string | number> = []
     const netRemoved: Array<string | number> = []
 
-    for (const key of added) {
+    for (const [key, delta] of keyDeltas) {
+      if (delta === 0) continue
       const existing = byKey.get(key)
-      if (existing) {
-        existing.refCount++
-      } else {
-        byKey.set(key, { refCount: 1 })
-        netAdded.push(key)
-      }
-    }
 
-    for (const key of removed) {
-      const existing = byKey.get(key)
-      if (!existing) continue
-      if (existing.refCount === 1) {
+      if (delta > 0) {
+        if (existing) {
+          existing.refCount += delta
+        } else {
+          byKey.set(key, { refCount: delta })
+          netAdded.push(key)
+        }
+        continue
+      }
+
+      if (!existing) {
+        continue
+      }
+
+      const nextRefCount = existing.refCount + delta
+      if (nextRefCount <= 0) {
         byKey.delete(key)
         netRemoved.push(key)
       } else {
-        existing.refCount--
+        existing.refCount = nextRefCount
       }
     }
 

--- a/packages/db/src/query/live/types.ts
+++ b/packages/db/src/query/live/types.ts
@@ -10,6 +10,7 @@ import type {
   RootObjectResultConstraint,
   RootQueryResult,
 } from '../builder/types.js'
+import type { LiveQueryTrackedSourceRecordsAggregator } from './tracked-source-records-aggregator.js'
 
 export type Changes<T> = {
   deletes: number
@@ -22,6 +23,12 @@ export type SyncState = {
   messagesCount: number
   subscribedToAllCollections: boolean
   unsubscribeCallbacks: Set<() => void>
+  /**
+   * Session-scoped aggregator that dedupes tracked source records across
+   * aliases and forwards transitions to source collections. Dies with the
+   * sync session.
+   */
+  trackedSourceRecordsAggregator: LiveQueryTrackedSourceRecordsAggregator
 
   graph?: D2
   inputs?: Record<string, RootStreamBuilder<unknown>>

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -87,29 +87,6 @@ export type SubscribeTrackedSourceRecordsOptions = {
   includeInitialState?: boolean
 }
 
-export type TrackedSourceCollectionUtils = {
-  /**
-   * Gets the source records for this collection that are currently tracked by active live queries.
-   *
-   * Base collections expose the union across all active live queries that depend on them.
-   * Live query collections may override this with query-local behavior.
-   */
-  getTrackedSourceRecords: () => Array<TrackedSourceRecord>
-  /**
-   * Subscribes to tracked source record membership changes for this collection.
-   *
-   * Base collections emit aggregated membership deltas across all active live queries that
-   * depend on them. Live query collections may override this with query-local behavior.
-   */
-  subscribeTrackedSourceRecords: (
-    callback: (changes: TrackedSourceRecordsChange) => void,
-    options?: SubscribeTrackedSourceRecordsOptions,
-  ) => () => void
-}
-
-export type CollectionUtils<TUtils extends UtilsRecord = {}> = TUtils &
-  TrackedSourceCollectionUtils
-
 /**
  *
  * @remarks `update` and `insert` are both represented as `Partial<T>`, but changes for `insert` could me made more precise by inferring the schema input type. In practice, this has almost 0 real world impact so it's not worth the added type complexity.

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -73,6 +73,43 @@ export type Fn = (...args: Array<any>) => any
  */
 export type UtilsRecord = Record<string, any>
 
+export type TrackedSourceRecord = {
+  collectionId: string
+  key: string | number
+}
+
+export type TrackedSourceRecordsChange = {
+  added: Array<TrackedSourceRecord>
+  removed: Array<TrackedSourceRecord>
+}
+
+export type SubscribeTrackedSourceRecordsOptions = {
+  includeInitialState?: boolean
+}
+
+export type TrackedSourceCollectionUtils = {
+  /**
+   * Gets the source records for this collection that are currently tracked by active live queries.
+   *
+   * Base collections expose the union across all active live queries that depend on them.
+   * Live query collections may override this with query-local behavior.
+   */
+  getTrackedSourceRecords: () => Array<TrackedSourceRecord>
+  /**
+   * Subscribes to tracked source record membership changes for this collection.
+   *
+   * Base collections emit aggregated membership deltas across all active live queries that
+   * depend on them. Live query collections may override this with query-local behavior.
+   */
+  subscribeTrackedSourceRecords: (
+    callback: (changes: TrackedSourceRecordsChange) => void,
+    options?: SubscribeTrackedSourceRecordsOptions,
+  ) => () => void
+}
+
+export type CollectionUtils<TUtils extends UtilsRecord = {}> = TUtils &
+  TrackedSourceCollectionUtils
+
 /**
  *
  * @remarks `update` and `insert` are both represented as `Partial<T>`, but changes for `insert` could me made more precise by inferring the schema input type. In practice, this has almost 0 real world impact so it's not worth the added type complexity.

--- a/packages/db/tests/query/includes.test.ts
+++ b/packages/db/tests/query/includes.test.ts
@@ -2261,7 +2261,7 @@ describe(`includes subqueries`, () => {
       projectsWC.utils.write({
         type: `update`,
         value: { id: 1, name: `Alpha`, createdBy: `bob` },
-        oldValue: sampleProjectsWithCreator[0]!,
+        previousValue: sampleProjectsWithCreator[0]!,
       })
       projectsWC.utils.commit()
 
@@ -2306,7 +2306,7 @@ describe(`includes subqueries`, () => {
           title: `Feature for Alpha`,
           createdBy: `alice`,
         },
-        oldValue: sampleIssuesWithCreator[1]!,
+        previousValue: sampleIssuesWithCreator[1]!,
       })
       issuesWC.utils.commit()
 
@@ -2418,7 +2418,7 @@ describe(`includes subqueries`, () => {
       projectsWC.utils.write({
         type: `update`,
         value: { id: 1, name: `Alpha`, createdBy: `bob` },
-        oldValue: sampleProjectsWithCreator[0]!,
+        previousValue: sampleProjectsWithCreator[0]!,
       })
       projectsWC.utils.commit()
 

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -530,6 +530,117 @@ describe(`createLiveQueryCollection`, () => {
     unsubscribeBaseTracked()
   })
 
+  it(`should emit tracked source changes across truncate refetch when ordered queries track different keys`, async () => {
+    type Item = { id: number; value: string; rank: number }
+
+    let syncOps: Parameters<SyncConfig<Item>[`sync`]>[0] | undefined
+    let loadSubsetCallCount = 0
+    let loadSubsetResolver: (() => void) | undefined
+    let refetchVersion = 0
+
+    const sourceCollection = createCollection<Item>({
+      id: `tracked-truncate-different-keys-source`,
+      getKey: (item) => item.id,
+      startSync: true,
+      syncMode: `on-demand`,
+      autoIndex: `eager`,
+      defaultIndexType: BTreeIndex,
+      sync: {
+        sync: (cfg) => {
+          syncOps = cfg
+          cfg.markReady()
+
+          return {
+            loadSubset: (_options: LoadSubsetOptions) => {
+              loadSubsetCallCount++
+
+              return new Promise<void>((resolve) => {
+                loadSubsetResolver = () => {
+                  refetchVersion++
+                  const items =
+                    refetchVersion === 1
+                      ? [
+                          { id: 1, value: `initial-1`, rank: 1 },
+                          { id: 2, value: `initial-2`, rank: 2 },
+                        ]
+                      : [
+                          { id: 3, value: `refetched-3`, rank: 1 },
+                          { id: 4, value: `refetched-4`, rank: 2 },
+                        ]
+
+                  cfg.begin()
+                  items.forEach((item) => {
+                    cfg.write({ type: `insert`, value: item })
+                  })
+                  cfg.commit()
+                  resolve()
+                }
+              })
+            },
+          }
+        },
+      },
+    })
+
+    const topItems = createLiveQueryCollection((q) =>
+      q
+        .from({ item: sourceCollection })
+        .orderBy(({ item }) => item.rank, `asc`)
+        .limit(2),
+    )
+    const baseTrackingEvents: Array<TrackedSourceRecordsChange> = []
+
+    const unsubscribeBaseTracked =
+      sourceCollection.subscribeTrackedSourceRecords((changes) => {
+        baseTrackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      })
+
+    const subscription = topItems.subscribeChanges(() => {})
+    const preloadPromise = topItems.preload()
+
+    await vi.waitFor(() => expect(loadSubsetCallCount).toBe(1))
+    loadSubsetResolver?.()
+    await preloadPromise
+
+    baseTrackingEvents.length = 0
+    loadSubsetCallCount = 0
+
+    syncOps?.begin()
+    syncOps?.truncate()
+    syncOps?.commit()
+
+    await vi.waitFor(() => expect(loadSubsetCallCount).toBe(1))
+    expect(baseTrackingEvents).toEqual([])
+
+    loadSubsetResolver?.()
+    await flushPromises()
+
+    expect(baseTrackingEvents).toEqual([
+      {
+        added: [
+          { collectionId: sourceCollection.id, key: 3 },
+          { collectionId: sourceCollection.id, key: 4 },
+        ],
+        removed: [
+          { collectionId: sourceCollection.id, key: 1 },
+          { collectionId: sourceCollection.id, key: 2 },
+        ],
+      },
+    ])
+    expect(
+      sortTrackedSourceRecords(sourceCollection.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: sourceCollection.id, key: 3 },
+      { collectionId: sourceCollection.id, key: 4 },
+    ])
+
+    subscription.unsubscribe()
+    unsubscribeBaseTracked()
+  })
+
   it(`should expose live-query-local tracked source records via subscribeTrackedSourceRecords on the live query collection`, async () => {
     const activeUsers = createLiveQueryCollection((q) =>
       q

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -260,6 +260,44 @@ describe(`createLiveQueryCollection`, () => {
     unsubscribeTracked()
   })
 
+  it(`should replay tracked source records as initial state for base collections after tracking starts`, async () => {
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+    const trackingEvents: Array<{
+      added: Array<{ collectionId: string; key: string | number }>
+      removed: Array<{ collectionId: string; key: string | number }>
+    }> = []
+
+    const subscription = activeUsers.subscribeChanges(() => {})
+    await activeUsers.preload()
+
+    const unsubscribeTracked = usersCollection.subscribeTrackedSourceRecords(
+      (changes) => {
+        trackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+      { includeInitialState: true },
+    )
+
+    expect(trackingEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+
+    unsubscribeTracked()
+    subscription.unsubscribe()
+  })
+
   it(`should ref-count tracked source records on base collections across overlapping live queries`, async () => {
     const activeUsers = createLiveQueryCollection((q) =>
       q

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -434,7 +434,21 @@ describe(`createLiveQueryCollection`, () => {
       { collectionId: sourceCollection.id, key: 2 },
     ])
 
+    baseTrackingEvents.length = 0
+
     subscription.unsubscribe()
+
+    expect(baseTrackingEvents).toEqual([
+      {
+        added: [],
+        removed: [
+          { collectionId: sourceCollection.id, key: 1 },
+          { collectionId: sourceCollection.id, key: 2 },
+        ],
+      },
+    ])
+    expect(sourceCollection.getTrackedSourceRecords()).toEqual([])
+
     unsubscribeBaseTracked()
   })
 

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -123,34 +123,6 @@ describe(`createLiveQueryCollection`, () => {
     expect(activeUsers2.size).toBe(2)
   })
 
-  it(`should expose tracked source records only while the live query has active subscribers`, async () => {
-    const activeUsers = createLiveQueryCollection((q) =>
-      q
-        .from({ user: usersCollection })
-        .where(({ user }) => eq(user.active, true)),
-    )
-
-    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
-
-    await activeUsers.preload()
-
-    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
-
-    const subscription = activeUsers.subscribeChanges(() => {})
-    await activeUsers.preload()
-
-    expect(
-      sortTrackedSourceRecords(activeUsers.utils.getTrackedSourceRecords()),
-    ).toEqual([
-      { collectionId: usersCollection.id, key: 1 },
-      { collectionId: usersCollection.id, key: 2 },
-    ])
-
-    subscription.unsubscribe()
-
-    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
-  })
-
   it(`should emit tracked source record deltas for membership changes and clear when the last subscriber leaves`, async () => {
     const activeUsers = createLiveQueryCollection((q) =>
       q
@@ -162,7 +134,7 @@ describe(`createLiveQueryCollection`, () => {
       removed: Array<{ collectionId: string; key: string | number }>
     }> = []
 
-    const unsubscribeTracked = activeUsers.utils.subscribeTrackedSourceRecords(
+    const unsubscribeTracked = usersCollection.subscribeTrackedSourceRecords(
       (changes) => {
         trackingEvents.push({
           added: sortTrackedSourceRecords(changes.added),
@@ -224,7 +196,7 @@ describe(`createLiveQueryCollection`, () => {
         ],
       },
     ])
-    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
+    expect(usersCollection.getTrackedSourceRecords()).toEqual([])
 
     unsubscribeTracked()
   })
@@ -240,10 +212,10 @@ describe(`createLiveQueryCollection`, () => {
       removed: Array<{ collectionId: string; key: string | number }>
     }> = []
 
-    expect(usersCollection.utils.getTrackedSourceRecords()).toEqual([])
+    expect(usersCollection.getTrackedSourceRecords()).toEqual([])
 
     const unsubscribeTracked =
-      usersCollection.utils.subscribeTrackedSourceRecords(
+      usersCollection.subscribeTrackedSourceRecords(
         (changes) => {
           trackingEvents.push({
             added: sortTrackedSourceRecords(changes.added),
@@ -257,7 +229,7 @@ describe(`createLiveQueryCollection`, () => {
     await activeUsers.preload()
 
     expect(
-      sortTrackedSourceRecords(usersCollection.utils.getTrackedSourceRecords()),
+      sortTrackedSourceRecords(usersCollection.getTrackedSourceRecords()),
     ).toEqual([
       { collectionId: usersCollection.id, key: 1 },
       { collectionId: usersCollection.id, key: 2 },
@@ -275,7 +247,7 @@ describe(`createLiveQueryCollection`, () => {
     trackingEvents.length = 0
     subscription.unsubscribe()
 
-    expect(usersCollection.utils.getTrackedSourceRecords()).toEqual([])
+    expect(usersCollection.getTrackedSourceRecords()).toEqual([])
     expect(trackingEvents).toEqual([
       {
         added: [],
@@ -304,7 +276,7 @@ describe(`createLiveQueryCollection`, () => {
     }> = []
 
     const unsubscribeTracked =
-      usersCollection.utils.subscribeTrackedSourceRecords(
+      usersCollection.subscribeTrackedSourceRecords(
         (changes) => {
           trackingEvents.push({
             added: sortTrackedSourceRecords(changes.added),
@@ -333,7 +305,7 @@ describe(`createLiveQueryCollection`, () => {
     await bobOnlyUsers.preload()
 
     expect(
-      sortTrackedSourceRecords(usersCollection.utils.getTrackedSourceRecords()),
+      sortTrackedSourceRecords(usersCollection.getTrackedSourceRecords()),
     ).toEqual([
       { collectionId: usersCollection.id, key: 1 },
       { collectionId: usersCollection.id, key: 2 },
@@ -343,7 +315,7 @@ describe(`createLiveQueryCollection`, () => {
     activeUsersSubscription.unsubscribe()
 
     expect(
-      sortTrackedSourceRecords(usersCollection.utils.getTrackedSourceRecords()),
+      sortTrackedSourceRecords(usersCollection.getTrackedSourceRecords()),
     ).toEqual([{ collectionId: usersCollection.id, key: 2 }])
     expect(trackingEvents).toEqual([
       {
@@ -356,7 +328,7 @@ describe(`createLiveQueryCollection`, () => {
 
     bobOnlySubscription.unsubscribe()
 
-    expect(usersCollection.utils.getTrackedSourceRecords()).toEqual([])
+    expect(usersCollection.getTrackedSourceRecords()).toEqual([])
     expect(trackingEvents).toEqual([
       {
         added: [],
@@ -398,19 +370,10 @@ describe(`createLiveQueryCollection`, () => {
         .orderBy(({ item }) => item.value, `asc`)
         .limit(2),
     )
-    const liveTrackingEvents: Array<TrackedSourceRecordsChange> = []
     const baseTrackingEvents: Array<TrackedSourceRecordsChange> = []
 
-    const unsubscribeLiveTracked = topItems.utils.subscribeTrackedSourceRecords(
-      (changes) => {
-        liveTrackingEvents.push({
-          added: sortTrackedSourceRecords(changes.added),
-          removed: sortTrackedSourceRecords(changes.removed),
-        })
-      },
-    )
     const unsubscribeBaseTracked =
-      sourceCollection.utils.subscribeTrackedSourceRecords((changes) => {
+      sourceCollection.subscribeTrackedSourceRecords((changes) => {
         baseTrackingEvents.push({
           added: sortTrackedSourceRecords(changes.added),
           removed: sortTrackedSourceRecords(changes.removed),
@@ -420,14 +383,6 @@ describe(`createLiveQueryCollection`, () => {
     const subscription = topItems.subscribeChanges(() => {})
     await topItems.preload()
 
-    expect(
-      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
-    ).toEqual([
-      { collectionId: sourceCollection.id, key: 1 },
-      { collectionId: sourceCollection.id, key: 2 },
-    ])
-
-    liveTrackingEvents.length = 0
     baseTrackingEvents.length = 0
 
     sourceCollection.update(1, (draft) => {
@@ -435,25 +390,15 @@ describe(`createLiveQueryCollection`, () => {
     })
     await flushPromises()
 
-    expect(liveTrackingEvents).toEqual([])
     expect(baseTrackingEvents).toEqual([])
     expect(
-      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
-    ).toEqual([
-      { collectionId: sourceCollection.id, key: 1 },
-      { collectionId: sourceCollection.id, key: 2 },
-    ])
-    expect(
-      sortTrackedSourceRecords(
-        sourceCollection.utils.getTrackedSourceRecords(),
-      ),
+      sortTrackedSourceRecords(sourceCollection.getTrackedSourceRecords()),
     ).toEqual([
       { collectionId: sourceCollection.id, key: 1 },
       { collectionId: sourceCollection.id, key: 2 },
     ])
 
     subscription.unsubscribe()
-    unsubscribeLiveTracked()
     unsubscribeBaseTracked()
   })
 
@@ -507,19 +452,10 @@ describe(`createLiveQueryCollection`, () => {
         .orderBy(({ item }) => item.rank, `asc`)
         .limit(2),
     )
-    const liveTrackingEvents: Array<TrackedSourceRecordsChange> = []
     const baseTrackingEvents: Array<TrackedSourceRecordsChange> = []
 
-    const unsubscribeLiveTracked = topItems.utils.subscribeTrackedSourceRecords(
-      (changes) => {
-        liveTrackingEvents.push({
-          added: sortTrackedSourceRecords(changes.added),
-          removed: sortTrackedSourceRecords(changes.removed),
-        })
-      },
-    )
     const unsubscribeBaseTracked =
-      sourceCollection.utils.subscribeTrackedSourceRecords((changes) => {
+      sourceCollection.subscribeTrackedSourceRecords((changes) => {
         baseTrackingEvents.push({
           added: sortTrackedSourceRecords(changes.added),
           removed: sortTrackedSourceRecords(changes.removed),
@@ -533,14 +469,6 @@ describe(`createLiveQueryCollection`, () => {
     loadSubsetResolver?.()
     await preloadPromise
 
-    expect(
-      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
-    ).toEqual([
-      { collectionId: sourceCollection.id, key: 1 },
-      { collectionId: sourceCollection.id, key: 2 },
-    ])
-
-    liveTrackingEvents.length = 0
     baseTrackingEvents.length = 0
     loadSubsetCallCount = 0
 
@@ -549,32 +477,221 @@ describe(`createLiveQueryCollection`, () => {
     syncOps?.commit()
 
     await vi.waitFor(() => expect(loadSubsetCallCount).toBe(1))
-    expect(liveTrackingEvents).toEqual([])
     expect(baseTrackingEvents).toEqual([])
 
     loadSubsetResolver?.()
     await flushPromises()
 
-    expect(liveTrackingEvents).toEqual([])
     expect(baseTrackingEvents).toEqual([])
     expect(
-      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
-    ).toEqual([
-      { collectionId: sourceCollection.id, key: 1 },
-      { collectionId: sourceCollection.id, key: 2 },
-    ])
-    expect(
-      sortTrackedSourceRecords(
-        sourceCollection.utils.getTrackedSourceRecords(),
-      ),
+      sortTrackedSourceRecords(sourceCollection.getTrackedSourceRecords()),
     ).toEqual([
       { collectionId: sourceCollection.id, key: 1 },
       { collectionId: sourceCollection.id, key: 2 },
     ])
 
     subscription.unsubscribe()
-    unsubscribeLiveTracked()
     unsubscribeBaseTracked()
+  })
+
+  it(`should expose live-query-local tracked source records via subscribeTrackedSourceRecords on the live query collection`, async () => {
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+    const liveQueryEvents: Array<TrackedSourceRecordsChange> = []
+
+    const unsubscribeLiveQueryTracked =
+      activeUsers.subscribeTrackedSourceRecords((changes) => {
+        liveQueryEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      })
+
+    const subscription = activeUsers.subscribeChanges(() => {})
+    await activeUsers.preload()
+
+    expect(liveQueryEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+
+    liveQueryEvents.length = 0
+
+    usersCollection.insert({ id: 4, name: `David`, active: true })
+    await flushPromises()
+
+    expect(liveQueryEvents).toEqual([
+      {
+        added: [{ collectionId: usersCollection.id, key: 4 }],
+        removed: [],
+      },
+    ])
+
+    liveQueryEvents.length = 0
+
+    subscription.unsubscribe()
+
+    // 1→0 subscriber transition replays the snapshot as removed.
+    expect(liveQueryEvents).toEqual([
+      {
+        added: [],
+        removed: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+          { collectionId: usersCollection.id, key: 4 },
+        ],
+      },
+    ])
+    expect(activeUsers.getTrackedSourceRecords()).toEqual([])
+
+    unsubscribeLiveQueryTracked()
+  })
+
+  it(`should replay the live-query-local snapshot as initial state when includeInitialState is set`, async () => {
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+
+    const subscription = activeUsers.subscribeChanges(() => {})
+    await activeUsers.preload()
+
+    const liveQueryEvents: Array<TrackedSourceRecordsChange> = []
+    const unsubscribeLiveQueryTracked =
+      activeUsers.subscribeTrackedSourceRecords(
+        (changes) => {
+          liveQueryEvents.push({
+            added: sortTrackedSourceRecords(changes.added),
+            removed: sortTrackedSourceRecords(changes.removed),
+          })
+        },
+        { includeInitialState: true },
+      )
+
+    expect(liveQueryEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+
+    expect(
+      sortTrackedSourceRecords(activeUsers.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: usersCollection.id, key: 1 },
+      { collectionId: usersCollection.id, key: 2 },
+    ])
+
+    unsubscribeLiveQueryTracked()
+    subscription.unsubscribe()
+  })
+
+  it(`should scope subscribeTrackedSourceRecords differently on base collection vs live query collection`, async () => {
+    // Two live queries with disjoint where-clauses against the same base.
+    // The base view sees the union of what each query is using; each
+    // live-query view sees only its own scope. Same method, different scope.
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+    const inactiveUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, false)),
+    )
+
+    const baseEvents: Array<TrackedSourceRecordsChange> = []
+    const activeEvents: Array<TrackedSourceRecordsChange> = []
+    const inactiveEvents: Array<TrackedSourceRecordsChange> = []
+
+    const unsubscribeBase = usersCollection.subscribeTrackedSourceRecords(
+      (changes) => {
+        baseEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+    )
+    const unsubscribeActive = activeUsers.subscribeTrackedSourceRecords(
+      (changes) => {
+        activeEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+    )
+    const unsubscribeInactive = inactiveUsers.subscribeTrackedSourceRecords(
+      (changes) => {
+        inactiveEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+    )
+
+    const activeSub = activeUsers.subscribeChanges(() => {})
+    const inactiveSub = inactiveUsers.subscribeChanges(() => {})
+    await Promise.all([activeUsers.preload(), inactiveUsers.preload()])
+
+    // Live-query-local views: each query sees only its own keys.
+    expect(activeEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+    expect(inactiveEvents).toEqual([
+      {
+        added: [{ collectionId: usersCollection.id, key: 3 }],
+        removed: [],
+      },
+    ])
+
+    // Base view: union of all live queries' tracked keys.
+    expect(
+      sortTrackedSourceRecords(usersCollection.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: usersCollection.id, key: 1 },
+      { collectionId: usersCollection.id, key: 2 },
+      { collectionId: usersCollection.id, key: 3 },
+    ])
+
+    // Each live query reports only its own snapshot.
+    expect(
+      sortTrackedSourceRecords(activeUsers.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: usersCollection.id, key: 1 },
+      { collectionId: usersCollection.id, key: 2 },
+    ])
+    expect(inactiveUsers.getTrackedSourceRecords()).toEqual([
+      { collectionId: usersCollection.id, key: 3 },
+    ])
+
+    // Sanity: every base event should have arrived as one of the
+    // live-query events (the base view is the union of per-query deltas).
+    expect(baseEvents.length).toBeGreaterThan(0)
+
+    activeSub.unsubscribe()
+    inactiveSub.unsubscribe()
+    unsubscribeBase()
+    unsubscribeActive()
+    unsubscribeInactive()
   })
 
   describe(`compareOptions inheritance`, () => {

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -745,6 +745,82 @@ describe(`createLiveQueryCollection`, () => {
     subscription.unsubscribe()
   })
 
+  it(`should expose direct source records for nested live queries`, async () => {
+    const activeUsers = createLiveQueryCollection({
+      id: `tracked-active-users`,
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) => eq(user.active, true)),
+    })
+    const activeUserNames = createLiveQueryCollection({
+      id: `tracked-active-user-names`,
+      query: (q) =>
+        q.from({ activeUser: activeUsers }).select(({ activeUser }) => ({
+          id: activeUser.id,
+          name: activeUser.name,
+        })),
+    })
+    const activeUsersEvents: Array<TrackedSourceRecordsChange> = []
+    const activeUserNamesEvents: Array<TrackedSourceRecordsChange> = []
+
+    const unsubscribeActiveUsersTracked =
+      activeUsers.subscribeTrackedSourceRecords((changes) => {
+        activeUsersEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      })
+    const unsubscribeActiveUserNamesTracked =
+      activeUserNames.subscribeTrackedSourceRecords((changes) => {
+        activeUserNamesEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      })
+
+    const activeUserNamesSubscription = activeUserNames.subscribeChanges(
+      () => {},
+    )
+    await activeUserNames.preload()
+
+    expect(activeUsersEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+    expect(activeUserNamesEvents).toEqual([
+      {
+        added: [
+          { collectionId: activeUsers.id, key: 1 },
+          { collectionId: activeUsers.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+
+    expect(
+      sortTrackedSourceRecords(activeUsers.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: usersCollection.id, key: 1 },
+      { collectionId: usersCollection.id, key: 2 },
+    ])
+    expect(
+      sortTrackedSourceRecords(activeUserNames.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: activeUsers.id, key: 1 },
+      { collectionId: activeUsers.id, key: 2 },
+    ])
+
+    activeUserNamesSubscription.unsubscribe()
+    unsubscribeActiveUserNamesTracked()
+    unsubscribeActiveUsersTracked()
+  })
+
   it(`should scope subscribeTrackedSourceRecords differently on base collection vs live query collection`, async () => {
     // Two live queries with disjoint where-clauses against the same base.
     // The base view sees the union of what each query is using; each

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -214,16 +214,15 @@ describe(`createLiveQueryCollection`, () => {
 
     expect(usersCollection.getTrackedSourceRecords()).toEqual([])
 
-    const unsubscribeTracked =
-      usersCollection.subscribeTrackedSourceRecords(
-        (changes) => {
-          trackingEvents.push({
-            added: sortTrackedSourceRecords(changes.added),
-            removed: sortTrackedSourceRecords(changes.removed),
-          })
-        },
-        { includeInitialState: true },
-      )
+    const unsubscribeTracked = usersCollection.subscribeTrackedSourceRecords(
+      (changes) => {
+        trackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+      { includeInitialState: true },
+    )
 
     const subscription = activeUsers.subscribeChanges(() => {})
     await activeUsers.preload()
@@ -275,16 +274,15 @@ describe(`createLiveQueryCollection`, () => {
       removed: Array<{ collectionId: string; key: string | number }>
     }> = []
 
-    const unsubscribeTracked =
-      usersCollection.subscribeTrackedSourceRecords(
-        (changes) => {
-          trackingEvents.push({
-            added: sortTrackedSourceRecords(changes.added),
-            removed: sortTrackedSourceRecords(changes.removed),
-          })
-        },
-        { includeInitialState: true },
-      )
+    const unsubscribeTracked = usersCollection.subscribeTrackedSourceRecords(
+      (changes) => {
+        trackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+      { includeInitialState: true },
+    )
 
     const activeUsersSubscription = activeUsers.subscribeChanges(() => {})
     await activeUsers.preload()

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -19,7 +19,12 @@ import {
 import { createDeferred } from '../../src/deferred'
 import { BTreeIndex } from '../../src/indexes/btree-index'
 import { Func, Value } from '../../src/query/ir.js'
-import type { ChangeMessage, LoadSubsetOptions } from '../../src/types.js'
+import type {
+  ChangeMessage,
+  LoadSubsetOptions,
+  SyncConfig,
+  TrackedSourceRecordsChange,
+} from '../../src/types.js'
 
 // Sample user type for tests
 type User = {
@@ -43,6 +48,18 @@ function createUsersCollection() {
       initialData: sampleUsers,
     }),
   )
+}
+
+function sortTrackedSourceRecords(
+  records: ReadonlyArray<{ collectionId: string; key: string | number }>,
+) {
+  return [...records].sort((left, right) => {
+    if (left.collectionId !== right.collectionId) {
+      return left.collectionId.localeCompare(right.collectionId)
+    }
+
+    return String(left.key).localeCompare(String(right.key))
+  })
 }
 
 describe(`createLiveQueryCollection`, () => {
@@ -104,6 +121,460 @@ describe(`createLiveQueryCollection`, () => {
     expect(activeUsers2).toBeDefined()
     expect(activeUsers1.size).toBe(2)
     expect(activeUsers2.size).toBe(2)
+  })
+
+  it(`should expose tracked source records only while the live query has active subscribers`, async () => {
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+
+    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
+
+    await activeUsers.preload()
+
+    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
+
+    const subscription = activeUsers.subscribeChanges(() => {})
+    await activeUsers.preload()
+
+    expect(
+      sortTrackedSourceRecords(activeUsers.utils.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: usersCollection.id, key: 1 },
+      { collectionId: usersCollection.id, key: 2 },
+    ])
+
+    subscription.unsubscribe()
+
+    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
+  })
+
+  it(`should emit tracked source record deltas for membership changes and clear when the last subscriber leaves`, async () => {
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+    const trackingEvents: Array<{
+      added: Array<{ collectionId: string; key: string | number }>
+      removed: Array<{ collectionId: string; key: string | number }>
+    }> = []
+
+    const unsubscribeTracked = activeUsers.utils.subscribeTrackedSourceRecords(
+      (changes) => {
+        trackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+      { includeInitialState: true },
+    )
+
+    const subscription = activeUsers.subscribeChanges(() => {})
+    await activeUsers.preload()
+
+    expect(trackingEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+
+    trackingEvents.length = 0
+
+    usersCollection.insert({ id: 4, name: `David`, active: true })
+    await flushPromises()
+
+    expect(trackingEvents).toEqual([
+      {
+        added: [{ collectionId: usersCollection.id, key: 4 }],
+        removed: [],
+      },
+    ])
+
+    trackingEvents.length = 0
+
+    usersCollection.update(2, (draft) => {
+      draft.active = false
+    })
+    await flushPromises()
+
+    expect(trackingEvents).toEqual([
+      {
+        added: [],
+        removed: [{ collectionId: usersCollection.id, key: 2 }],
+      },
+    ])
+
+    trackingEvents.length = 0
+
+    subscription.unsubscribe()
+
+    expect(trackingEvents).toEqual([
+      {
+        added: [],
+        removed: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 4 },
+        ],
+      },
+    ])
+    expect(activeUsers.utils.getTrackedSourceRecords()).toEqual([])
+
+    unsubscribeTracked()
+  })
+
+  it(`should expose tracked source records on base collections while dependent live queries have active subscribers`, async () => {
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+    const trackingEvents: Array<{
+      added: Array<{ collectionId: string; key: string | number }>
+      removed: Array<{ collectionId: string; key: string | number }>
+    }> = []
+
+    expect(usersCollection.utils.getTrackedSourceRecords()).toEqual([])
+
+    const unsubscribeTracked =
+      usersCollection.utils.subscribeTrackedSourceRecords(
+        (changes) => {
+          trackingEvents.push({
+            added: sortTrackedSourceRecords(changes.added),
+            removed: sortTrackedSourceRecords(changes.removed),
+          })
+        },
+        { includeInitialState: true },
+      )
+
+    const subscription = activeUsers.subscribeChanges(() => {})
+    await activeUsers.preload()
+
+    expect(
+      sortTrackedSourceRecords(usersCollection.utils.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: usersCollection.id, key: 1 },
+      { collectionId: usersCollection.id, key: 2 },
+    ])
+    expect(trackingEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+
+    trackingEvents.length = 0
+    subscription.unsubscribe()
+
+    expect(usersCollection.utils.getTrackedSourceRecords()).toEqual([])
+    expect(trackingEvents).toEqual([
+      {
+        added: [],
+        removed: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+      },
+    ])
+
+    unsubscribeTracked()
+  })
+
+  it(`should ref-count tracked source records on base collections across overlapping live queries`, async () => {
+    const activeUsers = createLiveQueryCollection((q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true)),
+    )
+    const bobOnlyUsers = createLiveQueryCollection((q) =>
+      q.from({ user: usersCollection }).where(({ user }) => eq(user.id, 2)),
+    )
+    const trackingEvents: Array<{
+      added: Array<{ collectionId: string; key: string | number }>
+      removed: Array<{ collectionId: string; key: string | number }>
+    }> = []
+
+    const unsubscribeTracked =
+      usersCollection.utils.subscribeTrackedSourceRecords(
+        (changes) => {
+          trackingEvents.push({
+            added: sortTrackedSourceRecords(changes.added),
+            removed: sortTrackedSourceRecords(changes.removed),
+          })
+        },
+        { includeInitialState: true },
+      )
+
+    const activeUsersSubscription = activeUsers.subscribeChanges(() => {})
+    await activeUsers.preload()
+
+    expect(trackingEvents).toEqual([
+      {
+        added: [
+          { collectionId: usersCollection.id, key: 1 },
+          { collectionId: usersCollection.id, key: 2 },
+        ],
+        removed: [],
+      },
+    ])
+
+    trackingEvents.length = 0
+
+    const bobOnlySubscription = bobOnlyUsers.subscribeChanges(() => {})
+    await bobOnlyUsers.preload()
+
+    expect(
+      sortTrackedSourceRecords(usersCollection.utils.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: usersCollection.id, key: 1 },
+      { collectionId: usersCollection.id, key: 2 },
+    ])
+    expect(trackingEvents).toEqual([])
+
+    activeUsersSubscription.unsubscribe()
+
+    expect(
+      sortTrackedSourceRecords(usersCollection.utils.getTrackedSourceRecords()),
+    ).toEqual([{ collectionId: usersCollection.id, key: 2 }])
+    expect(trackingEvents).toEqual([
+      {
+        added: [],
+        removed: [{ collectionId: usersCollection.id, key: 1 }],
+      },
+    ])
+
+    trackingEvents.length = 0
+
+    bobOnlySubscription.unsubscribe()
+
+    expect(usersCollection.utils.getTrackedSourceRecords()).toEqual([])
+    expect(trackingEvents).toEqual([
+      {
+        added: [],
+        removed: [{ collectionId: usersCollection.id, key: 2 }],
+      },
+    ])
+
+    unsubscribeTracked()
+  })
+
+  it(`should not emit tracked source churn for ordered updates that keep the same keys in range`, async () => {
+    type Item = { id: number; value: number }
+    const sourceCollection = createCollection<Item>({
+      id: `tracked-ordered-update-source`,
+      getKey: (item) => item.id,
+      startSync: true,
+      autoIndex: `eager`,
+      defaultIndexType: BTreeIndex,
+      sync: {
+        sync: ({ begin, write, commit, markReady }) => {
+          begin()
+          ;[
+            { id: 1, value: 1 },
+            { id: 2, value: 2 },
+            { id: 3, value: 3 },
+          ].forEach((item) => {
+            write({ type: `insert`, value: item })
+          })
+          commit()
+          markReady()
+        },
+      },
+      onUpdate: async () => {},
+    })
+
+    const topItems = createLiveQueryCollection((q) =>
+      q
+        .from({ item: sourceCollection })
+        .orderBy(({ item }) => item.value, `asc`)
+        .limit(2),
+    )
+    const liveTrackingEvents: Array<TrackedSourceRecordsChange> = []
+    const baseTrackingEvents: Array<TrackedSourceRecordsChange> = []
+
+    const unsubscribeLiveTracked = topItems.utils.subscribeTrackedSourceRecords(
+      (changes) => {
+        liveTrackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+    )
+    const unsubscribeBaseTracked =
+      sourceCollection.utils.subscribeTrackedSourceRecords((changes) => {
+        baseTrackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      })
+
+    const subscription = topItems.subscribeChanges(() => {})
+    await topItems.preload()
+
+    expect(
+      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: sourceCollection.id, key: 1 },
+      { collectionId: sourceCollection.id, key: 2 },
+    ])
+
+    liveTrackingEvents.length = 0
+    baseTrackingEvents.length = 0
+
+    sourceCollection.update(1, (draft) => {
+      draft.value = 1.5
+    })
+    await flushPromises()
+
+    expect(liveTrackingEvents).toEqual([])
+    expect(baseTrackingEvents).toEqual([])
+    expect(
+      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: sourceCollection.id, key: 1 },
+      { collectionId: sourceCollection.id, key: 2 },
+    ])
+    expect(
+      sortTrackedSourceRecords(
+        sourceCollection.utils.getTrackedSourceRecords(),
+      ),
+    ).toEqual([
+      { collectionId: sourceCollection.id, key: 1 },
+      { collectionId: sourceCollection.id, key: 2 },
+    ])
+
+    subscription.unsubscribe()
+    unsubscribeLiveTracked()
+    unsubscribeBaseTracked()
+  })
+
+  it(`should not emit tracked source churn across truncate refetch when ordered queries keep tracking the same keys`, async () => {
+    type Item = { id: number; value: string; rank: number }
+
+    let syncOps: Parameters<SyncConfig<Item>[`sync`]>[0] | undefined
+    let loadSubsetCallCount = 0
+    let loadSubsetResolver: (() => void) | undefined
+
+    const sourceCollection = createCollection<Item>({
+      id: `tracked-truncate-source`,
+      getKey: (item) => item.id,
+      startSync: true,
+      syncMode: `on-demand`,
+      autoIndex: `eager`,
+      defaultIndexType: BTreeIndex,
+      sync: {
+        sync: (cfg) => {
+          syncOps = cfg
+          cfg.markReady()
+
+          return {
+            loadSubset: (_options: LoadSubsetOptions) => {
+              loadSubsetCallCount++
+
+              return new Promise<void>((resolve) => {
+                loadSubsetResolver = () => {
+                  cfg.begin()
+                  cfg.write({
+                    type: `insert`,
+                    value: { id: 1, value: `refetched-1`, rank: 1 },
+                  })
+                  cfg.write({
+                    type: `insert`,
+                    value: { id: 2, value: `refetched-2`, rank: 2 },
+                  })
+                  cfg.commit()
+                  resolve()
+                }
+              })
+            },
+          }
+        },
+      },
+    })
+
+    const topItems = createLiveQueryCollection((q) =>
+      q
+        .from({ item: sourceCollection })
+        .orderBy(({ item }) => item.rank, `asc`)
+        .limit(2),
+    )
+    const liveTrackingEvents: Array<TrackedSourceRecordsChange> = []
+    const baseTrackingEvents: Array<TrackedSourceRecordsChange> = []
+
+    const unsubscribeLiveTracked = topItems.utils.subscribeTrackedSourceRecords(
+      (changes) => {
+        liveTrackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      },
+    )
+    const unsubscribeBaseTracked =
+      sourceCollection.utils.subscribeTrackedSourceRecords((changes) => {
+        baseTrackingEvents.push({
+          added: sortTrackedSourceRecords(changes.added),
+          removed: sortTrackedSourceRecords(changes.removed),
+        })
+      })
+
+    const subscription = topItems.subscribeChanges(() => {})
+    const preloadPromise = topItems.preload()
+
+    await vi.waitFor(() => expect(loadSubsetCallCount).toBe(1))
+    loadSubsetResolver?.()
+    await preloadPromise
+
+    expect(
+      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: sourceCollection.id, key: 1 },
+      { collectionId: sourceCollection.id, key: 2 },
+    ])
+
+    liveTrackingEvents.length = 0
+    baseTrackingEvents.length = 0
+    loadSubsetCallCount = 0
+
+    syncOps?.begin()
+    syncOps?.truncate()
+    syncOps?.commit()
+
+    await vi.waitFor(() => expect(loadSubsetCallCount).toBe(1))
+    expect(liveTrackingEvents).toEqual([])
+    expect(baseTrackingEvents).toEqual([])
+
+    loadSubsetResolver?.()
+    await flushPromises()
+
+    expect(liveTrackingEvents).toEqual([])
+    expect(baseTrackingEvents).toEqual([])
+    expect(
+      sortTrackedSourceRecords(topItems.utils.getTrackedSourceRecords()),
+    ).toEqual([
+      { collectionId: sourceCollection.id, key: 1 },
+      { collectionId: sourceCollection.id, key: 2 },
+    ])
+    expect(
+      sortTrackedSourceRecords(
+        sourceCollection.utils.getTrackedSourceRecords(),
+      ),
+    ).toEqual([
+      { collectionId: sourceCollection.id, key: 1 },
+      { collectionId: sourceCollection.id, key: 2 },
+    ])
+
+    subscription.unsubscribe()
+    unsubscribeLiveTracked()
+    unsubscribeBaseTracked()
   })
 
   describe(`compareOptions inheritance`, () => {

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -540,7 +540,21 @@ describe(`createLiveQueryCollection`, () => {
       { collectionId: sourceCollection.id, key: 2 },
     ])
 
+    baseTrackingEvents.length = 0
+
     subscription.unsubscribe()
+
+    expect(baseTrackingEvents).toEqual([
+      {
+        added: [],
+        removed: [
+          { collectionId: sourceCollection.id, key: 1 },
+          { collectionId: sourceCollection.id, key: 2 },
+        ],
+      },
+    ])
+    expect(sourceCollection.getTrackedSourceRecords()).toEqual([])
+
     unsubscribeBaseTracked()
   })
 

--- a/packages/db/tests/tracked-source-records.test.ts
+++ b/packages/db/tests/tracked-source-records.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { createCollection } from '../src/collection/index.js'
+import { TrackedSourceRecordsManager } from '../src/collection/tracked-source-records.js'
+import { LiveQueryTrackedSourceRecordsAggregator } from '../src/query/live/tracked-source-records-aggregator.js'
+import { mockSyncCollectionOptions } from './utils.js'
+import type { TrackedSourceRecordsChange } from '../src/types.js'
+
+type User = {
+  id: number
+  name: string
+}
+
+function createUsersCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<User>({
+      id: `users`,
+      getKey: (user) => user.id,
+      initialData: [],
+    }),
+  )
+}
+
+describe(`TrackedSourceRecordsManager`, () => {
+  it(`nets overlapping additions and removals before applying them`, () => {
+    const manager = new TrackedSourceRecordsManager<number>(`users`)
+    const changes: Array<TrackedSourceRecordsChange> = []
+    manager.subscribe((change) => changes.push(change))
+
+    manager.apply([1], [1])
+
+    expect(manager.get()).toEqual([])
+    expect(changes).toEqual([])
+
+    manager.apply([1], [])
+    changes.length = 0
+
+    manager.apply([1], [1])
+
+    expect(manager.get()).toEqual([{ collectionId: `users`, key: 1 }])
+    expect(changes).toEqual([])
+  })
+})
+
+describe(`LiveQueryTrackedSourceRecordsAggregator`, () => {
+  it(`nets overlapping additions and removals before notifying listeners`, () => {
+    const usersCollection = createUsersCollection()
+    const sourceChanges: Array<TrackedSourceRecordsChange> = []
+    const liveQueryChanges: Array<TrackedSourceRecordsChange> = []
+    const listeners = new Set<(change: TrackedSourceRecordsChange) => void>([
+      (change) => liveQueryChanges.push(change),
+    ])
+    const aggregator = new LiveQueryTrackedSourceRecordsAggregator(
+      { [usersCollection.id]: usersCollection },
+      listeners,
+    )
+
+    usersCollection.subscribeTrackedSourceRecords((change) =>
+      sourceChanges.push(change),
+    )
+    aggregator.setExposed(true)
+
+    aggregator.apply(usersCollection.id, [1], [1])
+
+    expect(aggregator.snapshot()).toEqual([])
+    expect(usersCollection.getTrackedSourceRecords()).toEqual([])
+    expect(liveQueryChanges).toEqual([])
+    expect(sourceChanges).toEqual([])
+  })
+})

--- a/packages/db/tests/utility-exposure.test.ts
+++ b/packages/db/tests/utility-exposure.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, test } from 'vitest'
 import { createCollection } from '../src/collection/index.js'
+import { createLiveQueryCollection } from '../src/query/index.js'
 import type { CollectionConfig, SyncConfig, UtilsRecord } from '../src/types'
 
 // Mock utility functions for testing
 interface TestUtils extends UtilsRecord {
   testFn: (input: string) => string
   asyncFn: (input: number) => Promise<number>
+}
+
+class GetterBackedUtils {
+  constructor(private readonly active: boolean) {}
+
+  public get isActive() {
+    return this.active
+  }
+
+  public describe() {
+    return this.active ? `active` : `inactive`
+  }
 }
 
 describe(`Utility exposure pattern`, () => {
@@ -55,9 +68,12 @@ describe(`Utility exposure pattern`, () => {
       sync: mockSync,
     })
 
-    // Verify .utils exists but is empty
+    // Collections always expose tracked-source helpers, even without custom utils
     expect(collection.utils).toBeDefined()
-    expect(Object.keys(collection.utils).length).toBe(0)
+    expect(Object.keys(collection.utils).sort()).toEqual([
+      `getTrackedSourceRecords`,
+      `subscribeTrackedSourceRecords`,
+    ])
   })
 
   test(`preserves type information for collection data`, async () => {
@@ -98,5 +114,44 @@ describe(`Utility exposure pattern`, () => {
     // TypeScript knows the collection is for TestItem type
     // This is a compile-time check that we can't verify at runtime directly
     // But we've verified the utilities work
+  })
+
+  test(`preserves getter-backed utility objects when attaching tracked source helpers`, () => {
+    const utils = new GetterBackedUtils(true)
+    const collection = createCollection({
+      getKey: (item: { id: string }) => item.id,
+      sync: {
+        sync: () => {},
+      },
+      utils,
+    })
+
+    expect(collection.utils).toBe(utils)
+    expect(collection.utils.isActive).toBe(true)
+    expect(collection.utils.describe()).toBe(`active`)
+    expect(collection.utils.getTrackedSourceRecords).toBeDefined()
+    expect(collection.utils.subscribeTrackedSourceRecords).toBeDefined()
+  })
+
+  test(`preserves custom live query utils while attaching live query helpers`, () => {
+    const source = createCollection({
+      getKey: (item: { id: string }) => item.id,
+      sync: {
+        sync: () => {},
+      },
+    })
+    const utils = {
+      describeMode: () => `search`,
+    }
+    const liveQuery = createLiveQueryCollection({
+      query: (q) => q.from({ source }),
+      utils,
+    })
+
+    expect(liveQuery.utils).toBe(utils)
+    expect(liveQuery.utils.describeMode()).toBe(`search`)
+    expect(liveQuery.utils.getRunCount).toBeDefined()
+    expect(liveQuery.utils.getTrackedSourceRecords).toBeDefined()
+    expect(liveQuery.utils.subscribeTrackedSourceRecords).toBeDefined()
   })
 })

--- a/packages/db/tests/utility-exposure.test.ts
+++ b/packages/db/tests/utility-exposure.test.ts
@@ -9,18 +9,6 @@ interface TestUtils extends UtilsRecord {
   asyncFn: (input: number) => Promise<number>
 }
 
-class GetterBackedUtils {
-  constructor(private readonly active: boolean) {}
-
-  public get isActive() {
-    return this.active
-  }
-
-  public describe() {
-    return this.active ? `active` : `inactive`
-  }
-}
-
 describe(`Utility exposure pattern`, () => {
   test(`exposes utilities at top level and under .utils namespace`, () => {
     // Create mock utility functions
@@ -68,12 +56,9 @@ describe(`Utility exposure pattern`, () => {
       sync: mockSync,
     })
 
-    // Collections always expose tracked-source helpers, even without custom utils
+    // Verify .utils exists but is empty
     expect(collection.utils).toBeDefined()
-    expect(Object.keys(collection.utils).sort()).toEqual([
-      `getTrackedSourceRecords`,
-      `subscribeTrackedSourceRecords`,
-    ])
+    expect(Object.keys(collection.utils).length).toBe(0)
   })
 
   test(`preserves type information for collection data`, async () => {
@@ -116,42 +101,23 @@ describe(`Utility exposure pattern`, () => {
     // But we've verified the utilities work
   })
 
-  test(`preserves getter-backed utility objects when attaching tracked source helpers`, () => {
-    const utils = new GetterBackedUtils(true)
-    const collection = createCollection({
-      getKey: (item: { id: string }) => item.id,
-      sync: {
-        sync: () => {},
-      },
-      utils,
-    })
-
-    expect(collection.utils).toBe(utils)
-    expect(collection.utils.isActive).toBe(true)
-    expect(collection.utils.describe()).toBe(`active`)
-    expect(collection.utils.getTrackedSourceRecords).toBeDefined()
-    expect(collection.utils.subscribeTrackedSourceRecords).toBeDefined()
-  })
-
-  test(`preserves custom live query utils while attaching live query helpers`, () => {
+  test(`user-supplied utils override built-in helpers on name collision`, () => {
     const source = createCollection({
       getKey: (item: { id: string }) => item.id,
       sync: {
         sync: () => {},
       },
     })
-    const utils = {
-      describeMode: () => `search`,
-    }
+
+    // User deliberately overrides getRunCount; their version should win.
+    const userGetRunCount = () => 42
+    const utils = { getRunCount: userGetRunCount }
     const liveQuery = createLiveQueryCollection({
       query: (q) => q.from({ source }),
       utils,
     })
 
-    expect(liveQuery.utils).toBe(utils)
-    expect(liveQuery.utils.describeMode()).toBe(`search`)
-    expect(liveQuery.utils.getRunCount).toBeDefined()
-    expect(liveQuery.utils.getTrackedSourceRecords).toBeDefined()
-    expect(liveQuery.utils.subscribeTrackedSourceRecords).toBeDefined()
+    expect(liveQuery.utils.getRunCount).toBe(userGetRunCount)
+    expect(liveQuery.utils.getRunCount()).toBe(42)
   })
 })


### PR DESCRIPTION
## Description

Two new APIs let application code observe which **source records** a live query is consuming, so callers can subscribe/unsubscribe at an underlying sync layer in lockstep with query usage.

### What's added

```ts
type TrackedSourceRecord = {
  collectionId: string
  key: string | number
}

type TrackedSourceRecordsChange = {
  added: Array<TrackedSourceRecord>
  removed: Array<TrackedSourceRecord>
}

type SubscribeTrackedSourceRecordsOptions = {
  includeInitialState?: boolean
}
```

Methods on every `Collection`:

```ts
collection.getTrackedSourceRecords(): Array<TrackedSourceRecord>
collection.subscribeTrackedSourceRecords(
  callback: (change: TrackedSourceRecordsChange) => void,
  options?: SubscribeTrackedSourceRecordsOptions,
): () => void
```

Same method, polymorphic dispatch:

- On a **live-query collection** → "records this query reads from its sources." Refcounted across the query's aliases (self-joins are deduped). Visible only while the query has active subscribers.
- On any **other collection** (base, electric, query-db, localStorage, sqlite-persisted, etc.) → "records of mine consumed by some live query." Refcounted across all live queries that depend on this collection. If two queries use key `K`, the base view sees `K` once; only when the last query stops using `K` does it emit `removed`.

### Why

Useful for custom sync layers that subscribe/unsubscribe at the record level. They need to subscribe when a record becomes actively used by queries and unsubscribe when the last query stops using it. Base-collection residency is too broad — it covers everything sync'd, whether queries want it or not. These APIs provide the narrower "actively used by live queries" signal.

### How an app developer uses this

**On a single live query** (per-query scope):

```tsx
function ActiveUsersList() {
  const activeUsers = useMemo(
    () =>
      createLiveQueryCollection((q) =>
        q.from({ user: usersCollection }).where(({ user }) => eq(user.active, true)),
      ),
    [],
  )

  // The hook drives sync (it calls subscribeChanges internally), so the
  // tracked-source listener will start receiving deltas as the live query
  // mounts and reads from its sources.
  useEffect(() => {
    return activeUsers.subscribeTrackedSourceRecords(({ added, removed }) => {
      for (const r of added) mySyncLayer.subscribe(r.collectionId, r.key)
      for (const r of removed) mySyncLayer.unsubscribe(r.collectionId, r.key)
    })
  }, [activeUsers])

  const { data } = useLiveQuery(activeUsers)
  return <ul>{data?.map((u) => <li key={u.id}>{u.name}</li>)}</ul>
}
```

**On a base collection** (union scope across all live queries):

```ts
const unsubscribe = usersCollection.subscribeTrackedSourceRecords(
  ({ added, removed }) => {
    // Fires only when the first query starts tracking a key (0→1),
    // or the last one stops (1→0).
    for (const r of added) mySyncLayer.subscribe(r.collectionId, r.key)
    for (const r of removed) mySyncLayer.unsubscribe(r.collectionId, r.key)
  },
  { includeInitialState: true },
)
```

The same pattern works for any collection that uses `CollectionImpl` under the hood — electric, query-db, localStorage, sqlite-persisted, etc. The feature is sync-backend-agnostic because tracking happens in the live-query pipeline (the IVM), not in the sync config.

**Behaviour notes:**

- `includeInitialState: true` replays the current snapshot as `added` on subscribe (if any records are currently tracked and exposed).
- `0 → 1+` subscribers (a live query gains its first consumer): the per-query view emits `added` for every key the query is reading; the base view emits `added` for any key reaching refcount 1.
- `1+ → 0` subscribers (last consumer leaves): the per-query view emits `removed` for every key it was reading; the base view emits `removed` for any key whose refcount drops to 0.
- Stable-membership updates (an ordered query updates a row that stays in range) emit **nothing**.
- `must-refetch` / truncate-refetch cycles that end with the same keys still tracked emit **nothing**.

### How this works internally

Three concentric scopes, each with a real owner.

**Scope 1 — alias-level: `CollectionSubscriber.sentToD2Keys`**

For every alias in a live query (e.g. `{ user: usersCollection }`), one `CollectionSubscriber` is created. It already maintained `sentToD2Keys: Set<string | number>` to deduplicate inserts into the D2 dataflow graph — the authoritative per-alias record of "keys this alias is feeding the query."

This PR turns that set's mutations into events. On each `sendChangesToPipeline`, after `filterDuplicateInserts` has mutated the set, the subscriber derives a net delta from the filtered change stream itself — every surviving insert is a 0→1 transition for its key, every surviving delete is a 1→0 transition. Insert/delete pairs for the same key within one batch (emitted by `splitUpdates` for stable-membership ordered updates) net to zero. Cost is `O(|batch|)` — no dependency on the size of `sentToD2Keys`. The result is emitted via a single public callback property assigned 1:1 by the builder.

**Scope 2 — per-live-query: `LiveQueryTrackedSourceRecordsAggregator`**

One aggregator per sync session. Owns a nested refcount map:

```ts
private readonly entries = new Map<string, Map<string | number, { refCount: number }>>()
private exposed = false
```

Outer key is `collectionId`, inner key is the source record's primitive `key` — no composite serialization. The refcount is over aliases: a self-join like `{ employee: emp, manager: emp }` has two subscribers emitting independently, and the aggregator dedupes. `apply(collectionId, added, removed)`:

1. Refcount the adds/removes against the per-collection inner map. 0→1 transitions go into `netAdded`, 1→0 into `netRemoved`. Empty inner buckets are pruned.
2. If `exposed`: propagate net transitions to `sourceCollections[collectionId]._trackedSourceRecords.apply(...)` (scope 3), and fan out directly to the live-query-local listener set (held by reference from the builder).

`setExposed(boolean)` is the lifecycle gate. `false → true` replays the snapshot as `added`. `true → false` replays as `removed`. The builder wires this to `subscribers:change`:

```ts
config.collection.on('subscribers:change', (event) => {
  trackedSourceRecordsAggregator.setExposed(event.subscriberCount > 0)
})
```

**Scope 3 — per-base-collection: `TrackedSourceRecordsManager`**

Each `CollectionImpl` owns one `_trackedSourceRecords: TrackedSourceRecordsManager<TKey>` field. Refcount map is `Map<TKey, { key, refCount }>` over live queries. On 0↔1 transitions, listeners registered via `subscribe` see `added` / `removed`. Record-object allocation is skipped when the listener set is empty.

**Polymorphic dispatch on `Collection.subscribeTrackedSourceRecords`**

`CollectionImpl` has an optional `_liveQueryTrackedSourceView` field. It's `undefined` on every collection except live queries; `bridgeToCreateCollection` sets it at construction time to a stable adapter on `CollectionConfigBuilder` (which routes through whatever aggregator the current sync session has). The public methods on `CollectionImpl`:

```ts
public getTrackedSourceRecords(): Array<TrackedSourceRecord> {
  return this._liveQueryTrackedSourceView?.snapshot()
    ?? this._trackedSourceRecords.get()
}

public subscribeTrackedSourceRecords(callback, options?): () => void {
  if (this._liveQueryTrackedSourceView) {
    return this._liveQueryTrackedSourceView.subscribe(callback, options)
  }
  return this._trackedSourceRecords.subscribe(callback, options)
}
```

So callers don't need to branch on collection type. Same method name, scope determined by what kind of collection you're holding.

The live-query listener set lives on `CollectionConfigBuilder` (long-lived). The aggregator holds it by reference. External subscribers attached before the first sync session, or across session start/stop cycles, do not need to re-attach.

**End-to-end flow:**

```
CollectionSubscriber
  sentToD2Keys mutates (filterDuplicateInserts)
    count inserts/deletes in filtered batch → net delta
    → onTrackedKeysChange({ added, removed })            [direct callback, 1:1]
      ↓
LiveQueryTrackedSourceRecordsAggregator
  apply(collectionId, added, removed)
    refcount per (collectionId → key) in nested map
    if exposed:
      → sourceCollections[id]._trackedSourceRecords.apply(netAdded, netRemoved)
      if liveQuery listeners.size > 0:
        for listener of listeners: listener({ added: records, removed: records })
                              ↑
                              liveQuery.subscribeTrackedSourceRecords
                              (held by reference; survives sync sessions)
        ↓
TrackedSourceRecordsManager (on each source collection)
  apply(netAdded, netRemoved)
    refcount per key
    if 0↔1 transitions AND listeners.size > 0:
      for listener of listeners: listener({ added: records, removed: records })
                              ↑
                              baseCollection.subscribeTrackedSourceRecords
```

### Performance characteristics

All hot paths are bounded by batch size, with no dependency on the total tracked-set size:

- **Scope 1 delta:** `O(|batch|)` via insert/delete count netting on the filtered stream. No copy of `sentToD2Keys`.
- **Scope 2 refcount:** `O(|batch|)` using a nested `Map<collectionId, Map<key, Entry>>` — primitive keys, no serialization.
- **Scope 3 refcount:** `O(|batch|)` using `Map<TKey, Entry>` — primitive keys, no serialization.
- **Record-object allocation at scopes 2 and 3** is gated on a non-empty listener set. Pure-internal batches (refcount updates with no app-code subscribers) skip the object materialization entirely.

### Why not just expose `CollectionSubscription.subscribedKeys`?

Two reasons:

1. `sentToD2Keys` is per-alias. A live query with multiple aliases on the same collection (self-joins) would require consumers to dedupe. Scope 2 exists precisely to handle that.
2. `subscribeChanges` buffers truncate/refetch to hide transient empty states. `subscribeTrackedSourceRecords` needs to emit *net* membership. Deriving one from the other would mix concerns.

Three scopes with clear ownership match the three semantic views application code may want.

### What's not changed

The feature is purely additive on `CollectionImpl`. `Collection.utils` and `createCollection` are byte-identical to upstream — no in-place mutation of user-supplied utils, no merge-precedence changes. The live-query path's utils merge stays at upstream's `{ ...options.utils, ...config.utils }` (config wins). Tracked-source helpers are not on `utils` at all; they're direct methods on `CollectionImpl`.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Regression coverage in `packages/db/tests/query/live-query-collection.test.ts`:

- Base-view delta flow with `includeInitialState`, plus snapshot-as-removed on last-subscriber unsubscribe.
- Base-view ref-counting across overlapping live queries (key not removed until the last query stops using it).
- Stable-membership updates emit nothing (ordered query, in-range update).
- Truncate-refetch cycles that keep the same keys tracked emit nothing.
- Live-query-local view: delta flow + snapshot-as-removed on unsubscribe.
- Live-query-local view: `includeInitialState` replay.
- Polymorphic-scope test: two live queries with disjoint where-clauses on the same base, asserting the base view sees the union and each per-query view sees only its own scope.

Plus a regression test in `packages/db/tests/utility-exposure.test.ts` pinning that user-supplied `utils` keys override built-ins on collision (the upstream merge-precedence contract).

The feature lives entirely on `CollectionImpl` and the live-query pipeline (`CollectionSubscriber` → aggregator → manager) — none of the sync backends are touched, so the in-memory tests exercise the same code paths that electric, query-db, localStorage, etc. would hit.

## Screenshots
