### PR TITLE
Title: fix(react-db): add getServerSnapshot to useSyncExternalStore for React 19 SSR

### DIFF
--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -20,6 +20,11 @@ import type {
 
 const DEFAULT_GC_TIME_MS = 1 // Live queries created by useLiveQuery are cleaned up immediately (0 disables GC)
 
+// Module-level constant so React 19 receives a stable object reference for the
+// server snapshot. Creating this inside the hook would produce a new reference
+// on every render, causing an infinite loop during SSR/hydration.
+const SERVER_SNAPSHOT = { collection: null, version: 0 } as const
+
 export type UseLiveQueryStatus = CollectionStatus | `disabled`
 
 /**
@@ -483,6 +488,7 @@ export function useLiveQuery(
   const snapshot = useSyncExternalStore(
     subscribeRef.current,
     getSnapshotRef.current,
+    () => SERVER_SNAPSHOT,
   )
 
   // Track last snapshot (from useSyncExternalStore) and the returned value separately


### PR DESCRIPTION
React 19 requires `useSyncExternalStore` to receive a third argument (`getServerSnapshot`) when used in SSR/server component contexts (Next.js App Router). Without it, the app throws during hydration or enters an infinite render loop.

The fix adds a module-level `SERVER_SNAPSHOT` constant passed as the third argument. It must be module-level — a new object created inside the hook on each render would fail React 19's stability check and cause an infinite loop.

Reproduces with: Next.js 15/16 + React 19 + `@tanstack/react-db` in any SSR route that uses `useLiveQuery`.

## 🎯 Changes

- Added `SERVER_SNAPSHOT` module-level constant in `useLiveQuery`
- Passed it as the third argument to `useSyncExternalStore` to satisfy React 19's SSR requirements
- Prevents hydration errors and infinite render loops in Next.js App Router with React 19

## ✅ Checklist

- [x] Fix verified in Next.js 16 + React 19 App Router environment
- [x] No changeset needed — patch fix to existing hook, no API surface change
- [x] Existing tests pass

## 🚀 Release Impact

Patch release. No API changes. Fixes a crash/loop for all users on React 19 + SSR.