### PR TITLE
docs(db): clarify caseWhen, coalesce, manual transactions, and multi-endpoint behavior

### DIFF
--- a/.changeset/docs-feedback-clarifications.md
+++ b/.changeset/docs-feedback-clarifications.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Clarify documentation for caseWhen, coalesce, manual transactions, and multi-endpoint Query Collection behavior. Add utility function categorization and fix reference index ordering.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -486,7 +486,8 @@ matches your API semantics:
   and `offset`) are passed to your `queryFn` via `ctx.meta.loadSubsetOptions`,
   letting you translate them into API parameters.
 - Use separate Query Collections when endpoints represent distinct server scopes
-  whose results should not replace each other.
+  whose results should not replace each other. Use `unionAll` to combine them
+  into a single query when you need a unified view across endpoints.
 - Use direct writes such as `writeUpsert`/`writeBatch` for lower-level
   incremental loading when you intentionally want to merge server responses into
   the synced store yourself.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -471,6 +471,26 @@ The query collection treats the `queryFn` result as the **complete state** of th
 - Items in the query result but not in the collection will be inserted
 - Items present in both will be updated if they differ
 
+This is important when the same entity type can be loaded from multiple REST
+endpoints. For example, do not point the same Query Collection at
+`/api/documents/preview` for one load and `/api/documents/deleted` for another
+unless each result represents the complete state for that collection
+scope. A narrower endpoint can otherwise remove rows that were loaded from a
+different endpoint.
+
+For multiple endpoint or subset-loading use cases, choose the pattern that
+matches your API semantics:
+
+- Use `syncMode: 'on-demand'` when one logical collection can serve different
+  subsets of data. In this mode, query predicates (`where`, `orderBy`, `limit`,
+  and `offset`) are passed to your `queryFn` via `ctx.meta.loadSubsetOptions`,
+  letting you translate them into API parameters.
+- Use separate Query Collections when endpoints represent distinct server scopes
+  whose results should not replace each other.
+- Use direct writes such as `writeUpsert`/`writeBatch` for lower-level
+  incremental loading when you intentionally want to merge server responses into
+  the synced store yourself.
+
 ### Empty Array Behavior
 
 When `queryFn` returns an empty array, **all items in the collection will be deleted**. This is because the collection interprets an empty array as "the server has no items".

--- a/docs/guides/live-queries.md
+++ b/docs/guides/live-queries.md
@@ -2551,11 +2551,56 @@ Add two numbers:
 add(user.salary, user.bonus)
 ```
 
+### Utility Functions
+
 #### `coalesce(...values)`
-Return the first non-null value:
+Return the first non-null/undefined value:
 ```ts
 coalesce(user.displayName, user.name, 'Unknown')
 ```
+
+This is useful for display fallbacks when the stored value is `null` or
+`undefined`:
+
+```ts
+.select(({ document }) => ({
+  ...document,
+  displayTitle: coalesce(document.title, 'Untitled document'),
+}))
+```
+
+If you also need to treat another value, such as an empty string, as missing,
+use `caseWhen` to express that condition explicitly.
+
+#### `caseWhen(condition, value, ...)`
+Return the value for the first matching condition, similar to SQL `CASE WHEN`.
+Arguments are provided as condition/value pairs followed by an optional default
+value:
+
+```ts
+caseWhen(gt(user.age, 65), 'senior', gt(user.age, 18), 'adult', 'minor')
+```
+
+If no condition matches and no default value is provided, scalar expressions
+return `null`.
+
+Use `caseWhen` when a computed field needs conditional logic that cannot be
+represented with `coalesce` alone. For example, to display a fallback for both
+`null`/`undefined` and empty-string titles:
+
+```ts
+.select(({ document }) => ({
+  ...document,
+  displayTitle: caseWhen(
+    eq(coalesce(document.title, ''), ''),
+    'Untitled document',
+    document.title,
+  ),
+}))
+```
+
+`caseWhen` can also be used in expression contexts such as `select`, `where`,
+`orderBy`, `groupBy`, `having`, and equality join operands.
 
 ### Aggregate Functions
 

--- a/docs/guides/mutations.md
+++ b/docs/guides/mutations.md
@@ -796,34 +796,11 @@ manual transaction's `mutationFn` is responsible for persisting
 
 This makes manual transactions a good fit for draft-style workflows where local
 state should update immediately, but persistence should wait for a later user
-action such as Save or Blur:
-
-```ts
-const editTx = createTransaction({
-  autoCommit: false,
-  mutationFn: async ({ transaction }) => {
-    await api.updateTodos(
-      transaction.mutations.map((mutation) => ({
-        id: mutation.key,
-        changes: mutation.changes,
-      }))
-    )
-  },
-})
-
-// Update local optimistic state while the user edits.
-editTx.mutate(() => {
-  todoCollection.update(todoId, (draft) => {
-    draft.text = nextText
-  })
-})
-
-// Later, when the user saves or the input blurs:
-await editTx.commit()
-
-// Or discard the local optimistic changes:
-// editTx.rollback()
-```
+action such as Save or Blur. Each `tx.mutate()` call updates the optimistic
+state instantly, so the UI reflects changes as the user types. When the user
+triggers Save, `tx.commit()` fires the `mutationFn` to persist all accumulated
+mutations in a single batch. If the user cancels instead, `tx.rollback()`
+discards the optimistic changes and reverts the UI.
 
 ### Multi-Step Workflows
 

--- a/docs/guides/mutations.md
+++ b/docs/guides/mutations.md
@@ -788,6 +788,43 @@ await tx.commit()
 tx.rollback()
 ```
 
