### PR TITLE
chore: add codeowners

### DIFF
--- a/.changeset/CODEOWNERS
+++ b/.changeset/CODEOWNERS
@@ -1,0 +1,6 @@
+.github/ @TanStack/tanstack-core
+.nx/ @TanStack/tanstack-core
+nx.json @TanStack/tanstack-core
+.changeset/config.json @TanStack/tanstack-core
+scripts/ @TanStack/tanstack-core
+.npmrc @TanStack/tanstack-core


### PR DESCRIPTION
As part of our ongoing security hardening, we're mandating specific sensitive release files to be approved by the core maintainers team.