### PR TITLE
fix(db): require all or() branches to be index-optimizable

### DIFF
--- a/.changeset/fix-or-partial-union.md
+++ b/.changeset/fix-or-partial-union.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fix(db): require all or() branches to be index-optimizable before using index result

--- a/packages/db/src/utils/index-optimization.ts
+++ b/packages/db/src/utils/index-optimization.ts
@@ -469,22 +469,17 @@ function optimizeOrExpression<T extends object, TKey extends string | number>(
 
   const results: Array<OptimizationResult<TKey>> = []
 
-  // Try to optimize each part, keep the optimizable ones
   for (const arg of expression.args) {
     const result = optimizeQueryRecursive(arg, collection)
-    if (result.canOptimize) {
-      results.push(result)
+    if (!result.canOptimize) {
+      return { canOptimize: false, matchingKeys: new Set() }
     }
+    results.push(result)
   }
 
-  if (results.length === expression.args.length) {
-    // Use unionSets utility for OR logic
-    const allMatchingSets = results.map((r) => r.matchingKeys)
-    const unionedKeys = unionSets(allMatchingSets)
-    return { canOptimize: true, matchingKeys: unionedKeys }
-  }
-
-  return { canOptimize: false, matchingKeys: new Set() }
+  const allMatchingSets = results.map((r) => r.matchingKeys)
+  const unionedKeys = unionSets(allMatchingSets)
+  return { canOptimize: true, matchingKeys: unionedKeys }
 }
 
 /**

--- a/packages/db/src/utils/index-optimization.ts
+++ b/packages/db/src/utils/index-optimization.ts
@@ -498,8 +498,8 @@ function canOptimizeOrExpression<
     return false
   }
 
-  // If any argument can be optimized, we can gain some speedup
-  return expression.args.some((arg) => canOptimizeExpression(arg, collection))
+  // All branches must be optimizable — partial OR optimization is unsound
+  return expression.args.every((arg) => canOptimizeExpression(arg, collection))
 }
 
 /**

--- a/packages/db/src/utils/index-optimization.ts
+++ b/packages/db/src/utils/index-optimization.ts
@@ -477,7 +477,7 @@ function optimizeOrExpression<T extends object, TKey extends string | number>(
     }
   }
 
-  if (results.length > 0) {
+  if (results.length === expression.args.length) {
     // Use unionSets utility for OR logic
     const allMatchingSets = results.map((r) => r.matchingKeys)
     const unionedKeys = unionSets(allMatchingSets)

--- a/packages/db/tests/query/or-partial-optimization.test.ts
+++ b/packages/db/tests/query/or-partial-optimization.test.ts
@@ -36,13 +36,13 @@ describe(`or() with partially indexed branches`, () => {
     })
 
     const liveQuery = createLiveQueryCollection({
-      query: (q: any) =>
+      query: (q) =>
         q
           .from({ item: collection })
-          .where(({ item }: any) =>
+          .where(({ item }) =>
             or(eq(item.category, `A`), eq(item.tag, `x`)),
           )
-          .select(({ item }: any) => ({
+          .select(({ item }) => ({
             id: item.id,
             category: item.category,
             tag: item.tag,

--- a/packages/db/tests/query/or-partial-optimization.test.ts
+++ b/packages/db/tests/query/or-partial-optimization.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { createCollection } from '../../src/collection/index.js'
+import { BasicIndex } from '../../src/indexes/basic-index.js'
+import { createLiveQueryCollection } from '../../src/query/live-query-collection'
+import { eq, or } from '../../src/query/builder/functions'
+import { mockSyncCollectionOptions } from '../utils'
+
+interface TestItem {
+  id: string
+  category: string
+  tag: string
+}
+
+const testData: Array<TestItem> = [
+  { id: `1`, category: `A`, tag: `x` },
+  { id: `2`, category: `B`, tag: `y` },
+  { id: `3`, category: `A`, tag: `z` },
+  { id: `4`, category: `C`, tag: `x` },
+]
+
+describe(`or() with partially indexed branches`, () => {
+  it(`returns all matching rows when only one or() branch is indexed`, async () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<TestItem>({
+        id: `or-partial-index`,
+        getKey: (item) => item.id,
+        initialData: testData,
+        autoIndex: `off`,
+      }),
+    )
+
+    await collection.stateWhenReady()
+
+    collection.createIndex((row) => row.category, {
+      indexType: BasicIndex,
+    })
+
+    const liveQuery = createLiveQueryCollection({
+      query: (q: any) =>
+        q
+          .from({ item: collection })
+          .where(({ item }: any) =>
+            or(eq(item.category, `A`), eq(item.tag, `x`)),
+          )
+          .select(({ item }: any) => ({
+            id: item.id,
+            category: item.category,
+            tag: item.tag,
+          })),
+      startSync: true,
+    })
+
+    await liveQuery.stateWhenReady()
+
+    const ids = liveQuery.toArray.map((r) => r.id).sort()
+    expect(ids).toEqual([`1`, `3`, `4`])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #1502.

`optimizeOrExpression` returned `canOptimize: true` when only *some* `or()` branches had matching indexes, producing a partial union that silently dropped rows from unindexed branches.

The fix requires all branches to be optimizable (`results.length === expression.args.length`) before returning the index result. If any branch can't be optimized, fall back to full scan.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test:pr`.
- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OR-style queries now only use index results when every branch is index-optimizable, preventing partial index use that could produce incomplete results.

* **Tests**
  * Added tests to validate live-query behavior for OR queries when only some branches are indexed, ensuring correct and consistent results.

* **Chores**
  * Release metadata updated to mark a patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->