### PR TITLE
test(transactions): demonstrate ambient tx loss across await in mutate()

### DIFF
--- a/packages/db/tests/transactions.test.ts
+++ b/packages/db/tests/transactions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createTransaction } from '../src/transactions'
 import { createCollection } from '../src/collection/index.js'
 import {
@@ -83,6 +83,35 @@ describe(`Transactions`, () => {
     expect(transaction.mutations).toHaveLength(2)
 
     transaction.commit()
+  })
+  // Asserts the docstring on Transaction#mutate: "If the callback returns a
+  // Promise, the transaction context will remain active until the promise
+  // settles, allowing optimistic writes after `await` boundaries."
+  it(`should keep the ambient transaction active across awaits inside mutate()`, async () => {
+    const onInsert = vi.fn(async () => {})
+    const collection = createCollection<{ id: number; value: string }>({
+      id: `ambient-tx-across-await`,
+      getKey: (item) => item.id,
+      onInsert,
+      sync: { sync: () => {} },
+    })
+
+    const transaction = createTransaction({
+      mutationFn: async () => Promise.resolve(),
+      autoCommit: false,
+    })
+
+    transaction.mutate(async () => {
+      collection.insert({ id: 1, value: `before-await` })
+      await Promise.resolve()
+      collection.insert({ id: 2, value: `after-await` })
+    })
+
+    // Let the async callback's microtasks drain.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(transaction.mutations).toHaveLength(2)
+    expect(onInsert).not.toHaveBeenCalled()
   })
   it(`should allow mutating multiple collections`, () => {
     const transaction = createTransaction({


### PR DESCRIPTION
## 🎯 Changes

Adds a test that demonstrates a mismatch between `Transaction#mutate`'s documented contract and its implementation for async callbacks.

### The contract

The docstring on `Transaction#mutate` (`packages/db/src/transactions.ts:248-251`) states:

> If the callback returns a Promise, the transaction context will remain active until the promise settles, allowing optimistic writes after `await` boundaries.

### What actually happens

`mutate()` invokes the callback synchronously and pops the transaction off the ambient stack in a `finally` block (`packages/db/src/transactions.ts:287-298`):

```ts
mutate(callback: () => void): Transaction<T> {
  // ...
  registerTransaction(this)
  try { callback() }                  // not awaited
  finally { unregisterTransaction(this) }
  // ...
}
```

When the callback is `async`, `callback()` returns its Promise at the first `await`, the `finally` fires immediately, and `unregisterTransaction(this)` removes the transaction from `transactionStack` before any post-`await` code runs. Collection operations after the await see no ambient transaction and either throw `MissingInsertHandlerError` (no `onInsert`) or create a brand-new direct transaction via the collection's handler.

Additional signals that the async path is unsupported today:

- The callback parameter is typed `() => void`, not `() => void | Promise<void>`.
- No existing test in `packages/db/tests/` exercises an async `mutate()` callback. The async tests in `transactions.test.ts` cover `mutationFn` and `commit()`, not the `mutate()` callback.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).