### PR TITLE
fix(db): preserve union types in select result extraction

### DIFF
--- a/.changeset/fix-ref-union-collapse.md
+++ b/.changeset/fix-ref-union-collapse.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+fix: preserve discriminated union types when selecting object fields via `.select()`

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -322,9 +322,16 @@ export type ResultTypeFromSelect<TSelectObject> =
                 : // includes subquery (bare QueryBuilder) — produces a child Collection
                   TSelectObject[K] extends QueryBuilder<infer TChildContext>
                   ? Collection<GetResult<TChildContext>>
-                  : // Ref (full object ref or spread with RefBrand) - recursively process properties
+                  : // Ref (full object ref or spread with RefBrand)
                     TSelectObject[K] extends Ref<infer _T>
-                    ? ExtractRef<TSelectObject[K]>
+                    ? // When the branded type is a union, extract it directly to
+                      // preserve the discriminated union. ExtractRef would collapse
+                      // it via keyof/Prettify which only yield common keys.
+                      true extends IsUnion<ExtractRefBrand<TSelectObject[K]>>
+                      ? IsNullableRef<TSelectObject[K]> extends true
+                        ? ExtractRefBrand<TSelectObject[K]> | undefined
+                        : ExtractRefBrand<TSelectObject[K]>
+                      : ExtractRef<TSelectObject[K]>
                     : // RefLeaf (simple property ref like user.name)
                       TSelectObject[K] extends RefLeaf<infer T>
                       ? IsNullableRef<TSelectObject[K]> extends true
@@ -371,6 +378,9 @@ export type SelectResult<TSelect> =
   IsPlainObject<TSelect> extends true
     ? ResultTypeFromSelect<TSelect>
     : ResultTypeFromSelectValue<TSelect>
+
+// Extract the raw type stored in a RefLeaf's brand
+type ExtractRefBrand<T> = T extends RefLeaf<infer U> ? U : never
 
 // Extract Ref or subobject with a spread or a Ref
 type ExtractRef<T> = Prettify<ResultTypeFromSelect<WithoutRefBrand<T>>>
@@ -1067,6 +1077,14 @@ type IsPlainObject<T> = T extends unknown
   : false
 
 type IsAny<T> = 0 extends 1 & T ? true : false
+
+// Detects whether T is a union type (e.g., A | B | C returns true, A returns false)
+type IsUnion<T, U = T> = T extends unknown
+  ? [U] extends [T]
+    ? false
+    : true
+  : false
+
 
 /**
  * JsBuiltIns - List of JavaScript built-ins

--- a/packages/db/tests/query/select.test-d.ts
+++ b/packages/db/tests/query/select.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, test } from 'vitest'
 import { createCollection } from '../../src/collection/index.js'
-import { createLiveQueryCollection } from '../../src/query/index.js'
+import { createLiveQueryCollection, eq } from '../../src/query/index.js'
 import { mockSyncCollectionOptions } from '../utils.js'
 import { upper } from '../../src/query/builder/functions.js'
 import type { OutputWithVirtual } from '../utils.js'
@@ -107,6 +107,67 @@ describe(`select types`, () => {
     const results = col.toArray[0]!
 
     expectTypeOf(results).toMatchTypeOf<OutputWithVirtualKeyed<Expected>>()
+  })
+
+  test(`select preserves union types and where works on common keys`, () => {
+    type ItemDocument =
+      | { type: 'pdf'; url: string; pages: number }
+      | { type: 'image'; url: string; width: number; height: number }
+      | { type: 'legacy'; path: string }
+
+    type Item = { id: number; name: string; document: ItemDocument }
+
+    const items = createCollection(
+      mockSyncCollectionOptions<Item>({
+        id: `union-field-items`,
+        getKey: (i) => i.id,
+        initialData: [],
+      }),
+    )
+
+    // Filtering by a common key of the union should compile,
+    // and the result should preserve the full discriminated union
+    const col = createLiveQueryCollection((q) =>
+      q
+        .from({ i: items })
+        .where(({ i }) => eq(i.document.type, `pdf`))
+        .select(({ i }) => ({
+          id: i.id,
+          document: i.document,
+        })),
+    )
+
+    const result = col.toArray[0]!
+    expectTypeOf(result.document).toEqualTypeOf<ItemDocument>()
+  })
+
+  test(`select preserves union when collection type is a union`, () => {
+    type DocV1 = { version: 1; title: string }
+    type DocV2 = { version: 2; title: string; subtitle: string }
+    type Doc = DocV1 | DocV2
+
+    const docs = createCollection(
+      mockSyncCollectionOptions<Doc>({
+        id: `union-collection`,
+        getKey: (d) => d.title,
+        initialData: [],
+      }),
+    )
+
+    // Without select — union preserved
+    const col1 = createLiveQueryCollection((q) => q.from({ d: docs }))
+    const r1 = col1.toArray[0]!
+    expectTypeOf(r1).toMatchTypeOf<Doc>()
+
+    // With select on individual fields — per-field unions (not top-level union)
+    const col2 = createLiveQueryCollection((q) =>
+      q.from({ d: docs }).select(({ d }) => ({
+        version: d.version,
+        title: d.title,
+      })),
+    )
+    const r2 = col2.toArray[0]!
+    expectTypeOf(r2).toMatchTypeOf<{ version: 1 | 2; title: string }>()
   })
 
   test(`nested spread preserves object structure types`, () => {


### PR DESCRIPTION
Fixes #1511

## 🎯 Changes

When a collection field is a discriminated union of object types, selecting that field via `.select()` collapses the union into a single type with only the intersection of keys.

```ts
type Document =
  | { type: 'pdf'; url: string; pages: number }
  | { type: 'image'; url: string; width: number; height: number }
  | { type: 'legacy'; path: string }

type Item = { id: number; document: Document }

// Before: result.document is { type: string } — union collapsed, variant keys lost
// After:  result.document is Document — full discriminated union preserved
q.from({ i: items }).select(({ i }) => ({ id: i.id, document: i.document }))
```

The root cause is in `ResultTypeFromSelect`: when a `Ref<T>` holds a union type, `ExtractRef` recurses into the mapped keys via `keyof`/`Prettify`, which collapse the union to only common keys.

The fix detects when a `Ref`'s branded type (`RefLeaf<T>`) is a union and extracts it directly, bypassing `ExtractRef`. This preserves `Ref<T>`'s mapped type structure so that common keys of the union remain accessible in `.where()` and `.orderBy()` callbacks (e.g., `eq(i.document.type, 'pdf')`).

New helpers:
- `IsUnion<T>` — detects union types
- `ExtractRefBrand<T>` — extracts the raw type from a `RefLeaf`'s brand

Tests added:
- Select preserves union types on object fields
- Where clause works on common keys of union fields
- Select preserves union when collection type is a union

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
-  ~This change is docs/CI/dev-only (no release).~