### PR TITLE
fix(db): avoid undefined enumerable keys in compare options

### DIFF
--- a/.changeset/fix-compare-options-undefined-keys.md
+++ b/.changeset/fix-compare-options-undefined-keys.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fix(db): avoid assigning undefined locale/localeOptions in buildCompareOptionsFromConfig

--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -996,11 +996,11 @@ function buildCompareOptionsFromConfig(
 ): StringCollationConfig {
   if (config.defaultStringCollation) {
     const options = config.defaultStringCollation
+    const localeMode = options.stringSort === `locale`
     return {
       stringSort: options.stringSort ?? `locale`,
-      locale: options.stringSort === `locale` ? options.locale : undefined,
-      localeOptions:
-        options.stringSort === `locale` ? options.localeOptions : undefined,
+      ...(localeMode && options.locale !== undefined && { locale: options.locale }),
+      ...(localeMode && options.localeOptions !== undefined && { localeOptions: options.localeOptions }),
     }
   } else {
     return {

--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -996,9 +996,10 @@ function buildCompareOptionsFromConfig(
 ): StringCollationConfig {
   if (config.defaultStringCollation) {
     const options = config.defaultStringCollation
-    const localeMode = options.stringSort === `locale`
+    const stringSortEffective = options.stringSort ?? `locale`
+    const localeMode = stringSortEffective === `locale`
     return {
-      stringSort: options.stringSort ?? `locale`,
+      stringSort: stringSortEffective,
       ...(localeMode && options.locale !== undefined && { locale: options.locale }),
       ...(localeMode && options.localeOptions !== undefined && { localeOptions: options.localeOptions }),
     }

--- a/packages/db/tests/collection-auto-index.test.ts
+++ b/packages/db/tests/collection-auto-index.test.ts
@@ -1010,6 +1010,29 @@ describe(`Collection Auto-Indexing`, () => {
     expect(Object.keys(opts).sort()).toEqual([`locale`, `localeOptions`, `stringSort`])
   })
 
+  it(`should include locale fields when stringSort is omitted but locale values are provided`, () => {
+    const collection = createCollection<TestItem, string>({
+      getKey: (item) => item.id,
+      defaultStringCollation: {
+        locale: `en-US`,
+        localeOptions: { sensitivity: `base` },
+      },
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const opts = collection.compareOptions
+    expect(opts.stringSort).toBe(`locale`)
+    expect(opts.locale).toBe(`en-US`)
+    expect(opts.localeOptions).toEqual({ sensitivity: `base` })
+  })
+
   it(`should not create duplicate auto-indexes when defaultStringCollation matches defaults`, async () => {
     const collection = createCollection<TestItem, string>({
       getKey: (item) => item.id,

--- a/packages/db/tests/collection-auto-index.test.ts
+++ b/packages/db/tests/collection-auto-index.test.ts
@@ -942,4 +942,119 @@ describe(`Collection Auto-Indexing`, () => {
       })
     })
   })
+
+  it(`should not include undefined locale/localeOptions keys in compareOptions when stringSort is not locale`, () => {
+    const collection = createCollection<TestItem, string>({
+      getKey: (item) => item.id,
+      defaultStringCollation: { stringSort: `codepoint` },
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const opts = collection.compareOptions
+    expect(opts.stringSort).toBe(`codepoint`)
+    expect(Object.keys(opts)).not.toContain(`locale`)
+    expect(Object.keys(opts)).not.toContain(`localeOptions`)
+    expect(Object.keys(opts)).toEqual([`stringSort`])
+  })
+
+  it(`should not include undefined locale/localeOptions keys when stringSort is locale without explicit locale`, () => {
+    const collection = createCollection<TestItem, string>({
+      getKey: (item) => item.id,
+      defaultStringCollation: { stringSort: `locale` },
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const opts = collection.compareOptions
+    expect(opts.stringSort).toBe(`locale`)
+    expect(Object.keys(opts)).not.toContain(`locale`)
+    expect(Object.keys(opts)).not.toContain(`localeOptions`)
+    expect(Object.keys(opts)).toEqual([`stringSort`])
+  })
+
+  it(`should include locale and localeOptions keys when explicitly provided`, () => {
+    const collection = createCollection<TestItem, string>({
+      getKey: (item) => item.id,
+      defaultStringCollation: {
+        stringSort: `locale`,
+        locale: `en-US`,
+        localeOptions: { sensitivity: `base` },
+      },
+      startSync: true,
+      sync: {
+        sync: ({ begin, commit, markReady }) => {
+          begin()
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    const opts = collection.compareOptions
+    expect(opts.stringSort).toBe(`locale`)
+    expect(opts.locale).toBe(`en-US`)
+    expect(opts.localeOptions).toEqual({ sensitivity: `base` })
+    expect(Object.keys(opts).sort()).toEqual([`locale`, `localeOptions`, `stringSort`])
+  })
+
+  it(`should not create duplicate auto-indexes when defaultStringCollation matches defaults`, async () => {
+    const collection = createCollection<TestItem, string>({
+      getKey: (item) => item.id,
+      autoIndex: `eager`,
+      defaultIndexType: BTreeIndex,
+      defaultStringCollation: { stringSort: `locale` },
+      startSync: true,
+      sync: {
+        sync: ({ begin, write, commit, markReady }) => {
+          begin()
+          for (const item of testData) {
+            write({ type: `insert`, value: item })
+          }
+          commit()
+          markReady()
+        },
+      },
+    })
+
+    await collection.stateWhenReady()
+
+    const sub1 = collection.subscribeChanges(() => {}, {
+      whereExpression: eq(row.status, `active`),
+    })
+    expect(collection.indexes.size).toBe(1)
+
+    // A second subscription on the same field should reuse the index
+    const sub2 = collection.subscribeChanges(() => {}, {
+      whereExpression: eq(row.status, `inactive`),
+    })
+    expect(collection.indexes.size).toBe(1)
+
+    // Verify the index is used for queries
+    withIndexTracking(collection, (tracker) => {
+      collection.currentStateAsChanges({
+        where: eq(row.status, `active`),
+      })
+
+      expectIndexUsage(tracker.stats, {
+        shouldUseIndex: true,
+        shouldUseFullScan: false,
+      })
+    })
+
+    sub1.unsubscribe()
+    sub2.unsubscribe()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

`buildCompareOptionsFromConfig` assigned `locale: undefined` and `localeOptions: undefined` as enumerable properties when `stringSort !== 'locale'`. These extra keys cause `deepEquals` in `BaseIndex.matchesCompareOptions` to fail on `Object.keys` length mismatch, preventing index matching and silently falling back to full scan.

The fix conditionally spreads these properties so they only exist when they have actual values.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test:pr`.
- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/db/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string-collation handling so locale and locale options are only included when applicable, preventing unnecessary undefined values and clarifying text comparison/sorting configs.

* **Tests**
  * Added tests verifying conditional inclusion of locale fields and auto-index de-duplication/usage behavior under various collation and indexing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->