### PR TITLE
feat: add materialize() helper for includes subqueries

### DIFF
--- a/packages/db/src/query/builder/functions.ts
+++ b/packages/db/src/query/builder/functions.ts
@@ -2,6 +2,7 @@ import { Aggregate, Func } from '../ir'
 import { toExpression } from './ref-proxy.js'
 import type { BasicExpression } from '../ir'
 import type { RefProxy } from './ref-proxy.js'
+import type { SingleResult } from '../../types.js'
 import type {
   Context,
   GetRawResult,
@@ -450,8 +451,58 @@ export class ConcatToArrayWrapper<_T = unknown> {
   constructor(public readonly query: QueryBuilder<any>) {}
 }
 
+export class MaterializeWrapper<
+  _T = unknown,
+  _IsSingle extends boolean = boolean,
+> {
+  readonly __brand = `MaterializeWrapper` as const
+  declare readonly _type: `materialize`
+  declare readonly _result: _T
+  declare readonly _isSingle: _IsSingle
+  constructor(public readonly query: QueryBuilder<any>) {}
+}
+
 export function toArray<TContext extends Context>(
   query: QueryBuilder<TContext>,
 ): ToArrayWrapper<GetRawResult<TContext>> {
   return new ToArrayWrapper(query)
+}
+
+/**
+ * Materialize an includes subquery into a plain value on the parent row.
+ *
+ * - For multi-row subqueries, the parent receives an `Array<T>` snapshot
+ *   (equivalent to `toArray()`).
+ * - For `findOne()` subqueries, the parent receives a single `T | undefined`
+ *   value — `undefined` when no child matches.
+ *
+ * The snapshot updates reactively: parent rows re-emit when the underlying
+ * children change.
+ *
+ * @example
+ * ```ts
+ * // Multi-row: produces Array<Issue> on each project
+ * select(({ p }) => ({
+ *   ...p,
+ *   issues: materialize(
+ *     q.from({ i: issues }).where(({ i }) => eq(i.projectId, p.id)),
+ *   ),
+ * }))
+ *
+ * // Singleton: produces Author | undefined on each post
+ * select(({ p }) => ({
+ *   ...p,
+ *   author: materialize(
+ *     q.from({ a: authors }).where(({ a }) => eq(a.id, p.authorId)).findOne(),
+ *   ),
+ * }))
+ * ```
+ */
+export function materialize<TContext extends Context>(
+  query: QueryBuilder<TContext>,
+): MaterializeWrapper<
+  GetRawResult<TContext>,
+  TContext extends SingleResult ? true : false
+> {
+  return new MaterializeWrapper(query)
 }

--- a/packages/db/src/query/builder/functions.ts
+++ b/packages/db/src/query/builder/functions.ts
@@ -2,6 +2,7 @@ import { Aggregate, Func } from '../ir'
 import { isRefProxy, toExpression } from './ref-proxy.js'
 import type { BasicExpression } from '../ir'
 import type { RefProxy } from './ref-proxy.js'
+import type { SingleResult } from '../../types.js'
 import type {
   Context,
   GetRawResult,
@@ -723,6 +724,17 @@ export class CaseWhenWrapper<_T = any> {
   constructor(public readonly args: Array<CaseWhenValue>) {}
 }
 
+export class MaterializeWrapper<
+  _T = unknown,
+  _IsSingle extends boolean = boolean,
+> {
+  readonly __brand = `MaterializeWrapper` as const
+  declare readonly _type: `materialize`
+  declare readonly _result: _T
+  declare readonly _isSingle: _IsSingle
+  constructor(public readonly query: QueryBuilder<any>) {}
+}
+
 export function toArray<TContext extends Context>(
   query: QueryBuilder<TContext>,
 ): ToArrayWrapper<GetRawResult<TContext>> {
@@ -787,4 +799,43 @@ function isExpressionValue(value: CaseWhenValue | undefined): boolean {
 
 function isConditionValue(value: CaseWhenValue | undefined): boolean {
   return isExpressionValue(value) && !Array.isArray(value)
+}
+
+/**
+ * Materialize an includes subquery into a plain value on the parent row.
+ *
+ * - For multi-row subqueries, the parent receives an `Array<T>` snapshot
+ *   (equivalent to `toArray()`).
+ * - For `findOne()` subqueries, the parent receives a single `T | undefined`
+ *   value — `undefined` when no child matches.
+ *
+ * The snapshot updates reactively: parent rows re-emit when the underlying
+ * children change.
+ *
+ * @example
+ * ```ts
+ * // Multi-row: produces Array<Issue> on each project
+ * select(({ p }) => ({
+ *   ...p,
+ *   issues: materialize(
+ *     q.from({ i: issues }).where(({ i }) => eq(i.projectId, p.id)),
+ *   ),
+ * }))
+ *
+ * // Singleton: produces Author | undefined on each post
+ * select(({ p }) => ({
+ *   ...p,
+ *   author: materialize(
+ *     q.from({ a: authors }).where(({ a }) => eq(a.id, p.authorId)).findOne(),
+ *   ),
+ * }))
+ * ```
+ */
+export function materialize<TContext extends Context>(
+  query: QueryBuilder<TContext>,
+): MaterializeWrapper<
+  GetRawResult<TContext>,
+  TContext extends SingleResult ? true : false
+> {
+  return new MaterializeWrapper(query)
 }

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -25,7 +25,11 @@ import {
   isRefProxy,
   toExpression,
 } from './ref-proxy.js'
-import { ConcatToArrayWrapper, ToArrayWrapper } from './functions.js'
+import {
+  ConcatToArrayWrapper,
+  MaterializeWrapper,
+  ToArrayWrapper,
+} from './functions.js'
 import type { NamespacedRow, SingleResult } from '../../types.js'
 import type {
   Aggregate,
@@ -918,6 +922,17 @@ function buildNestedSelect(obj: any, parentAliases: Array<string> = []): any {
         throw new Error(`concat(toArray(...)) must wrap a subquery builder`)
       }
       out[k] = buildIncludesSubquery(v.query, k, parentAliases, `concat`)
+      continue
+    }
+    if (v instanceof MaterializeWrapper) {
+      if (!(v.query instanceof BaseQueryBuilder)) {
+        throw new Error(`materialize() must wrap a subquery builder`)
+      }
+      const childQuery = v.query._getQuery()
+      const materialization: IncludesMaterialization = childQuery.singleResult
+        ? `singleton`
+        : `array`
+      out[k] = buildIncludesSubquery(v.query, k, parentAliases, materialization)
       continue
     }
     out[k] = buildNestedSelect(v, parentAliases)

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -31,6 +31,7 @@ import {
 import {
   CaseWhenWrapper,
   ConcatToArrayWrapper,
+  MaterializeWrapper,
   ToArrayWrapper,
 } from './functions.js'
 import type { SourceClauseContext } from '../../errors.js'
@@ -1030,6 +1031,17 @@ function buildNestedSelect(
         throw new Error(`concat(toArray(...)) must wrap a subquery builder`)
       }
       out[k] = buildIncludesSubquery(v.query, k, parentAliases, `concat`)
+      continue
+    }
+    if (v instanceof MaterializeWrapper) {
+      if (!(v.query instanceof BaseQueryBuilder)) {
+        throw new Error(`materialize() must wrap a subquery builder`)
+      }
+      const childQuery = v.query._getQuery()
+      const materialization: IncludesMaterialization = childQuery.singleResult
+        ? `singleton`
+        : `array`
+      out[k] = buildIncludesSubquery(v.query, k, parentAliases, materialization)
       continue
     }
     if (v instanceof CaseWhenWrapper) {

--- a/packages/db/src/query/builder/ref-proxy.ts
+++ b/packages/db/src/query/builder/ref-proxy.ts
@@ -286,8 +286,8 @@ export function createRefProxyWithSelected<T extends Record<string, any>>(
 /**
  * Converts a value to an Expression.
  * If it's a RefProxy, creates a PropRef. Throws if the value is a
- * ToArrayWrapper or ConcatToArrayWrapper (these must be used as direct
- * select fields). Otherwise wraps it as a Value.
+ * ToArrayWrapper, ConcatToArrayWrapper, or MaterializeWrapper (these must be
+ * used as direct select fields). Otherwise wraps it as a Value.
  */
 export function toExpression<T = any>(value: T): BasicExpression<T>
 export function toExpression(value: RefProxy<any>): BasicExpression<any>
@@ -295,15 +295,21 @@ export function toExpression(value: any): BasicExpression<any> {
   if (isRefProxy(value)) {
     return new PropRef(value.__path)
   }
-  // toArray() and concat(toArray()) must be used as direct select fields, not inside expressions
+  // toArray(), concat(toArray()), and materialize() must be used as direct
+  // select fields, not inside expressions
   if (
     value &&
     typeof value === `object` &&
     (value.__brand === `ToArrayWrapper` ||
-      value.__brand === `ConcatToArrayWrapper`)
+      value.__brand === `ConcatToArrayWrapper` ||
+      value.__brand === `MaterializeWrapper`)
   ) {
     const name =
-      value.__brand === `ToArrayWrapper` ? `toArray()` : `concat(toArray())`
+      value.__brand === `ToArrayWrapper`
+        ? `toArray()`
+        : value.__brand === `ConcatToArrayWrapper`
+          ? `concat(toArray())`
+          : `materialize()`
     throw new Error(
       `${name} cannot be used inside expressions (e.g., coalesce(), eq(), not()). ` +
         `Use ${name} directly as a select field value instead.`,

--- a/packages/db/src/query/builder/ref-proxy.ts
+++ b/packages/db/src/query/builder/ref-proxy.ts
@@ -286,8 +286,8 @@ export function createRefProxyWithSelected<T extends Record<string, any>>(
 /**
  * Converts a value to an Expression.
  * If it's a RefProxy, creates a PropRef. Throws if the value is a
- * ToArrayWrapper, ConcatToArrayWrapper, or CaseWhenWrapper (these must be used
- * as direct select fields). Otherwise wraps it as a Value.
+ * ToArrayWrapper, ConcatToArrayWrapper, CaseWhenWrapper, or MaterializeWrapper
+ * (these must be used as direct select fields). Otherwise wraps it as a Value.
  */
 export function toExpression<T = any>(value: T): BasicExpression<T>
 export function toExpression(value: RefProxy<any>): BasicExpression<any>
@@ -295,20 +295,24 @@ export function toExpression(value: any): BasicExpression<any> {
   if (isRefProxy(value)) {
     return new PropRef(value.__path)
   }
-  // toArray() and concat(toArray()) must be used as direct select fields, not inside expressions
+  // toArray(), concat(toArray()), and materialize() must be used as direct
+  // select fields, not inside expressions
   if (
     value &&
     typeof value === `object` &&
     (value.__brand === `ToArrayWrapper` ||
       value.__brand === `ConcatToArrayWrapper` ||
-      value.__brand === `CaseWhenWrapper`)
+      value.__brand === `CaseWhenWrapper` ||
+      value.__brand === `MaterializeWrapper`)
   ) {
     const name =
       value.__brand === `ToArrayWrapper`
         ? `toArray()`
         : value.__brand === `ConcatToArrayWrapper`
           ? `concat(toArray())`
-          : `caseWhen()`
+          : value.__brand === `CaseWhenWrapper`
+            ? `caseWhen()`
+            : `materialize()`
     throw new Error(
       `${name} cannot be used inside expressions (e.g., coalesce(), eq(), not()). ` +
         `Use ${name} directly as a select field value instead.`,

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -245,38 +245,38 @@ export type ResultTypeFromSelectValue<TSelectValue> =
                   : Array<T>
                 : TSelectValue extends QueryBuilder<infer TChildContext>
                   ? Collection<GetResult<TChildContext>>
-                : TSelectValue extends Ref<infer _T>
-                  ? ExtractRef<TSelectValue>
-                  : TSelectValue extends RefLeaf<infer T>
-                    ? IsNullableRef<TSelectValue> extends true
-                      ? T | undefined
-                      : T
-                    : TSelectValue extends RefLeaf<infer T> | undefined
-                      ? T | undefined
-                      : TSelectValue extends RefLeaf<infer T> | null
-                        ? IsNullableRef<
-                            Exclude<TSelectValue, null>
-                          > extends true
-                          ? T | null | undefined
-                          : T | null
-                        : TSelectValue extends Ref<infer _T> | undefined
-                          ?
-                              | ExtractRef<Exclude<TSelectValue, undefined>>
-                              | undefined
-                          : TSelectValue extends Ref<infer _T> | null
-                            ? ExtractRef<Exclude<TSelectValue, null>> | null
-                            : TSelectValue extends Aggregate<infer T>
-                              ? T
-                              : TSelectValue extends
-                                    | string
-                                    | number
-                                    | boolean
-                                    | null
-                                    | undefined
-                                ? TSelectValue
-                                : TSelectValue extends Record<string, any>
-                                  ? ResultTypeFromSelect<TSelectValue>
-                                  : never
+                  : TSelectValue extends Ref<infer _T>
+                    ? ExtractRef<TSelectValue>
+                    : TSelectValue extends RefLeaf<infer T>
+                      ? IsNullableRef<TSelectValue> extends true
+                        ? T | undefined
+                        : T
+                      : TSelectValue extends RefLeaf<infer T> | undefined
+                        ? T | undefined
+                        : TSelectValue extends RefLeaf<infer T> | null
+                          ? IsNullableRef<
+                              Exclude<TSelectValue, null>
+                            > extends true
+                            ? T | null | undefined
+                            : T | null
+                          : TSelectValue extends Ref<infer _T> | undefined
+                            ?
+                                | ExtractRef<Exclude<TSelectValue, undefined>>
+                                | undefined
+                            : TSelectValue extends Ref<infer _T> | null
+                              ? ExtractRef<Exclude<TSelectValue, null>> | null
+                              : TSelectValue extends Aggregate<infer T>
+                                ? T
+                                : TSelectValue extends
+                                      | string
+                                      | number
+                                      | boolean
+                                      | null
+                                      | undefined
+                                  ? TSelectValue
+                                  : TSelectValue extends Record<string, any>
+                                    ? ResultTypeFromSelect<TSelectValue>
+                                    : never
       >
 
 /**
@@ -330,57 +330,60 @@ export type ResultTypeFromSelect<TSelectObject> =
                 ? string
                 : // materialize() — Array<T> for multi-row, T | undefined for findOne()
                   TSelectObject[K] extends MaterializeWrapper<
-                    infer T,
-                    infer IsSingle
-                  >
+                      infer T,
+                      infer IsSingle
+                    >
                   ? IsSingle extends true
                     ? T | undefined
                     : Array<T>
                   : // includes subquery (bare QueryBuilder) — produces a child Collection
                     TSelectObject[K] extends QueryBuilder<infer TChildContext>
                     ? Collection<GetResult<TChildContext>>
-                  : // Ref (full object ref or spread with RefBrand) - recursively process properties
-                    TSelectObject[K] extends Ref<infer _T>
-                    ? ExtractRef<TSelectObject[K]>
-                    : // RefLeaf (simple property ref like user.name)
-                      TSelectObject[K] extends RefLeaf<infer T>
-                      ? IsNullableRef<TSelectObject[K]> extends true
-                        ? T | undefined
-                        : T
-                      : // RefLeaf | undefined (schema-optional field)
-                        TSelectObject[K] extends RefLeaf<infer T> | undefined
-                        ? T | undefined
-                        : // RefLeaf | null (schema-nullable field)
-                          TSelectObject[K] extends RefLeaf<infer T> | null
-                          ? IsNullableRef<
-                              Exclude<TSelectObject[K], null>
-                            > extends true
-                            ? T | null | undefined
-                            : T | null
-                          : // Ref | undefined (optional object-type schema field)
-                            TSelectObject[K] extends Ref<infer _T> | undefined
-                            ?
-                                | ExtractRef<
-                                    Exclude<TSelectObject[K], undefined>
-                                  >
-                                | undefined
-                            : // Ref | null (nullable object-type schema field)
-                              TSelectObject[K] extends Ref<infer _T> | null
-                              ? ExtractRef<
-                                  Exclude<TSelectObject[K], null>
-                                > | null
-                              : TSelectObject[K] extends Aggregate<infer T>
-                                ? T
-                                : TSelectObject[K] extends
-                                      | string
-                                      | number
-                                      | boolean
-                                      | null
-                                      | undefined
-                                  ? TSelectObject[K]
-                                  : TSelectObject[K] extends Record<string, any>
-                                    ? ResultTypeFromSelect<TSelectObject[K]>
-                                    : never
+                    : // Ref (full object ref or spread with RefBrand) - recursively process properties
+                      TSelectObject[K] extends Ref<infer _T>
+                      ? ExtractRef<TSelectObject[K]>
+                      : // RefLeaf (simple property ref like user.name)
+                        TSelectObject[K] extends RefLeaf<infer T>
+                        ? IsNullableRef<TSelectObject[K]> extends true
+                          ? T | undefined
+                          : T
+                        : // RefLeaf | undefined (schema-optional field)
+                          TSelectObject[K] extends RefLeaf<infer T> | undefined
+                          ? T | undefined
+                          : // RefLeaf | null (schema-nullable field)
+                            TSelectObject[K] extends RefLeaf<infer T> | null
+                            ? IsNullableRef<
+                                Exclude<TSelectObject[K], null>
+                              > extends true
+                              ? T | null | undefined
+                              : T | null
+                            : // Ref | undefined (optional object-type schema field)
+                              TSelectObject[K] extends Ref<infer _T> | undefined
+                              ?
+                                  | ExtractRef<
+                                      Exclude<TSelectObject[K], undefined>
+                                    >
+                                  | undefined
+                              : // Ref | null (nullable object-type schema field)
+                                TSelectObject[K] extends Ref<infer _T> | null
+                                ? ExtractRef<
+                                    Exclude<TSelectObject[K], null>
+                                  > | null
+                                : TSelectObject[K] extends Aggregate<infer T>
+                                  ? T
+                                  : TSelectObject[K] extends
+                                        | string
+                                        | number
+                                        | boolean
+                                        | null
+                                        | undefined
+                                    ? TSelectObject[K]
+                                    : TSelectObject[K] extends Record<
+                                          string,
+                                          any
+                                        >
+                                      ? ResultTypeFromSelect<TSelectObject[K]>
+                                      : never
         }>
       >
 

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -10,7 +10,11 @@ import type {
 } from '../ir.js'
 import type { InitialQueryBuilder, QueryBuilder } from './index.js'
 import type { VirtualRowProps, WithVirtualProps } from '../../virtual-props.js'
-import type { ConcatToArrayWrapper, ToArrayWrapper } from './functions.js'
+import type {
+  ConcatToArrayWrapper,
+  MaterializeWrapper,
+  ToArrayWrapper,
+} from './functions.js'
 
 /**
  * Context - The central state container for query builder operations
@@ -182,6 +186,7 @@ type SelectValue =
   | Array<RefLeaf<any>>
   | ToArrayWrapper // toArray() wrapped subquery
   | ConcatToArrayWrapper // concat(toArray(...)) wrapped subquery
+  | MaterializeWrapper // materialize() wrapped subquery (Array<T> or T | undefined)
   | QueryBuilder<any> // includes subquery (produces a child Collection)
 
 // Recursive shape for select objects allowing nested projections
@@ -234,8 +239,12 @@ export type ResultTypeFromSelectValue<TSelectValue> =
             ? Array<T>
             : TSelectValue extends ConcatToArrayWrapper<any>
               ? string
-              : TSelectValue extends QueryBuilder<infer TChildContext>
-                ? Collection<GetResult<TChildContext>>
+              : TSelectValue extends MaterializeWrapper<infer T, infer IsSingle>
+                ? IsSingle extends true
+                  ? T | undefined
+                  : Array<T>
+                : TSelectValue extends QueryBuilder<infer TChildContext>
+                  ? Collection<GetResult<TChildContext>>
                 : TSelectValue extends Ref<infer _T>
                   ? ExtractRef<TSelectValue>
                   : TSelectValue extends RefLeaf<infer T>
@@ -319,9 +328,17 @@ export type ResultTypeFromSelect<TSelectObject> =
               ? Array<T>
               : TSelectObject[K] extends ConcatToArrayWrapper<any>
                 ? string
-                : // includes subquery (bare QueryBuilder) — produces a child Collection
-                  TSelectObject[K] extends QueryBuilder<infer TChildContext>
-                  ? Collection<GetResult<TChildContext>>
+                : // materialize() — Array<T> for multi-row, T | undefined for findOne()
+                  TSelectObject[K] extends MaterializeWrapper<
+                    infer T,
+                    infer IsSingle
+                  >
+                  ? IsSingle extends true
+                    ? T | undefined
+                    : Array<T>
+                  : // includes subquery (bare QueryBuilder) — produces a child Collection
+                    TSelectObject[K] extends QueryBuilder<infer TChildContext>
+                    ? Collection<GetResult<TChildContext>>
                   : // Ref (full object ref or spread with RefBrand) - recursively process properties
                     TSelectObject[K] extends Ref<infer _T>
                     ? ExtractRef<TSelectObject[K]>

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -13,6 +13,7 @@ import type { VirtualRowProps, WithVirtualProps } from '../../virtual-props.js'
 import type {
   CaseWhenWrapper,
   ConcatToArrayWrapper,
+  MaterializeWrapper,
   ToArrayWrapper,
 } from './functions.js'
 
@@ -251,6 +252,7 @@ type SelectValue =
   | ToArrayWrapper // toArray() wrapped subquery
   | ConcatToArrayWrapper // concat(toArray(...)) wrapped subquery
   | CaseWhenWrapper // conditional projection
+  | MaterializeWrapper // materialize() wrapped subquery (Array<T> or T | undefined)
   | QueryBuilder<any> // includes subquery (produces a child Collection)
 
 // Recursive shape for select objects allowing nested projections
@@ -303,45 +305,49 @@ export type ResultTypeFromSelectValue<TSelectValue> =
             ? Array<T>
             : TSelectValue extends ConcatToArrayWrapper<any>
               ? string
-              : TSelectValue extends {
-                    readonly __brand: `CaseWhenWrapper`
-                    readonly _result?: infer T
-                  }
-                ? ResultTypeFromCaseWhen<T>
-                : TSelectValue extends QueryBuilder<infer TChildContext>
-                  ? Collection<GetResult<TChildContext>>
-                  : TSelectValue extends Ref<infer _T>
-                    ? ExtractRef<TSelectValue>
-                    : TSelectValue extends RefLeaf<infer T>
-                      ? IsNullableRef<TSelectValue> extends true
-                        ? T | undefined
-                        : T
-                      : TSelectValue extends RefLeaf<infer T> | undefined
-                        ? T | undefined
-                        : TSelectValue extends RefLeaf<infer T> | null
-                          ? IsNullableRef<
-                              Exclude<TSelectValue, null>
-                            > extends true
-                            ? T | null | undefined
-                            : T | null
-                          : TSelectValue extends Ref<infer _T> | undefined
-                            ?
-                                | ExtractRef<Exclude<TSelectValue, undefined>>
-                                | undefined
-                            : TSelectValue extends Ref<infer _T> | null
-                              ? ExtractRef<Exclude<TSelectValue, null>> | null
-                              : TSelectValue extends Aggregate<infer T>
-                                ? T
-                                : TSelectValue extends
-                                      | string
-                                      | number
-                                      | boolean
-                                      | null
-                                      | undefined
-                                  ? TSelectValue
-                                  : TSelectValue extends Record<string, any>
-                                    ? ResultTypeFromSelect<TSelectValue>
-                                    : never
+              : TSelectValue extends MaterializeWrapper<infer T, infer IsSingle>
+                ? IsSingle extends true
+                  ? T | undefined
+                  : Array<T>
+                : TSelectValue extends {
+                      readonly __brand: `CaseWhenWrapper`
+                      readonly _result?: infer T
+                    }
+                  ? ResultTypeFromCaseWhen<T>
+                  : TSelectValue extends QueryBuilder<infer TChildContext>
+                    ? Collection<GetResult<TChildContext>>
+                    : TSelectValue extends Ref<infer _T>
+                      ? ExtractRef<TSelectValue>
+                      : TSelectValue extends RefLeaf<infer T>
+                        ? IsNullableRef<TSelectValue> extends true
+                          ? T | undefined
+                          : T
+                        : TSelectValue extends RefLeaf<infer T> | undefined
+                          ? T | undefined
+                          : TSelectValue extends RefLeaf<infer T> | null
+                            ? IsNullableRef<
+                                Exclude<TSelectValue, null>
+                              > extends true
+                              ? T | null | undefined
+                              : T | null
+                            : TSelectValue extends Ref<infer _T> | undefined
+                              ?
+                                  | ExtractRef<Exclude<TSelectValue, undefined>>
+                                  | undefined
+                              : TSelectValue extends Ref<infer _T> | null
+                                ? ExtractRef<Exclude<TSelectValue, null>> | null
+                                : TSelectValue extends Aggregate<infer T>
+                                  ? T
+                                  : TSelectValue extends
+                                        | string
+                                        | number
+                                        | boolean
+                                        | null
+                                        | undefined
+                                    ? TSelectValue
+                                    : TSelectValue extends Record<string, any>
+                                      ? ResultTypeFromSelect<TSelectValue>
+                                      : never
       >
 
 /**
@@ -393,59 +399,71 @@ export type ResultTypeFromSelect<TSelectObject> =
               ? Array<T>
               : TSelectObject[K] extends ConcatToArrayWrapper<any>
                 ? string
-                : TSelectObject[K] extends {
-                      readonly __brand: `CaseWhenWrapper`
-                      readonly _result?: infer T
-                    }
-                  ? ResultTypeFromCaseWhen<T>
-                  : // includes subquery (bare QueryBuilder) — produces a child Collection
-                    TSelectObject[K] extends QueryBuilder<infer TChildContext>
-                    ? Collection<GetResult<TChildContext>>
-                    : // Ref (full object ref or spread with RefBrand) - recursively process properties
-                      TSelectObject[K] extends Ref<infer _T>
-                      ? ExtractRef<TSelectObject[K]>
-                      : // RefLeaf (simple property ref like user.name)
-                        TSelectObject[K] extends RefLeaf<infer T>
-                        ? IsNullableRef<TSelectObject[K]> extends true
-                          ? T | undefined
-                          : T
-                        : // RefLeaf | undefined (schema-optional field)
-                          TSelectObject[K] extends RefLeaf<infer T> | undefined
-                          ? T | undefined
-                          : // RefLeaf | null (schema-nullable field)
-                            TSelectObject[K] extends RefLeaf<infer T> | null
-                            ? IsNullableRef<
-                                Exclude<TSelectObject[K], null>
-                              > extends true
-                              ? T | null | undefined
-                              : T | null
-                            : // Ref | undefined (optional object-type schema field)
-                              TSelectObject[K] extends Ref<infer _T> | undefined
-                              ?
-                                  | ExtractRef<
-                                      Exclude<TSelectObject[K], undefined>
-                                    >
-                                  | undefined
-                              : // Ref | null (nullable object-type schema field)
-                                TSelectObject[K] extends Ref<infer _T> | null
-                                ? ExtractRef<
-                                    Exclude<TSelectObject[K], null>
-                                  > | null
-                                : TSelectObject[K] extends Aggregate<infer T>
-                                  ? T
-                                  : TSelectObject[K] extends
-                                        | string
-                                        | number
-                                        | boolean
-                                        | null
-                                        | undefined
-                                    ? TSelectObject[K]
-                                    : TSelectObject[K] extends Record<
-                                          string,
-                                          any
-                                        >
-                                      ? ResultTypeFromSelect<TSelectObject[K]>
-                                      : never
+                : // materialize() — Array<T> for multi-row, T | undefined for findOne()
+                  TSelectObject[K] extends MaterializeWrapper<
+                      infer T,
+                      infer IsSingle
+                    >
+                  ? IsSingle extends true
+                    ? T | undefined
+                    : Array<T>
+                  : TSelectObject[K] extends {
+                        readonly __brand: `CaseWhenWrapper`
+                        readonly _result?: infer T
+                      }
+                    ? ResultTypeFromCaseWhen<T>
+                    : // includes subquery (bare QueryBuilder) — produces a child Collection
+                      TSelectObject[K] extends QueryBuilder<infer TChildContext>
+                      ? Collection<GetResult<TChildContext>>
+                      : // Ref (full object ref or spread with RefBrand) - recursively process properties
+                        TSelectObject[K] extends Ref<infer _T>
+                        ? ExtractRef<TSelectObject[K]>
+                        : // RefLeaf (simple property ref like user.name)
+                          TSelectObject[K] extends RefLeaf<infer T>
+                          ? IsNullableRef<TSelectObject[K]> extends true
+                            ? T | undefined
+                            : T
+                          : // RefLeaf | undefined (schema-optional field)
+                            TSelectObject[K] extends
+                                | RefLeaf<infer T>
+                                | undefined
+                            ? T | undefined
+                            : // RefLeaf | null (schema-nullable field)
+                              TSelectObject[K] extends RefLeaf<infer T> | null
+                              ? IsNullableRef<
+                                  Exclude<TSelectObject[K], null>
+                                > extends true
+                                ? T | null | undefined
+                                : T | null
+                              : // Ref | undefined (optional object-type schema field)
+                                TSelectObject[K] extends
+                                    | Ref<infer _T>
+                                    | undefined
+                                ?
+                                    | ExtractRef<
+                                        Exclude<TSelectObject[K], undefined>
+                                      >
+                                    | undefined
+                                : // Ref | null (nullable object-type schema field)
+                                  TSelectObject[K] extends Ref<infer _T> | null
+                                  ? ExtractRef<
+                                      Exclude<TSelectObject[K], null>
+                                    > | null
+                                  : TSelectObject[K] extends Aggregate<infer T>
+                                    ? T
+                                    : TSelectObject[K] extends
+                                          | string
+                                          | number
+                                          | boolean
+                                          | null
+                                          | undefined
+                                      ? TSelectObject[K]
+                                      : TSelectObject[K] extends Record<
+                                            string,
+                                            any
+                                          >
+                                        ? ResultTypeFromSelect<TSelectObject[K]>
+                                        : never
         }>
       >
 

--- a/packages/db/src/query/index.ts
+++ b/packages/db/src/query/index.ts
@@ -62,6 +62,7 @@ export {
   max,
   // Includes helpers
   toArray,
+  materialize,
 } from './builder/functions.js'
 
 // Ref proxy utilities

--- a/packages/db/src/query/index.ts
+++ b/packages/db/src/query/index.ts
@@ -67,6 +67,7 @@ export {
   max,
   // Includes helpers
   toArray,
+  materialize,
 } from './builder/functions.js'
 
 // Ref proxy utilities

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -25,7 +25,11 @@ export interface QueryIR {
   fnHaving?: Array<(row: NamespacedRow) => any>
 }
 
-export type IncludesMaterialization = `collection` | `array` | `concat`
+export type IncludesMaterialization =
+  | `collection`
+  | `array`
+  | `singleton`
+  | `concat`
 
 export const INCLUDES_SCALAR_FIELD = `__includes_scalar__`
 

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -1196,6 +1196,8 @@ function materializeIncludedValue(
     if (state.materialization === `concat`) {
       return ``
     }
+    // `singleton` and `collection` both fall through to undefined when no
+    // child entry exists for the parent's correlation key.
     return undefined
   }
 
@@ -1210,6 +1212,12 @@ function materializeIncludedValue(
 
   if (state.materialization === `array`) {
     return values
+  }
+
+  if (state.materialization === `singleton`) {
+    // findOne() doesn't currently push LIMIT 1 to the IR, so the child
+    // Collection may hold more than one row; pick the first deterministically.
+    return values[0]
   }
 
   return values.map((value) => String(value ?? ``)).join(``)

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -1214,6 +1214,8 @@ function materializeIncludedValue(
     if (state.materialization === `concat`) {
       return ``
     }
+    // `singleton` and `collection` both fall through to undefined when no
+    // child entry exists for the parent's correlation key.
     return undefined
   }
 
@@ -1228,6 +1230,12 @@ function materializeIncludedValue(
 
   if (state.materialization === `array`) {
     return values
+  }
+
+  if (state.materialization === `singleton`) {
+    // findOne() doesn't currently push LIMIT 1 to the IR, so the child
+    // Collection may hold more than one row; pick the first deterministically.
+    return values[0]
   }
 
   return values.map((value) => String(value ?? ``)).join(``)

--- a/packages/db/tests/query/includes.test-d.ts
+++ b/packages/db/tests/query/includes.test-d.ts
@@ -4,6 +4,7 @@ import {
   concat,
   createLiveQueryCollection,
   eq,
+  materialize,
   queryOnce,
   toArray,
 } from '../../src/query/index.js'
@@ -419,6 +420,132 @@ describe(`includes subquery types`, () => {
 
       // @ts-expect-error - top-level scalar select is not supported for queryOnce
       queryOnce({ query: scalarRootQuery })
+    })
+  })
+
+  describe(`materialize`, () => {
+    test(`materialize over a multi-row subquery infers Array<T>`, () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ p: projects }).select(({ p }) => ({
+          id: p.id,
+          name: p.name,
+          issues: materialize(
+            q
+              .from({ i: issues })
+              .where(({ i }) => eq(i.projectId, p.id))
+              .select(({ i }) => ({
+                id: i.id,
+                title: i.title,
+              })),
+          ),
+        })),
+      )
+
+      const result = collection.toArray[0]!
+      expectTypeOf(result.id).toEqualTypeOf<number>()
+      expectTypeOf(result.name).toEqualTypeOf<string>()
+      expectTypeOf(result.issues).toMatchTypeOf<
+        Array<WithVirtualProps<{ id: number; title: string }>>
+      >()
+    })
+
+    test(`materialize over a findOne() subquery infers T | undefined`, () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ i: issues }).select(({ i }) => ({
+          id: i.id,
+          title: i.title,
+          project: materialize(
+            q
+              .from({ p: projects })
+              .where(({ p }) => eq(p.id, i.projectId))
+              .select(({ p }) => ({
+                id: p.id,
+                name: p.name,
+              }))
+              .findOne(),
+          ),
+        })),
+      )
+
+      const result = collection.toArray[0]!
+      expectTypeOf(result.id).toEqualTypeOf<number>()
+      expectTypeOf(result.title).toEqualTypeOf<string>()
+      expectTypeOf(result.project).toMatchTypeOf<
+        WithVirtualProps<{ id: number; name: string }> | undefined
+      >()
+    })
+
+    test(`materialize without select on findOne() infers full row | undefined`, () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ i: issues }).select(({ i }) => ({
+          id: i.id,
+          project: materialize(
+            q
+              .from({ p: projects })
+              .where(({ p }) => eq(p.id, i.projectId))
+              .findOne(),
+          ),
+        })),
+      )
+
+      const result = collection.toArray[0]!
+      expectTypeOf(result.project).toMatchTypeOf<
+        WithVirtualProps<Project> | undefined
+      >()
+    })
+
+    test(`materialize over a scalar findOne() infers value | undefined`, () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ m: messages }).select(({ m }) => ({
+          id: m.id,
+          firstChunk: materialize(
+            q
+              .from({ c: chunks })
+              .where(({ c }) => eq(c.messageId, m.id))
+              .orderBy(({ c }) => c.timestamp)
+              .select(({ c }) => c.text)
+              .findOne(),
+          ),
+        })),
+      )
+
+      const result = collection.toArray[0]!
+      expectTypeOf(result.firstChunk).toEqualTypeOf<string | undefined>()
+    })
+
+    test(`nested materialize: array of singletons`, () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ p: projects }).select(({ p }) => ({
+          id: p.id,
+          issues: materialize(
+            q
+              .from({ i: issues })
+              .where(({ i }) => eq(i.projectId, p.id))
+              .select(({ i }) => ({
+                id: i.id,
+                title: i.title,
+                firstComment: materialize(
+                  q
+                    .from({ c: comments })
+                    .where(({ c }) => eq(c.issueId, i.id))
+                    .select(({ c }) => ({ id: c.id, body: c.body }))
+                    .findOne(),
+                ),
+              })),
+          ),
+        })),
+      )
+
+      const result = collection.toArray[0]!
+      expectTypeOf(result.issues[0]!).toMatchTypeOf<
+        WithVirtualProps<{
+          id: number
+          title: string
+          firstComment:
+            | WithVirtualProps<{ id: number; body: string }>
+            | undefined
+        }>
+      >()
     })
   })
 })

--- a/packages/db/tests/query/includes.test.ts
+++ b/packages/db/tests/query/includes.test.ts
@@ -6,6 +6,7 @@ import {
   count,
   createLiveQueryCollection,
   eq,
+  materialize,
   toArray,
 } from '../../src/query/index.js'
 import { createCollection } from '../../src/collection/index.js'
@@ -5122,6 +5123,249 @@ describe(`includes subqueries`, () => {
       })
       await new Promise((r) => setTimeout(r, 100))
       expect(data().textDeltas).toHaveLength(2)
+    })
+  })
+
+  describe(`materialize`, () => {
+    // For singleton behavior we look up each issue's parent project.
+    // Each issue references exactly one project via projectId.
+    function buildSingletonQuery() {
+      return createLiveQueryCollection((q) =>
+        q.from({ i: issues }).select(({ i }) => ({
+          id: i.id,
+          title: i.title,
+          project: materialize(
+            q
+              .from({ p: projects })
+              .where(({ p }) => eq(p.id, i.projectId))
+              .select(({ p }) => ({
+                id: p.id,
+                name: p.name,
+              }))
+              .findOne(),
+          ),
+        })),
+      )
+    }
+
+    it(`findOne() materializes a single value, not an array`, async () => {
+      const collection = buildSingletonQuery()
+      await collection.preload()
+
+      const bug = collection.get(10) as any
+      expect(Array.isArray(bug.project)).toBe(false)
+      expect(stripVirtualPropsDeep(bug.project)).toEqual({
+        id: 1,
+        name: `Alpha`,
+      })
+
+      const betaBug = collection.get(20) as any
+      expect(stripVirtualPropsDeep(betaBug.project)).toEqual({
+        id: 2,
+        name: `Beta`,
+      })
+    })
+
+    it(`findOne() with no matching child yields undefined`, async () => {
+      // Issue referencing a non-existent project
+      issues.utils.begin()
+      issues.utils.write({
+        type: `insert`,
+        value: { id: 99, projectId: 999, title: `Orphan issue` },
+      })
+      issues.utils.commit()
+
+      const collection = buildSingletonQuery()
+      await collection.preload()
+
+      const orphan = collection.get(99) as any
+      expect(orphan.project).toBeUndefined()
+    })
+
+    it(`inserting the matching child re-emits parent with populated singleton`, async () => {
+      // Start with an issue whose project doesn't exist yet
+      issues.utils.begin()
+      issues.utils.write({
+        type: `insert`,
+        value: { id: 99, projectId: 999, title: `Orphan issue` },
+      })
+      issues.utils.commit()
+
+      const collection = buildSingletonQuery()
+      await collection.preload()
+
+      expect((collection.get(99) as any).project).toBeUndefined()
+
+      // Now create the matching project
+      projects.utils.begin()
+      projects.utils.write({
+        type: `insert`,
+        value: { id: 999, name: `Late Project` },
+      })
+      projects.utils.commit()
+
+      expect(stripVirtualPropsDeep((collection.get(99) as any).project)).toEqual(
+        { id: 999, name: `Late Project` },
+      )
+    })
+
+    it(`updating the matching child re-emits parent with updated singleton`, async () => {
+      const collection = buildSingletonQuery()
+      await collection.preload()
+
+      projects.utils.begin()
+      projects.utils.write({
+        type: `update`,
+        value: { id: 1, name: `Renamed Alpha` },
+      })
+      projects.utils.commit()
+
+      const bug = collection.get(10) as any
+      expect(stripVirtualPropsDeep(bug.project)).toEqual({
+        id: 1,
+        name: `Renamed Alpha`,
+      })
+    })
+
+    it(`deleting the matching child re-emits parent with undefined`, async () => {
+      const collection = buildSingletonQuery()
+      await collection.preload()
+
+      expect((collection.get(20) as any).project).toBeDefined()
+
+      projects.utils.begin()
+      projects.utils.write({
+        type: `delete`,
+        value: sampleProjects.find((p) => p.id === 2)!,
+      })
+      projects.utils.commit()
+
+      expect((collection.get(20) as any).project).toBeUndefined()
+    })
+
+    it(`two parents sharing a correlation key both see the singleton`, async () => {
+      const collection = buildSingletonQuery()
+      await collection.preload()
+
+      // Issues 10 and 11 both reference project 1
+      const bug = collection.get(10) as any
+      const feature = collection.get(11) as any
+      expect(stripVirtualPropsDeep(bug.project)).toEqual({
+        id: 1,
+        name: `Alpha`,
+      })
+      expect(stripVirtualPropsDeep(feature.project)).toEqual({
+        id: 1,
+        name: `Alpha`,
+      })
+
+      // Updating the shared project re-emits both parents
+      projects.utils.begin()
+      projects.utils.write({
+        type: `update`,
+        value: { id: 1, name: `Alpha v2` },
+      })
+      projects.utils.commit()
+
+      expect(stripVirtualPropsDeep((collection.get(10) as any).project)).toEqual(
+        { id: 1, name: `Alpha v2` },
+      )
+      expect(stripVirtualPropsDeep((collection.get(11) as any).project)).toEqual(
+        { id: 1, name: `Alpha v2` },
+      )
+    })
+
+    it(`materialize over a multi-row subquery still returns Array<T>`, async () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ p: projects }).select(({ p }) => ({
+          id: p.id,
+          name: p.name,
+          issues: materialize(
+            q
+              .from({ i: issues })
+              .where(({ i }) => eq(i.projectId, p.id))
+              .select(({ i }) => ({
+                id: i.id,
+                title: i.title,
+              })),
+          ),
+        })),
+      )
+      await collection.preload()
+
+      const alpha = collection.get(1) as any
+      expect(Array.isArray(alpha.issues)).toBe(true)
+      expect(sortedPlainRows(alpha.issues)).toEqual([
+        { id: 10, title: `Bug in Alpha` },
+        { id: 11, title: `Feature for Alpha` },
+      ])
+
+      const gamma = collection.get(3) as any
+      expect(Array.isArray(gamma.issues)).toBe(true)
+      expect(plainRows(gamma.issues)).toEqual([])
+    })
+
+    it(`materialize over a scalar findOne() returns the scalar value`, async () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ i: issues }).select(({ i }) => ({
+          id: i.id,
+          projectName: materialize(
+            q
+              .from({ p: projects })
+              .where(({ p }) => eq(p.id, i.projectId))
+              .select(({ p }) => p.name)
+              .findOne(),
+          ),
+        })),
+      )
+      await collection.preload()
+
+      expect((collection.get(10) as any).projectName).toBe(`Alpha`)
+      expect((collection.get(20) as any).projectName).toBe(`Beta`)
+    })
+
+    it(`nested materialize: array of issues with singleton first-comment lookup each`, async () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ p: projects }).select(({ p }) => ({
+          id: p.id,
+          name: p.name,
+          issues: materialize(
+            q
+              .from({ i: issues })
+              .where(({ i }) => eq(i.projectId, p.id))
+              .select(({ i }) => ({
+                id: i.id,
+                title: i.title,
+                firstComment: materialize(
+                  q
+                    .from({ c: comments })
+                    .where(({ c }) => eq(c.issueId, i.id))
+                    .orderBy(({ c }) => c.id, `asc`)
+                    .select(({ c }) => ({ id: c.id, body: c.body }))
+                    .findOne(),
+                ),
+              })),
+          ),
+        })),
+      )
+      await collection.preload()
+
+      const alpha = collection.get(1) as any
+      const issuesArr = stripVirtualPropsDeep(alpha.issues).sort(
+        (a: any, b: any) => a.id - b.id,
+      )
+      expect(issuesArr).toEqual([
+        {
+          id: 10,
+          title: `Bug in Alpha`,
+          firstComment: { id: 100, body: `Looks bad` },
+        },
+        {
+          id: 11,
+          title: `Feature for Alpha`,
+          firstComment: undefined,
+        },
+      ])
     })
   })
 })

--- a/packages/db/tests/query/includes.test.ts
+++ b/packages/db/tests/query/includes.test.ts
@@ -5204,9 +5204,9 @@ describe(`includes subqueries`, () => {
       })
       projects.utils.commit()
 
-      expect(stripVirtualPropsDeep((collection.get(99) as any).project)).toEqual(
-        { id: 999, name: `Late Project` },
-      )
+      expect(
+        stripVirtualPropsDeep((collection.get(99) as any).project),
+      ).toEqual({ id: 999, name: `Late Project` })
     })
 
     it(`updating the matching child re-emits parent with updated singleton`, async () => {
@@ -5267,12 +5267,12 @@ describe(`includes subqueries`, () => {
       })
       projects.utils.commit()
 
-      expect(stripVirtualPropsDeep((collection.get(10) as any).project)).toEqual(
-        { id: 1, name: `Alpha v2` },
-      )
-      expect(stripVirtualPropsDeep((collection.get(11) as any).project)).toEqual(
-        { id: 1, name: `Alpha v2` },
-      )
+      expect(
+        stripVirtualPropsDeep((collection.get(10) as any).project),
+      ).toEqual({ id: 1, name: `Alpha v2` })
+      expect(
+        stripVirtualPropsDeep((collection.get(11) as any).project),
+      ).toEqual({ id: 1, name: `Alpha v2` })
     })
 
     it(`materialize over a multi-row subquery still returns Array<T>`, async () => {


### PR DESCRIPTION
Closes #1481.

## Summary

- Adds `materialize()` — a single helper for materializing includes subqueries onto parent rows. It resolves to `Array<T>` when the wrapped subquery returns multiple rows, and to `T | undefined` when the subquery is `findOne()`. The intent is to spare callers from unwrapping a singleton array whenever they know the child query yields at most one row.
- `toArray()` is unchanged — it still always produces `Array<T>`. `materialize()` is purely additive.
- Implementation: extends the existing `IncludesMaterialization` enum with `'singleton'`, threads it through the IR / compiler / runtime, and updates the `materializeIncludedValue` helper to return the first child row (or `undefined`) for the singleton case. The reactive re-emit machinery routes through that helper, so insert/update/delete/no-match transitions all flow naturally.
- Type inference: `materialize(q.from(...).findOne())` infers `T | undefined`, `materialize(q.from(...))` infers `Array<T>`. Detected at the type level via a phantom `IsSingle` flag on `MaterializeWrapper` that's set from `TContext extends SingleResult`.
- `materialize()` is also rejected inside expressions (`coalesce()`, `eq()`, …) with the same kind of error message that `toArray()` produces.

## Example

```ts
// Multi-row → Array<Issue>
select(({ p }) => ({
  ...p,
  issues: materialize(
    q.from({ i: issues }).where(({ i }) => eq(i.projectId, p.id))
  ),
}))

// Singleton → Project | undefined
select(({ i }) => ({
  ...i,
  project: materialize(
    q.from({ p: projects }).where(({ p }) => eq(p.id, i.projectId)).findOne()
  ),
}))
```

A changeset will follow in a separate commit.

## Test plan

- [x] New runtime tests in `tests/query/includes.test.ts` cover singleton attach, missing-match → `undefined`, insert / update / delete reactivity, two parents sharing a correlation key, multi-row fallback, scalar singleton, and nested `materialize` (array of singletons).
- [x] New type tests in `tests/query/includes.test-d.ts` cover array, singleton (with select / without select / scalar), and a nested array-of-singleton case.
- [x] Full `packages/db` test suite passes (1502 tests, 0 type errors).
- [x] Package builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `materialize()` helper function for wrapping subqueries in SELECT statements, providing clean snapshot materialization.
  * Automatically returns `T | undefined` for single-row queries and `Array<T>` for multi-row queries.
  * Supports nested materialization for complex query structures.

* **Tests**
  * Added comprehensive test coverage for materialize functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->