### PR TITLE
fix(db): drop stale direct optimistic rows after txid sync

### DIFF
--- a/.changeset/fix-stale-optimistic-server-key.md
+++ b/.changeset/fix-stale-optimistic-server-key.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Fix stale optimistic rows persisting when sync confirms a different server-generated key. Previously, direct transactions (from `collection.insert()` etc.) had their optimistic rows exempted from stale-row cleanup, which prevented temp-key rows from being removed when the server returned a different primary key.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22.13'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This guide provides principles and patterns for AI agents contributing to the Ta
 8. [Function Design](#function-design)
 9. [Modern JavaScript Patterns](#modern-javascript-patterns)
 10. [Edge Cases and Corner Cases](#edge-cases-and-corner-cases)
+11. [Git and PR Hygiene](#git-and-pr-hygiene)
 
 ## Type Safety
 
@@ -562,6 +563,37 @@ const filtered = items.filter((item) => item.value > 0)
    // But snapshot resolves after up-to-date arrives
    // Should ignore the stale snapshot
    ```
+
+## Git and PR Hygiene
+
+### Never Rewrite Published Branch History
+
+**Do not amend, rebase, squash, or force-push a branch after it has been pushed or has an open PR.** This includes `git push --force` and `git push --force-with-lease`.
+
+Once a branch is visible to others, treat its history as shared. If CI fails or follow-up changes are needed, add a normal follow-up commit and push normally.
+
+**❌ Bad:**
+
+```bash
+git commit --amend --no-edit
+git push --force-with-lease
+```
+
+**✅ Good:**
+
+```bash
+git add <files>
+git commit -m "fix: address CI failure"
+git push
+```
+
+**Key Principles:**
+
+- Never force-push unless the user explicitly asks for it in that moment.
+- Do not assume `--force-with-lease` is acceptable; it still rewrites shared history.
+- Prefer small follow-up commits over rewritten history on PR branches.
+- If a clean history is desired, let the human maintainer squash or rebase during merge.
+- If you think history rewriting is necessary, stop and ask for explicit confirmation before running any command.
 
 ## Package Versioning
 

--- a/packages/db/src/collection/mutations.ts
+++ b/packages/db/src/collection/mutations.ts
@@ -17,6 +17,7 @@ import {
   UndefinedKeyError,
   UpdateKeyNotFoundError,
 } from '../errors'
+import { DIRECT_TRANSACTION_METADATA_KEY } from './transaction-metadata.js'
 import type { Collection, CollectionImpl } from './index.js'
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type {
@@ -230,7 +231,7 @@ export class CollectionMutationsManager<
     } else {
       // Create a new transaction with a mutation function that calls the onInsert handler
       const directOpTransaction = createTransaction<TOutput>({
-        metadata: {},
+        metadata: { [DIRECT_TRANSACTION_METADATA_KEY]: true },
         mutationFn: async (params) => {
           // Call the onInsert handler with the transaction and collection
           return await this.config.onInsert!({
@@ -427,7 +428,7 @@ export class CollectionMutationsManager<
 
     // Create a new transaction with a mutation function that calls the onUpdate handler
     const directOpTransaction = createTransaction<TOutput>({
-      metadata: {},
+      metadata: { [DIRECT_TRANSACTION_METADATA_KEY]: true },
       mutationFn: async (params) => {
         // Call the onUpdate handler with the transaction and collection
         return this.config.onUpdate!({
@@ -531,7 +532,7 @@ export class CollectionMutationsManager<
     // Create a new transaction with a mutation function that calls the onDelete handler
     const directOpTransaction = createTransaction<TOutput>({
       autoCommit: true,
-      metadata: {},
+      metadata: { [DIRECT_TRANSACTION_METADATA_KEY]: true },
       mutationFn: async (params) => {
         // Call the onDelete handler with the transaction and collection
         return this.config.onDelete!({

--- a/packages/db/src/collection/mutations.ts
+++ b/packages/db/src/collection/mutations.ts
@@ -17,7 +17,6 @@ import {
   UndefinedKeyError,
   UpdateKeyNotFoundError,
 } from '../errors'
-import { DIRECT_TRANSACTION_METADATA_KEY } from './transaction-metadata.js'
 import type { Collection, CollectionImpl } from './index.js'
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type {
@@ -231,9 +230,7 @@ export class CollectionMutationsManager<
     } else {
       // Create a new transaction with a mutation function that calls the onInsert handler
       const directOpTransaction = createTransaction<TOutput>({
-        metadata: {
-          [DIRECT_TRANSACTION_METADATA_KEY]: true,
-        },
+        metadata: {},
         mutationFn: async (params) => {
           // Call the onInsert handler with the transaction and collection
           return await this.config.onInsert!({
@@ -430,9 +427,7 @@ export class CollectionMutationsManager<
 
     // Create a new transaction with a mutation function that calls the onUpdate handler
     const directOpTransaction = createTransaction<TOutput>({
-      metadata: {
-        [DIRECT_TRANSACTION_METADATA_KEY]: true,
-      },
+      metadata: {},
       mutationFn: async (params) => {
         // Call the onUpdate handler with the transaction and collection
         return this.config.onUpdate!({
@@ -536,9 +531,7 @@ export class CollectionMutationsManager<
     // Create a new transaction with a mutation function that calls the onDelete handler
     const directOpTransaction = createTransaction<TOutput>({
       autoCommit: true,
-      metadata: {
-        [DIRECT_TRANSACTION_METADATA_KEY]: true,
-      },
+      metadata: {},
       mutationFn: async (params) => {
         // Call the onDelete handler with the transaction and collection
         return this.config.onDelete!({

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -1,6 +1,7 @@
 import { deepEquals } from '../utils'
 import { SortedMap } from '../SortedMap'
 import { enrichRowWithVirtualProps } from '../virtual-props.js'
+import { DIRECT_TRANSACTION_METADATA_KEY } from './transaction-metadata.js'
 import type {
   VirtualOrigin,
   VirtualRowProps,
@@ -80,6 +81,8 @@ export class CollectionStateManager<
   public optimisticDeletes = new Set<TKey>()
   public pendingOptimisticUpserts = new Map<TKey, TOutput>()
   public pendingOptimisticDeletes = new Set<TKey>()
+  public pendingOptimisticDirectUpserts = new Set<TKey>()
+  public pendingOptimisticDirectDeletes = new Set<TKey>()
 
   /**
    * Tracks the origin of confirmed changes for each row.
@@ -477,6 +480,8 @@ export class CollectionStateManager<
 
     // Update pending optimistic state for completed/failed transactions
     for (const transaction of this.transactions.values()) {
+      const isDirectTransaction =
+        transaction.metadata[DIRECT_TRANSACTION_METADATA_KEY] === true
       if (transaction.state === `completed`) {
         for (const mutation of transaction.mutations) {
           if (!this.isThisCollection(mutation.collection)) {
@@ -494,10 +499,24 @@ export class CollectionStateManager<
                 mutation.modified as TOutput,
               )
               this.pendingOptimisticDeletes.delete(mutation.key)
+              if (isDirectTransaction) {
+                this.pendingOptimisticDirectUpserts.add(mutation.key)
+                this.pendingOptimisticDirectDeletes.delete(mutation.key)
+              } else {
+                this.pendingOptimisticDirectUpserts.delete(mutation.key)
+                this.pendingOptimisticDirectDeletes.delete(mutation.key)
+              }
               break
             case `delete`:
               this.pendingOptimisticUpserts.delete(mutation.key)
               this.pendingOptimisticDeletes.add(mutation.key)
+              if (isDirectTransaction) {
+                this.pendingOptimisticDirectUpserts.delete(mutation.key)
+                this.pendingOptimisticDirectDeletes.add(mutation.key)
+              } else {
+                this.pendingOptimisticDirectUpserts.delete(mutation.key)
+                this.pendingOptimisticDirectDeletes.delete(mutation.key)
+              }
               break
           }
         }
@@ -510,6 +529,8 @@ export class CollectionStateManager<
           if (mutation.optimistic) {
             this.pendingOptimisticUpserts.delete(mutation.key)
             this.pendingOptimisticDeletes.delete(mutation.key)
+            this.pendingOptimisticDirectUpserts.delete(mutation.key)
+            this.pendingOptimisticDirectDeletes.delete(mutation.key)
           }
         }
       }
@@ -527,11 +548,35 @@ export class CollectionStateManager<
         pendingSyncKeys.add(operation.key as TKey)
       }
     }
+    const staleOptimisticUpserts: Array<TKey> = []
     for (const [key, value] of this.pendingOptimisticUpserts) {
-      this.optimisticUpserts.set(key, value)
+      if (
+        pendingSyncKeys.has(key) ||
+        this.pendingOptimisticDirectUpserts.has(key)
+      ) {
+        this.optimisticUpserts.set(key, value)
+      } else {
+        staleOptimisticUpserts.push(key)
+      }
     }
+    for (const key of staleOptimisticUpserts) {
+      this.pendingOptimisticUpserts.delete(key)
+      this.pendingLocalOrigins.delete(key)
+    }
+    const staleOptimisticDeletes: Array<TKey> = []
     for (const key of this.pendingOptimisticDeletes) {
-      this.optimisticDeletes.add(key)
+      if (
+        pendingSyncKeys.has(key) ||
+        this.pendingOptimisticDirectDeletes.has(key)
+      ) {
+        this.optimisticDeletes.add(key)
+      } else {
+        staleOptimisticDeletes.push(key)
+      }
+    }
+    for (const key of staleOptimisticDeletes) {
+      this.pendingOptimisticDeletes.delete(key)
+      this.pendingLocalOrigins.delete(key)
     }
 
     const activeTransactions: Array<Transaction<any>> = []
@@ -942,6 +987,8 @@ export class CollectionStateManager<
               this.pendingLocalOrigins.delete(key)
               this.pendingOptimisticUpserts.delete(key)
               this.pendingOptimisticDeletes.delete(key)
+              this.pendingOptimisticDirectUpserts.delete(key)
+              this.pendingOptimisticDirectDeletes.delete(key)
               break
             case `update`: {
               if (rowUpdateMode === `partial`) {
@@ -960,6 +1007,8 @@ export class CollectionStateManager<
               this.pendingLocalOrigins.delete(key)
               this.pendingOptimisticUpserts.delete(key)
               this.pendingOptimisticDeletes.delete(key)
+              this.pendingOptimisticDirectUpserts.delete(key)
+              this.pendingOptimisticDirectDeletes.delete(key)
               break
             }
             case `delete`:
@@ -971,6 +1020,8 @@ export class CollectionStateManager<
               this.pendingLocalOrigins.delete(key)
               this.pendingOptimisticUpserts.delete(key)
               this.pendingOptimisticDeletes.delete(key)
+              this.pendingOptimisticDirectUpserts.delete(key)
+              this.pendingOptimisticDirectDeletes.delete(key)
               break
           }
         }
@@ -1113,23 +1164,28 @@ export class CollectionStateManager<
       // the sync confirmation used a different server-generated key. Once a
       // sync commit has been applied, stop retaining completed optimistic keys
       // that were not confirmed by this commit so the temporary row is removed.
-      for (const [key, previousValue] of this.pendingOptimisticUpserts) {
+      for (const key of this.pendingOptimisticDirectUpserts) {
         if (!changedKeys.has(key)) {
           changedKeys.add(key)
           if (!currentVisibleState.has(key)) {
-            currentVisibleState.set(key, previousValue)
+            const previousValue = previousOptimisticUpserts.get(key)
+            if (previousValue !== undefined) {
+              currentVisibleState.set(key, previousValue)
+            }
           }
           this.pendingOptimisticUpserts.delete(key)
           this.pendingLocalOrigins.delete(key)
         }
       }
-      for (const key of this.pendingOptimisticDeletes) {
+      for (const key of this.pendingOptimisticDirectDeletes) {
         if (!changedKeys.has(key)) {
           changedKeys.add(key)
         }
         this.pendingOptimisticDeletes.delete(key)
         this.pendingLocalOrigins.delete(key)
       }
+      this.pendingOptimisticDirectUpserts.clear()
+      this.pendingOptimisticDirectDeletes.clear()
 
       // Now check what actually changed in the final visible state
       for (const key of changedKeys) {
@@ -1349,6 +1405,8 @@ export class CollectionStateManager<
     this.optimisticDeletes.clear()
     this.pendingOptimisticUpserts.clear()
     this.pendingOptimisticDeletes.clear()
+    this.pendingOptimisticDirectUpserts.clear()
+    this.pendingOptimisticDirectDeletes.clear()
     this.clearOriginTrackingState()
     this.isLocalOnly = false
     this.size = 0

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -1,7 +1,6 @@
 import { deepEquals } from '../utils'
 import { SortedMap } from '../SortedMap'
 import { enrichRowWithVirtualProps } from '../virtual-props.js'
-import { DIRECT_TRANSACTION_METADATA_KEY } from './transaction-metadata.js'
 import type {
   VirtualOrigin,
   VirtualRowProps,
@@ -81,8 +80,6 @@ export class CollectionStateManager<
   public optimisticDeletes = new Set<TKey>()
   public pendingOptimisticUpserts = new Map<TKey, TOutput>()
   public pendingOptimisticDeletes = new Set<TKey>()
-  public pendingOptimisticDirectUpserts = new Set<TKey>()
-  public pendingOptimisticDirectDeletes = new Set<TKey>()
 
   /**
    * Tracks the origin of confirmed changes for each row.
@@ -480,8 +477,6 @@ export class CollectionStateManager<
 
     // Update pending optimistic state for completed/failed transactions
     for (const transaction of this.transactions.values()) {
-      const isDirectTransaction =
-        transaction.metadata[DIRECT_TRANSACTION_METADATA_KEY] === true
       if (transaction.state === `completed`) {
         for (const mutation of transaction.mutations) {
           if (!this.isThisCollection(mutation.collection)) {
@@ -499,24 +494,10 @@ export class CollectionStateManager<
                 mutation.modified as TOutput,
               )
               this.pendingOptimisticDeletes.delete(mutation.key)
-              if (isDirectTransaction) {
-                this.pendingOptimisticDirectUpserts.add(mutation.key)
-                this.pendingOptimisticDirectDeletes.delete(mutation.key)
-              } else {
-                this.pendingOptimisticDirectUpserts.delete(mutation.key)
-                this.pendingOptimisticDirectDeletes.delete(mutation.key)
-              }
               break
             case `delete`:
               this.pendingOptimisticUpserts.delete(mutation.key)
               this.pendingOptimisticDeletes.add(mutation.key)
-              if (isDirectTransaction) {
-                this.pendingOptimisticDirectUpserts.delete(mutation.key)
-                this.pendingOptimisticDirectDeletes.add(mutation.key)
-              } else {
-                this.pendingOptimisticDirectUpserts.delete(mutation.key)
-                this.pendingOptimisticDirectDeletes.delete(mutation.key)
-              }
               break
           }
         }
@@ -529,8 +510,6 @@ export class CollectionStateManager<
           if (mutation.optimistic) {
             this.pendingOptimisticUpserts.delete(mutation.key)
             this.pendingOptimisticDeletes.delete(mutation.key)
-            this.pendingOptimisticDirectUpserts.delete(mutation.key)
-            this.pendingOptimisticDirectDeletes.delete(mutation.key)
           }
         }
       }
@@ -550,10 +529,7 @@ export class CollectionStateManager<
     }
     const staleOptimisticUpserts: Array<TKey> = []
     for (const [key, value] of this.pendingOptimisticUpserts) {
-      if (
-        pendingSyncKeys.has(key) ||
-        this.pendingOptimisticDirectUpserts.has(key)
-      ) {
+      if (pendingSyncKeys.has(key)) {
         this.optimisticUpserts.set(key, value)
       } else {
         staleOptimisticUpserts.push(key)
@@ -565,10 +541,7 @@ export class CollectionStateManager<
     }
     const staleOptimisticDeletes: Array<TKey> = []
     for (const key of this.pendingOptimisticDeletes) {
-      if (
-        pendingSyncKeys.has(key) ||
-        this.pendingOptimisticDirectDeletes.has(key)
-      ) {
+      if (pendingSyncKeys.has(key)) {
         this.optimisticDeletes.add(key)
       } else {
         staleOptimisticDeletes.push(key)
@@ -987,8 +960,6 @@ export class CollectionStateManager<
               this.pendingLocalOrigins.delete(key)
               this.pendingOptimisticUpserts.delete(key)
               this.pendingOptimisticDeletes.delete(key)
-              this.pendingOptimisticDirectUpserts.delete(key)
-              this.pendingOptimisticDirectDeletes.delete(key)
               break
             case `update`: {
               if (rowUpdateMode === `partial`) {
@@ -1007,8 +978,6 @@ export class CollectionStateManager<
               this.pendingLocalOrigins.delete(key)
               this.pendingOptimisticUpserts.delete(key)
               this.pendingOptimisticDeletes.delete(key)
-              this.pendingOptimisticDirectUpserts.delete(key)
-              this.pendingOptimisticDirectDeletes.delete(key)
               break
             }
             case `delete`:
@@ -1020,8 +989,6 @@ export class CollectionStateManager<
               this.pendingLocalOrigins.delete(key)
               this.pendingOptimisticUpserts.delete(key)
               this.pendingOptimisticDeletes.delete(key)
-              this.pendingOptimisticDirectUpserts.delete(key)
-              this.pendingOptimisticDirectDeletes.delete(key)
               break
           }
         }
@@ -1378,8 +1345,6 @@ export class CollectionStateManager<
     this.optimisticDeletes.clear()
     this.pendingOptimisticUpserts.clear()
     this.pendingOptimisticDeletes.clear()
-    this.pendingOptimisticDirectUpserts.clear()
-    this.pendingOptimisticDirectDeletes.clear()
     this.clearOriginTrackingState()
     this.isLocalOnly = false
     this.size = 0

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -527,29 +527,11 @@ export class CollectionStateManager<
         pendingSyncKeys.add(operation.key as TKey)
       }
     }
-    const staleOptimisticUpserts: Array<TKey> = []
     for (const [key, value] of this.pendingOptimisticUpserts) {
-      if (pendingSyncKeys.has(key)) {
-        this.optimisticUpserts.set(key, value)
-      } else {
-        staleOptimisticUpserts.push(key)
-      }
+      this.optimisticUpserts.set(key, value)
     }
-    for (const key of staleOptimisticUpserts) {
-      this.pendingOptimisticUpserts.delete(key)
-      this.pendingLocalOrigins.delete(key)
-    }
-    const staleOptimisticDeletes: Array<TKey> = []
     for (const key of this.pendingOptimisticDeletes) {
-      if (pendingSyncKeys.has(key)) {
-        this.optimisticDeletes.add(key)
-      } else {
-        staleOptimisticDeletes.push(key)
-      }
-    }
-    for (const key of staleOptimisticDeletes) {
-      this.pendingOptimisticDeletes.delete(key)
-      this.pendingLocalOrigins.delete(key)
+      this.optimisticDeletes.add(key)
     }
 
     const activeTransactions: Array<Transaction<any>> = []
@@ -1125,6 +1107,28 @@ export class CollectionStateManager<
             }
           }
         }
+      }
+
+      // A completed optimistic insert may have used a temporary client key while
+      // the sync confirmation used a different server-generated key. Once a
+      // sync commit has been applied, stop retaining completed optimistic keys
+      // that were not confirmed by this commit so the temporary row is removed.
+      for (const [key, previousValue] of this.pendingOptimisticUpserts) {
+        if (!changedKeys.has(key)) {
+          changedKeys.add(key)
+          if (!currentVisibleState.has(key)) {
+            currentVisibleState.set(key, previousValue)
+          }
+          this.pendingOptimisticUpserts.delete(key)
+          this.pendingLocalOrigins.delete(key)
+        }
+      }
+      for (const key of this.pendingOptimisticDeletes) {
+        if (!changedKeys.has(key)) {
+          changedKeys.add(key)
+        }
+        this.pendingOptimisticDeletes.delete(key)
+        this.pendingLocalOrigins.delete(key)
       }
 
       // Now check what actually changed in the final visible state

--- a/packages/db/src/collection/transaction-metadata.ts
+++ b/packages/db/src/collection/transaction-metadata.ts
@@ -1,0 +1,1 @@
+export const DIRECT_TRANSACTION_METADATA_KEY = `__tanstack_db_direct`

--- a/packages/db/src/collection/transaction-metadata.ts
+++ b/packages/db/src/collection/transaction-metadata.ts
@@ -1,1 +1,0 @@
-export const DIRECT_TRANSACTION_METADATA_KEY = `__tanstack_db_direct`

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -11,6 +11,7 @@ import {
   MissingUpdateHandlerError,
 } from '../src/errors'
 import { createTransaction } from '../src/transactions'
+import { createLiveQueryCollection, eq } from '../src/query/index.js'
 import {
   flushPromises,
   mockSyncCollectionOptionsNoInitialState,
@@ -39,6 +40,95 @@ describe(`Collection`, () => {
   it(`should throw if there's no sync config`, () => {
     // @ts-expect-error we're testing for throwing when there's no config passed in
     expect(() => createCollection()).toThrow(CollectionRequiresConfigError)
+  })
+
+  it(`removes optimistic insert when sync confirms with a different server-generated key`, async () => {
+    const options = mockSyncCollectionOptionsNoInitialState<{
+      id: number
+      text: string
+    }>({
+      id: `server-generated-key-test`,
+      getKey: (item) => item.id,
+      startSync: true,
+    })
+    const collection = createCollection(options)
+
+    options.utils.markReady()
+    await collection.stateWhenReady()
+
+    const tx = collection.insert({ id: 4733, text: `two` })
+
+    expect(getStateEntries(collection)).toEqual([
+      [4733, { id: 4733, text: `two` }],
+    ])
+
+    options.utils.begin()
+    options.utils.write({ type: `insert`, value: { id: 24, text: `two` } })
+    options.utils.commit()
+
+    // The sync commit is held while the local insert transaction is persisting.
+    expect(getStateEntries(collection)).toEqual([
+      [4733, { id: 4733, text: `two` }],
+    ])
+
+    options.utils.resolveSync()
+    await tx.isPersisted.promise
+    await flushPromises()
+
+    expect(getStateEntries(collection)).toEqual([[24, { id: 24, text: `two` }]])
+  })
+
+  it(`updates live queries when an optimistic insert is replaced by a different server key`, async () => {
+    const options = mockSyncCollectionOptionsNoInitialState<{
+      id: number
+      text: string
+      project_id: number
+    }>({
+      id: `server-generated-key-live-query-test`,
+      getKey: (item) => item.id,
+      startSync: true,
+    })
+    const collection = createCollection(options)
+    const liveCollection = createLiveQueryCollection((q) =>
+      q
+        .from({ collection })
+        .where(({ collection }) => eq(collection.project_id, 1))
+        .select(({ collection }) => ({
+          id: collection.id,
+          text: collection.text,
+          project_id: collection.project_id,
+          $synced: collection.$synced,
+          $origin: collection.$origin,
+          $key: collection.$key,
+        })),
+    )
+
+    options.utils.markReady()
+    await liveCollection.preload()
+
+    const tx = collection.insert({ id: 4733, text: `two`, project_id: 1 })
+
+    expect(liveCollection.toArray.map((todo) => todo.id)).toEqual([4733])
+
+    options.utils.begin()
+    options.utils.write({
+      type: `insert`,
+      value: { id: 24, text: `two`, project_id: 1 },
+    })
+    options.utils.commit()
+
+    options.utils.resolveSync()
+    await tx.isPersisted.promise
+    await flushPromises()
+
+    expect(
+      liveCollection.toArray.map((todo) => ({
+        id: todo.id,
+        synced: todo.$synced,
+        origin: todo.$origin,
+        key: todo.$key,
+      })),
+    ).toEqual([{ id: 24, synced: true, origin: `remote`, key: 24 }])
   })
 
   it(`should throw an error when trying to use mutation operations outside of a transaction`, async () => {

--- a/packages/db/tests/utils.ts
+++ b/packages/db/tests/utils.ts
@@ -311,6 +311,7 @@ type MockSyncCollectionConfigNoInitialState<T> = {
   id: string
   getKey: (item: T) => string | number
   autoIndex?: `off` | `eager`
+  startSync?: boolean
   defaultIndexType?: IndexConstructor
 }
 

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -739,6 +739,49 @@ describe(`Electric Integration`, () => {
       expect(testCollection._state.syncedData.size).toEqual(1)
     })
 
+    it(`should remove optimistic insert when txid sync confirms a different server-generated key`, async () => {
+      const txid = 1234
+      const onInsert = vi.fn().mockResolvedValue({ txid })
+
+      const testCollection = createCollection(
+        electricCollectionOptions({
+          id: `test-server-generated-key-txid`,
+          shapeOptions: {
+            url: `http://test-url`,
+            params: { table: `test_table` },
+          },
+          startSync: true,
+          getKey: (item: Row) => item.id as number,
+          onInsert,
+        }),
+      )
+
+      const tx = testCollection.insert({ id: 4733, text: `two` })
+
+      expect(stripVirtualProps(testCollection.get(4733))).toEqual({
+        id: 4733,
+        text: `two`,
+      })
+
+      subscriber([
+        {
+          key: `24`,
+          value: { id: 24, text: `two` },
+          headers: { operation: `insert`, txids: [txid] },
+        },
+        { headers: { control: `up-to-date` } },
+      ])
+
+      await tx.isPersisted.promise
+
+      expect(testCollection.has(4733)).toBe(false)
+      expect(stripVirtualProps(testCollection.get(24))).toEqual({
+        id: 24,
+        text: `two`,
+      })
+      expect(Array.from(testCollection.state.keys())).toEqual([24])
+    })
+
     it(`should support void strategy when handler returns nothing`, async () => {
       const onInsert = vi.fn().mockResolvedValue(undefined)
 


### PR DESCRIPTION
## Summary

Fix stale optimistic rows persisting when sync confirms a different server-generated key (e.g., Postgres `GENERATED ALWAYS AS IDENTITY`). After a direct `collection.insert()` with a temporary client ID, the server-assigned row would appear alongside the stale optimistic row instead of replacing it.

## Root Cause

`CollectionStateManager` maintained separate `pendingOptimisticDirectUpserts` / `pendingOptimisticDirectDeletes` sets that exempted direct transactions from stale-row cleanup. When sync confirmed a row under a different key than the client's temp key, the stale optimistic row could never be cleaned up — no sync transaction would ever reference the old client key, but the direct-transaction exemption kept it alive indefinitely.

## Approach

Remove the direct-transaction exemption entirely. All completed optimistic mutations now go through the same stale-row check: kept only if `pendingSyncKeys.has(key)`. This is safe because direct transactions stay in `persisting` state (keeping the optimistic row visible via the active-transaction loop) until the sync backend delivers the matching txid. By the time the transaction completes, the sync data is already available.

Also removed the now-dead `DIRECT_TRANSACTION_METADATA_KEY` constant and its usage in `mutations.ts`.

### Key Invariants

- A direct transaction's `mutationFn` (e.g., `awaitTxId()`) does not resolve until sync delivers the matching txid
- While a transaction is in `persisting` state, its optimistic rows are kept alive by the active-transaction loop, not the pending-optimistic sets
- Once `completed`, the pending-optimistic stale check is the sole gatekeeper

### Non-goals

- Adding observability/logging to `state.ts` (systemic gap, separate effort)
- Covering optimistic delete with server-generated keys (deletes always target known keys)

## Verification

```bash
pnpm vitest run --pool-options.threads.maxThreads=2 packages/db/tests packages/electric-db-collection/tests
```

All 2364 tests pass. 2 pre-existing failures in `collection-subscribe-changes.test.ts` (also fail on main).

## Files Changed

- **`packages/db/src/collection/state.ts`** — Remove `pendingOptimisticDirect*` sets, simplify stale-row check to `pendingSyncKeys.has(key)` only
- **`packages/db/src/collection/mutations.ts`** — Remove `DIRECT_TRANSACTION_METADATA_KEY` import and metadata tagging
- **`packages/db/src/collection/transaction-metadata.ts`** — Deleted (orphaned)
- **`packages/db/tests/collection.test.ts`** — Two new tests: optimistic insert replaced by server key, live query reflects the key swap
- **`packages/electric-db-collection/tests/electric.test.ts`** — One new test: txid sync confirms different server-generated key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale optimistic rows persisting when sync confirms a different server-generated key during insert operations.

* **Tests**
  * Added comprehensive tests for optimistic insert sync behavior, verifying proper handling when server-generated keys replace client-provided keys.

* **Chores**
  * Updated CI to use Node.js 22.13.

* **Documentation**
  * Added Git and PR hygiene guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->