+When you call collection methods inside `tx.mutate()`, the mutations are
+captured by the manual transaction. The collection's `onInsert`, `onUpdate`, and
+`onDelete` handlers are not invoked for those mutations; the
+manual transaction's `mutationFn` is responsible for persisting
+`transaction.mutations`.
+
+This makes manual transactions a good fit for draft-style workflows where local
+state should update immediately, but persistence should wait for a later user
+action such as Save or Blur:
+
+```ts
+const editTx = createTransaction({
+  autoCommit: false,
+  mutationFn: async ({ transaction }) => {
+    await api.updateTodos(
+      transaction.mutations.map((mutation) => ({
+        id: mutation.key,
+        changes: mutation.changes,
+      }))
+    )
+  },
+})
+
+// Update local optimistic state while the user edits.
+editTx.mutate(() => {
+  todoCollection.update(todoId, (draft) => {
+    draft.text = nextText
+  })
+})
+
+// Later, when the user saves or the input blurs:
+await editTx.commit()
+
+// Or discard the local optimistic changes:
+// editTx.rollback()
+```
+
 ### Multi-Step Workflows
 
 Manual transactions excel at complex workflows:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -265,6 +265,7 @@ title: "@tanstack/db"
 - [add](functions/add.md)
 - [and](functions/and.md)
 - [avg](functions/avg.md)
+- [caseWhen](functions/caseWhen.md)
 - [clearQueryPatterns](functions/clearQueryPatterns.md)
 - [coalesce](functions/coalesce.md)
 - [compileExpression](functions/compileExpression.md)

--- a/docs/reference/variables/operators.md
+++ b/docs/reference/variables/operators.md
@@ -6,9 +6,9 @@ title: operators
 # Variable: operators
 
 ```ts
-const operators: readonly ["eq", "gt", "gte", "lt", "lte", "in", "like", "ilike", "and", "or", "not", "isNull", "isUndefined", "upper", "lower", "length", "concat", "add", "coalesce", "count", "avg", "sum", "min", "max"];
+const operators: readonly ["eq", "gt", "gte", "lt", "lte", "in", "like", "ilike", "and", "or", "not", "isNull", "isUndefined", "upper", "lower", "length", "concat", "add", "coalesce", "caseWhen", "count", "avg", "sum", "min", "max"];
 ```
 
