### PR TITLE
fix(db): skip deletes for unsent keys in filterDuplicateInserts

### DIFF
--- a/.changeset/fix-ghost-delete-sentkeys.md
+++ b/.changeset/fix-ghost-delete-sentkeys.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fix(db): skip deletes for items never sent to D2 in filterDuplicateInserts

--- a/packages/db/src/query/live/utils.ts
+++ b/packages/db/src/query/live/utils.ts
@@ -339,7 +339,9 @@ export function filterDuplicateInserts(
       }
       sentKeys.add(change.key)
     } else if (change.type === `delete`) {
-      sentKeys.delete(change.key)
+      if (!sentKeys.delete(change.key)) {
+        continue
+      }
     }
     filtered.push(change)
   }

--- a/packages/db/tests/collection-subscriber-duplicate-inserts.test.ts
+++ b/packages/db/tests/collection-subscriber-duplicate-inserts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createCollection } from '../src/collection/index.js'
 import { BTreeIndex } from '../src/indexes/btree-index.js'
 import { createLiveQueryCollection, eq } from '../src/query/index.js'
+import { filterDuplicateInserts } from '../src/query/live/utils.js'
 import { mockSyncCollectionOptions } from './utils.js'
 import type { ChangeMessage } from '../src/types.js'
 
@@ -451,5 +452,58 @@ describe(`CollectionSubscriber duplicate insert prevention`, () => {
     expect(finalResults).toHaveLength(2)
 
     subscription.unsubscribe()
+  })
+
+  describe(`filterDuplicateInserts`, () => {
+    it(`should skip deletes for keys never sent to D2`, () => {
+      const sentKeys = new Set<string | number>([`1`, `2`])
+
+      const changes: Array<ChangeMessage<TestItem, string>> = [
+        { type: `delete`, key: `3`, value: { id: `3`, value: 50 } },
+      ]
+
+      const result = filterDuplicateInserts(changes, sentKeys)
+
+      expect(result).toHaveLength(0)
+      expect(sentKeys.has(`1`)).toBe(true)
+      expect(sentKeys.has(`2`)).toBe(true)
+      expect(sentKeys.has(`3`)).toBe(false)
+    })
+
+    it(`should forward deletes for keys that were sent to D2`, () => {
+      const sentKeys = new Set<string | number>([`1`, `2`])
+
+      const changes: Array<ChangeMessage<TestItem, string>> = [
+        { type: `delete`, key: `2`, value: { id: `2`, value: 90 } },
+      ]
+
+      const result = filterDuplicateInserts(changes, sentKeys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.type).toBe(`delete`)
+      expect(result[0]!.key).toBe(`2`)
+      expect(sentKeys.has(`2`)).toBe(false)
+    })
+
+    it(`should handle mixed inserts and ghost deletes correctly`, () => {
+      const sentKeys = new Set<string | number>([`1`])
+
+      const changes: Array<ChangeMessage<TestItem, string>> = [
+        { type: `insert`, key: `2`, value: { id: `2`, value: 90 } },
+        { type: `delete`, key: `3`, value: { id: `3`, value: 50 } },
+        { type: `delete`, key: `1`, value: { id: `1`, value: 100 } },
+        { type: `insert`, key: `4`, value: { id: `4`, value: 70 } },
+      ]
+
+      const result = filterDuplicateInserts(changes, sentKeys)
+
+      expect(result).toHaveLength(3)
+      expect(result.map((c) => ({ type: c.type, key: c.key }))).toEqual([
+        { type: `insert`, key: `2` },
+        { type: `delete`, key: `1` },
+        { type: `insert`, key: `4` },
+      ])
+      expect(sentKeys).toEqual(new Set([`2`, `4`]))
+    })
   })
 })

--- a/packages/db/tests/collection-subscriber-duplicate-inserts.test.ts
+++ b/packages/db/tests/collection-subscriber-duplicate-inserts.test.ts
@@ -455,6 +455,16 @@ describe(`CollectionSubscriber duplicate insert prevention`, () => {
   })
 
   describe(`filterDuplicateInserts`, () => {
+    it(`should return empty output for empty changes and empty sentKeys`, () => {
+      const sentKeys = new Set<string | number>()
+      const changes: Array<ChangeMessage<TestItem, string>> = []
+
+      const result = filterDuplicateInserts(changes, sentKeys)
+
+      expect(result).toEqual([])
+      expect(sentKeys.size).toBe(0)
+    })
+
     it(`should skip deletes for keys never sent to D2`, () => {
       const sentKeys = new Set<string | number>([`1`, `2`])
 


### PR DESCRIPTION
## 🎯 Changes

`filterDuplicateInserts` forwarded delete changes for keys never present in `sentKeys`. When SSE delivers deletes for items filtered out by the `where` clause, the spurious -1 multiplicity corrupts D2's TopKState window.

The fix checks the return value of `sentKeys.delete()` — if `false`, the key was never sent, so the delete is skipped.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test:pr`.
- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious delete events from being emitted for items that were never previously sent, improving synchronization consistency and preventing downstream mismatches.

* **Tests**
  * Added unit tests covering change-filtering behavior, including mixed insert/delete scenarios and “ghost delete” cases, to ensure deletes are only forwarded when appropriate and tracking state is updated correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->