### PR TITLE
security: stricter pnpm config blockExoticSubdeps & trustPolicy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 cleanupUnusedCatalogs: true
 linkWorkspacePackages: true
 preferWorkspacePackages: true
-blockExoticSubdeps: false
+blockExoticSubdeps: true
+trustPolicy: 'no-downgrade'
 
 packages:
   - packages/**


### PR DESCRIPTION
## Summary
- Enable pnpm `blockExoticSubdeps`.
- Add pnpm `trustPolicy: 'no-downgrade'`.

## Validation
- `pnpm install --frozen-lockfile` passed using pnpm v11.1.0, so `blockExoticSubdeps` was enabled rather than left false.