-Defined in: [packages/db/src/query/builder/functions.ts:403](https://github.com/TanStack/db/blob/main/packages/db/src/query/builder/functions.ts#L403)
+Defined in: [packages/db/src/query/builder/functions.ts](https://github.com/TanStack/db/blob/main/packages/db/src/query/builder/functions.ts)
 
 All supported operator names in TanStack DB expressions

--- a/packages/db/skills/db-core/live-queries/SKILL.md
+++ b/packages/db/skills/db-core/live-queries/SKILL.md
@@ -5,8 +5,8 @@ description: >
   fullJoin, select, fn.select, groupBy, having, orderBy, limit, offset, distinct,
   findOne. Operators: eq, gt, gte, lt, lte, like, ilike, inArray, isNull,
   isUndefined, and, or, not. Aggregates: count, sum, avg, min, max. String
-  functions: upper, lower, length, concat, coalesce. Math: add. $selected
-  namespace. createLiveQueryCollection. Derived collections. Predicate push-down.
+  functions: upper, lower, length, concat. Utility: coalesce, caseWhen. Math: add.
+  $selected namespace. createLiveQueryCollection. Derived collections. Predicate push-down.
   Incremental view maintenance via differential dataflow (d2ts). Virtual
   properties ($synced, $origin, $key, $collectionId). Includes subqueries
   for hierarchical data. toArray and concat(toArray(...)) scalar includes.
@@ -385,7 +385,7 @@ const { data } = useLiveQuery((q) =>
 
 ### HIGH: Not using the full operator set
 
-The library provides string functions (`upper`, `lower`, `length`, `concat`), math (`add`), utility (`coalesce`), and aggregates (`count`, `sum`, `avg`, `min`, `max`). All are incrementally maintained. Prefer them over JS equivalents.
+The library provides string functions (`upper`, `lower`, `length`, `concat`), math (`add`), utility functions (`coalesce`, `caseWhen`), and aggregates (`count`, `sum`, `avg`, `min`, `max`). All are incrementally maintained. Prefer them over JS equivalents.
 
 ```ts
 // WRONG
@@ -398,8 +398,39 @@ The library provides string functions (`upper`, `lower`, `length`, `concat`), ma
 .select(({ user, order }) => ({
   name: upper(user.name),
   total: add(order.price, order.tax),
+  displayName: coalesce(user.displayName, user.name, 'Unknown'),
 }))
 ```
+
+### HIGH: Missing conditional expression helpers
+
+Use `coalesce()` for null/undefined fallbacks and `caseWhen()` for conditional
+computed fields. JavaScript operators like `||` or ternaries do not build query
+expressions inside standard `.select()` callbacks.
+
+```ts
+// WRONG -- document.title is a query ref, not a runtime string
+.select(({ document }) => ({
+  displayTitle: document.title || 'Untitled document',
+}))
+
+// CORRECT -- fallback for null/undefined
+.select(({ document }) => ({
+  displayTitle: coalesce(document.title, 'Untitled document'),
+}))
+
+// CORRECT -- fallback for null/undefined and empty string
+.select(({ document }) => ({
+  displayTitle: caseWhen(
+    eq(coalesce(document.title, ''), ''),
+    'Untitled document',
+    document.title,
+  ),
+}))
+```
+
+Use `fn.select()` only when you genuinely need arbitrary JavaScript; it cannot
+be optimized like expression-based `.select()`.
 
 ### HIGH: .distinct() without .select()
 

--- a/packages/db/skills/db-core/mutations-optimistic/SKILL.md
+++ b/packages/db/skills/db-core/mutations-optimistic/SKILL.md
@@ -209,6 +209,14 @@ Inside `tx.mutate(() => { ... })`, the transaction is pushed onto an ambient
 stack. Any `collection.insert/update/delete` call joins the ambient transaction
 automatically via `getActiveTransaction()`.
 
+For mutations captured by a manual transaction, collection-level
+`onInsert`/`onUpdate`/`onDelete` handlers are not invoked automatically. The
+manual transaction's `mutationFn` is responsible for persisting
+`transaction.mutations`. This makes `createTransaction({ autoCommit: false })`
+a good fit for draft-style flows where local state updates immediately but the
+server call waits for Save/Blur; call `tx.rollback()` to discard the optimistic
+changes.
+
 ### 4. Mutation handler with refetch (QueryCollection pattern)
 
 ```ts


### PR DESCRIPTION
## Summary

Addresses documentation feedback by clarifying several areas where users were confused or the docs were incomplete:

- Document the new `caseWhen` operator with examples and usage guidance
- Clarify that `coalesce` handles both `null` and `undefined` (not just `null`)
- Explain that manual transaction mutations bypass collection-level `onInsert`/`onUpdate`/`onDelete` handlers, with a draft-style workflow example
- Warn about multi-endpoint Query Collection pitfalls when the same collection receives data from different REST endpoints

## Approach

These changes address real confusion points reported via feedback. Each addition follows the existing doc patterns: prose explanation followed by code examples showing WRONG vs CORRECT usage where applicable.

**Key decisions:**
- Added a new "Utility Functions" heading in the live queries guide to properly categorize `coalesce` and `caseWhen` (previously both were under "Mathematical Functions")
- Fixed the SKILL.md frontmatter to categorize `coalesce`/`caseWhen` as utility functions rather than string functions — important since LLMs read frontmatter for relevance
- Removed the stale line-number anchor from `operators.md` source link to prevent future rot
- Fixed `caseWhen` alphabetical ordering in the reference index

**Non-goals:**
- Did not restructure existing documentation sections beyond the minimal heading addition
- Did not add the untracked `docs/reference/functions/caseWhen.md` file (separate concern)

## Files changed

| File | Change |
|------|--------|
| `docs/collections/query-collection.md` | Multi-endpoint pitfall warning + three recommended patterns |
| `docs/guides/live-queries.md` | `coalesce` examples, `caseWhen` docs, new "Utility Functions" heading |
| `docs/guides/mutations.md` | Manual transaction handler bypass explanation + draft workflow example |
| `docs/reference/index.md` | Added `caseWhen` in correct alphabetical position |
| `docs/reference/variables/operators.md` | Added `caseWhen` to operators list, removed stale line anchor |
| `packages/db/skills/db-core/live-queries/SKILL.md` | Updated frontmatter categorization, added conditional expression helpers section |
| `packages/db/skills/db-core/mutations-optimistic/SKILL.md` | Added note about manual transactions bypassing collection handlers |

## Verification

These are documentation-only changes with no runtime impact.

```bash
# Verify docs build
pnpm docs:build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Query Collection full-state requirement and safe multi-endpoint/subset-loading patterns
  * Expanded coalesce behavior and added comprehensive caseWhen docs with examples and usage across query clauses; added caseWhen to reference and operators lists
  * Clarified manual transactions: how captured mutations interact with collection handlers, optimistic flows, commit/rollback examples
  * Reorganized utility-function guidance and improved reference ordering and documentation organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->