### PR TITLE
docs(db): clarify mutate callback is sync-only

### DIFF
--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -245,9 +245,12 @@ class Transaction<T extends object = Record<string, unknown>> {
 
   /**
    * Execute collection operations within this transaction
-   * @param callback - Function containing collection operations to group together. If the
-   * callback returns a Promise, the transaction context will remain active until the promise
-   * settles, allowing optimistic writes after `await` boundaries.
+   * @param callback - Synchronous function containing collection operations to group together.
+   * The transaction context is active only for the synchronous duration of this callback.
+   * Async work should happen in `mutationFn`; collection operations after `await` boundaries
+   * inside this callback will not be part of this transaction. For manual transactions, call
+   * `mutate` multiple times before committing to add more synchronous operations to the same
+   * transaction.
    * @returns This transaction for chaining
    * @example
    * // Group multiple operations
@@ -279,6 +282,11 @@ class Transaction<T extends object = Record<string, unknown>> {
    *
    * tx.mutate(() => {
    *   collection.insert({ id: "1", text: "Item" })
+   * })
+   *
+   * // Add more synchronous mutations to the same transaction
+   * tx.mutate(() => {
+   *   collection.update("1", draft => { draft.text = "Updated item" })
    * })
    *
    * // Commit later when ready


### PR DESCRIPTION
## Summary

Clarifies the `Transaction#mutate` docstring to match the current intended behavior:

- `mutate` callbacks are synchronous optimistic-write scopes only.
- The transaction context is active only for the synchronous duration of the callback.
- Collection operations after `await` boundaries are not part of the transaction.
- Async persistence work belongs in `mutationFn`.
- Manual transactions can call `mutate` multiple times before committing to add more synchronous operations to the same transaction.

This resolves the documentation mismatch highlighted by #1522 without changing runtime behavior.

## Testing

Not run; documentation-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that transaction context is only active during synchronous code execution and is not maintained across asynchronous boundaries within transaction callbacks.
  * Added example demonstrating how to perform multiple synchronous mutations within transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->