### PR TITLE
fix(db): avoid passing computed orderBy aliases to loadSubset

### DIFF
--- a/.changeset/fix-load-subset-order-by-hints.md
+++ b/.changeset/fix-load-subset-order-by-hints.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Fix `loadSubset` orderBy hints for subqueries with computed selected fields. We now stop ref-following on non-ref select expressions and only pass `orderBy`/`limit` hints when each `orderBy` ref resolves to a real source field.

--- a/packages/db/src/query/compiler/index.ts
+++ b/packages/db/src/query/compiler/index.ts
@@ -1107,15 +1107,17 @@ export function followRef(
     // is it part of the select clause?
     if (query.select) {
       const selectedField = query.select[field]
-      if (selectedField && selectedField.type === `ref`) {
-        return followRef(query, selectedField, collection)
+      if (selectedField) {
+        // Only pass-through refs can be followed to a raw collection field.
+        // Computed select expressions do not map to a source column.
+        if (selectedField.type === `ref`) {
+          return followRef(query, selectedField, collection)
+        }
+        return
       }
     }
 
-    // Either this field is not part of the select clause
-    // and thus it must be part of the collection itself
-    // or it is part of the select but is not a reference
-    // so we can stop here and don't have to follow it
+    // Field is not projected by select, so it belongs to the collection itself.
     return { collection, path: [field] }
   }
 

--- a/packages/db/src/query/ir.ts
+++ b/packages/db/src/query/ir.ts
@@ -246,15 +246,17 @@ export function followRef(
     // is it part of the select clause?
     if (query.select) {
       const selectedField = query.select[field]
-      if (selectedField && selectedField.type === `ref`) {
-        return followRef(query, selectedField, collection)
+      if (selectedField) {
+        // Only pass-through refs can be followed to a raw collection field.
+        // Computed select expressions do not map to a source column.
+        if (selectedField.type === `ref`) {
+          return followRef(query, selectedField, collection)
+        }
+        return
       }
     }
 
-    // Either this field is not part of the select clause
-    // and thus it must be part of the collection itself
-    // or it is part of the select but is not a reference
-    // so we can stop here and don't have to follow it
+    // Field is not projected by select, so it belongs to the collection itself.
     return { collection, path: [field] }
   }
 

--- a/packages/db/src/query/live/utils.ts
+++ b/packages/db/src/query/live/utils.ts
@@ -2,7 +2,7 @@ import { MultiSet, serializeValue } from '@tanstack/db-ivm'
 import { UnsupportedRootScalarSelectError } from '../../errors.js'
 import { normalizeOrderByPaths } from '../compiler/expressions.js'
 import { buildQuery, getQueryIR } from '../builder/index.js'
-import { IncludesSubquery } from '../ir.js'
+import { IncludesSubquery, followRef } from '../ir.js'
 import type { MultiSetArray, RootStreamBuilder } from '@tanstack/db-ivm'
 import type { Collection } from '../../collection/index.js'
 import type { ChangeMessage } from '../../types.js'
@@ -334,7 +334,7 @@ export function trackBiggestSentValue(
  * be scoped to the given alias (e.g. cross-collection refs or aggregates).
  */
 export function computeSubscriptionOrderByHints(
-  query: { orderBy?: OrderBy; limit?: number; offset?: number },
+  query: QueryIR,
   alias: string,
 ): { orderBy: OrderBy | undefined; limit: number | undefined } {
   const { orderBy, limit, offset } = query
@@ -345,14 +345,21 @@ export function computeSubscriptionOrderByHints(
     ? normalizeOrderByPaths(orderBy, alias)
     : undefined
 
-  // Only pass orderBy when it is scoped to this alias and uses simple refs,
-  // to avoid leaking cross-collection paths into backend-specific compilers.
+  // Only pass orderBy when:
+  // 1) it is scoped to this alias and uses simple refs, and
+  // 2) each ref can be traced to a raw source field (not a computed alias).
+  const rootCollection = extractCollectionFromSource(query)
   const canPassOrderBy =
-    normalizedOrderBy?.every((clause) => {
+    normalizedOrderBy?.every((clause, index) => {
       const exp = clause.expression
       if (exp.type !== `ref`) return false
       const path = exp.path
-      return Array.isArray(path) && path.length === 1
+      if (!(Array.isArray(path) && path.length === 1)) return false
+
+      const originalExp = orderBy?.[index]?.expression
+      if (!originalExp || originalExp.type !== `ref`) return false
+
+      return !!followRef(query, originalExp, rootCollection)
     }) ?? false
 
   return {

--- a/packages/db/tests/query/load-subset-subquery.test.ts
+++ b/packages/db/tests/query/load-subset-subquery.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createCollection } from '../../src/collection/index.js'
 import {
   and,
+  coalesce,
   createLiveQueryCollection,
   eq,
   gte,
@@ -264,5 +265,35 @@ describe(`loadSubset with subqueries`, () => {
     ]
 
     expect(lastCall!.orderBy).toEqual(expectedOrderBy)
+  })
+
+  it(`does not pass orderBy/limit to loadSubset for computed subquery orderBy`, async () => {
+    const { collection: ordersCollection, loadSubsetCalls } =
+      createOrdersCollectionWithTracking()
+
+    const subqueryQuery = createLiveQueryCollection((q) => {
+      const prepaidOrderQ = q
+        .from({ prepaidOrder: ordersCollection })
+        .select(({ prepaidOrder }) => ({
+          address_id: prepaidOrder.address_id,
+          sortKey: coalesce(prepaidOrder.scheduled_at, `1970-01-01`),
+        }))
+        .orderBy(({ $selected }) => $selected.sortKey, `desc`)
+        .limit(2)
+
+      return q
+        .from({ charge: chargesCollection })
+        .fullJoin({ prepaidOrder: prepaidOrderQ }, ({ charge, prepaidOrder }) =>
+          eq(charge.address_id, prepaidOrder.address_id),
+        )
+    })
+
+    await subqueryQuery.preload()
+
+    expect(loadSubsetCalls.length).toBeGreaterThan(0)
+    const lastCall = loadSubsetCalls[loadSubsetCalls.length - 1]
+    expect(lastCall).toBeDefined()
+    expect(lastCall!.orderBy).toBeUndefined()
+    expect(lastCall!.limit).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

TLDR: Fixes incorrect `loadSubset` optimization hints when a subquery orders by a computed selected field e.g. `sortKey: coalesce(...)`.

I ran into this when trying to use an `orderBy` field that is a projected/computed alias. That was causing subset loading to use an invalid ordering hint, so the top-N window is built from the wrong subset and I observed query results that looked like limit was being applied before orderBy.

This change makes ref resolution stop at computed select expressions (only pass-through `ref` projections are followed), and only forwards `orderBy` hints when each `orderBy` ref resolves to a real source field.

- Updated `followRef` in `packages/db/src/query/ir.ts` to return `undefined` for computed selected fields.
- Applied the same `followRef` fix in `packages/db/src/query/compiler/index.ts` to keep compiler behavior consistent.
- Tightened `computeSubscriptionOrderByHints` in `packages/db/src/query/live/utils.ts` to validate each `orderBy` ref via `followRef` before passing `orderBy`/`limit` hints to `loadSubset`.
- Added a regression test in `packages/db/tests/query/load-subset-subquery.test.ts` to ensure computed subquery `orderBy` aliases do not forward `orderBy`/`limit` hints.

ETA sample query that shows the issue:

```ts
const pagedQuery = useLiveQuery(
  (q) => {
    // 1) Aggregate child records per parent (derived subquery)
    const latestChildByParent = q
      .from({ child: childCollection })
      .groupBy(({ child }) => child.parentId)
      .select(({ child }) => ({
        parentId: child.parentId,
        latestAt: max(child.createdAt),
      }))

    // 2) Join aggregate back to parent and compute a projected sort alias
    const parentsWithComputedSort = q
      .from({ parent: parentCollection })
      .join(
        { latest: latestChildByParent },
        ({ parent, latest }) => eq(parent.id, latest.parentId),
      )
      .select(({ parent, latest }) => ({
        id: parent.id,
        // computed/projection field (not a raw source column)
        computedSortKey: coalesce(latest.latestAt, parent.createdAt),
      }))

    // 3) Filter + order by computed alias + paginate
    return q
      .from({ row: parentsWithComputedSort })
      .where(({ row }) => gt(row.computedSortKey, anchorDate))
      .orderBy(({ row }) => row.computedSortKey, 'asc')
      .select(({ row }) => ({
        id: row.id,
        computedSortKey: row.computedSortKey,
      }))
      .limit(3)
  },
)

// Expected (ascending by computedSortKey):
// A
// B
// C

// Actual:
// A
// D
// E

// If I increase pageSize to include all rows:
// A
// B
// C
// D
// E
// ...
```

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
