### PR TITLE
fix(react-db): refresh live query snapshot after subscribe

### DIFF
--- a/.changeset/bright-beds-reflect.md
+++ b/.changeset/bright-beds-reflect.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-db': patch
+---
+
+Refresh live query snapshots immediately after subscribing, even when the collection is still loading.

--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -439,11 +439,13 @@ export function useLiveQuery(
         versionRef.current += 1
         onStoreChange()
       })
-      // Collection may be ready and will not receive initial `subscribeChanges()`
-      if (collectionRef.current.status === `ready`) {
-        versionRef.current += 1
-        onStoreChange()
-      }
+      // The collection may have changed between render-time getSnapshot() and
+      // this subscription being attached. This is common when an on-demand query
+      // hydrates local rows immediately but keeps the collection loading while
+      // remote sync finishes. Force one post-subscribe snapshot refresh
+      // regardless of status so React sees those rows.
+      versionRef.current += 1
+      onStoreChange()
       return () => {
         subscription.unsubscribe()
       }

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -18,6 +18,7 @@ import {
   mockSyncCollectionOptions,
   stripVirtualProps,
 } from '../../db/tests/utils'
+import type { SyncConfig } from '@tanstack/db'
 
 type Person = {
   id: string
@@ -1559,6 +1560,56 @@ describe(`Query Collections`, () => {
   })
 
   describe(`eager execution during sync`, () => {
+    it(`refreshes the snapshot after subscribing while the collection is still loading`, async () => {
+      type TestRow = { id: string; value: number }
+
+      let syncBegin: (() => void) | undefined
+      let syncWrite: Parameters<SyncConfig<TestRow>[`sync`]>[0][`write`]
+      let syncCommit: (() => void) | undefined
+      let didWriteAfterSnapshot = false
+
+      const collection = createCollection<TestRow>({
+        id: `loading-subscribe-snapshot-refresh`,
+        getKey: row => row.id,
+        startSync: false,
+        sync: {
+          sync: ({ begin, write, commit }) => {
+            syncBegin = begin
+            syncWrite = write
+            syncCommit = commit
+          },
+        },
+      })
+
+      const { result } = renderHook(() => {
+        const queryResult = useLiveQuery(collection)
+
+        if (!didWriteAfterSnapshot) {
+          didWriteAfterSnapshot = true
+          // Simulate a collection receiving rows after useLiveQuery read its
+          // render-time snapshot, but before React attached the external-store
+          // subscription. The collection intentionally stays loading because
+          // the missed update should still be visible before remote sync
+          // finishes.
+          syncBegin!()
+          syncWrite({
+            type: `insert`,
+            value: { id: `1`, value: 1 },
+          })
+          syncCommit!()
+        }
+
+        return queryResult
+      })
+
+      await waitFor(() => {
+        expect(result.current.data.map(row => stripVirtualProps(row))).toEqual([
+          { id: `1`, value: 1 },
+        ])
+      })
+      expect(result.current.isLoading).toBe(true)
+    })
+
     it(`should show state while isLoading is true during sync`, async () => {
       let syncBegin: (() => void) | undefined
       let syncWrite: ((op: any) => void) | undefined

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -1570,7 +1570,7 @@ describe(`Query Collections`, () => {
 
       const collection = createCollection<TestRow>({
         id: `loading-subscribe-snapshot-refresh`,
-        getKey: row => row.id,
+        getKey: (row) => row.id,
         startSync: false,
         sync: {
           sync: ({ begin, write, commit }) => {
@@ -1603,9 +1603,9 @@ describe(`Query Collections`, () => {
       })
 
       await waitFor(() => {
-        expect(result.current.data.map(row => stripVirtualProps(row))).toEqual([
-          { id: `1`, value: 1 },
-        ])
+        expect(
+          result.current.data.map((row) => stripVirtualProps(row)),
+        ).toEqual([{ id: `1`, value: 1 }])
       })
       expect(result.current.isLoading).toBe(true)
     })


### PR DESCRIPTION
## 🎯 Changes

Fixes a `useLiveQuery` subscription timing bug where the client could fail to see rows that were already in the collection.

The failure mode was:

1. `useLiveQuery` read a render-time snapshot while the collection was still empty.
2. Rows were written into the collection before React attached the `useSyncExternalStore` subscription. In our app, this is the shape of local/persisted rows hydrating while upstream sync is still pending.
3. Because the collection status was still `loading`, the hook skipped its post-subscribe refresh.
4. React kept rendering the stale empty snapshot, even though the collection had rows available. The client did not see those rows until a later collection change or ready transition happened.

The fix is to force one snapshot refresh immediately after subscribing regardless of collection status. That makes rows written during the render-to-subscribe gap visible while `isLoading` can still remain true for upstream sync.

Adds a regression test with a real collection that writes a row through sync callbacks during that gap and verifies `useLiveQuery` returns the row while still loading.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
