### PR TITLE
fix(query-db-collection, trailbase-db-collection): add electric path alias for typecheck

### DIFF
--- a/packages/query-db-collection/tsconfig.json
+++ b/packages/query-db-collection/tsconfig.json
@@ -16,7 +16,8 @@
       "@tanstack/db": ["../db/src"],
       "@tanstack/db-ivm": ["../db-ivm/src"],
       "@tanstack/offline-transactions": ["../offline-transactions/src"],
-      "@tanstack/db-collection-e2e": ["../db-collection-e2e/src"]
+      "@tanstack/db-collection-e2e": ["../db-collection-e2e/src"],
+      "@tanstack/electric-db-collection": ["../electric-db-collection/src"]
     }
   },
   "include": [

--- a/packages/trailbase-db-collection/tsconfig.json
+++ b/packages/trailbase-db-collection/tsconfig.json
@@ -16,7 +16,8 @@
       "@tanstack/store": ["../store/src"],
       "@tanstack/db-ivm": ["../db-ivm/src"],
       "@tanstack/db": ["../db/src"],
-      "@tanstack/db-collection-e2e": ["../db-collection-e2e/src"]
+      "@tanstack/db-collection-e2e": ["../db-collection-e2e/src"],
+      "@tanstack/electric-db-collection": ["../electric-db-collection/src"]
     }
   },
   "include": ["src", "tests", "e2e", "vite.config.ts", "vitest.e2e.config.ts"],


### PR DESCRIPTION
Fresh clone of main, `pnpm --filter @tanstack/query-db-collection test` errors out before any test runs — the e2e suites barrel re-exports `moves.suite.ts` / `progressive.suite.ts`, both of which import `@tanstack/electric-db-collection`, but the path alias for electric is missing from this tsconfig (and from `trailbase-db-collection`'s too).

Adding the alias matches the existing pattern. After the change, `pnpm --filter @tanstack/query-db-collection test` is back to 190/190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript module path aliases in package configurations to support new module resolution patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->