### PR TITLE
fix(db): fall back to crypto.getRandomValues when randomUUID is unavailable

### DIFF
--- a/.changeset/safe-random-uuid-non-secure-context.md
+++ b/.changeset/safe-random-uuid-non-secure-context.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Fix `@tanstack/db` throwing `TypeError: crypto.randomUUID is not a function` in non-secure browser contexts. `crypto.randomUUID()` is restricted to secure contexts, so pages served over plain HTTP from a non-localhost host (such as a dev server reached via a LAN IP) could not insert into a collection, run a mutation, or open a transaction. UUID generation now centralises in `safeRandomUUID()` which prefers `crypto.randomUUID()` when available and falls back to RFC 4122 v4 via `crypto.getRandomValues()`.

--- a/packages/db/src/collection/index.ts
+++ b/packages/db/src/collection/index.ts
@@ -3,6 +3,7 @@ import {
   CollectionRequiresConfigError,
   CollectionRequiresSyncConfigError,
 } from '../errors'
+import { safeRandomUUID } from '../utils'
 import { currentStateAsChanges } from './change-events'
 
 import { CollectionStateManager } from './state'
@@ -329,7 +330,7 @@ export class CollectionImpl<
     if (config.id) {
       this.id = config.id
     } else {
-      this.id = crypto.randomUUID()
+      this.id = safeRandomUUID()
     }
 
     // Set default values for optional config properties

--- a/packages/db/src/collection/mutations.ts
+++ b/packages/db/src/collection/mutations.ts
@@ -17,6 +17,7 @@ import {
   UndefinedKeyError,
   UpdateKeyNotFoundError,
 } from '../errors'
+import { safeRandomUUID } from '../utils'
 import { DIRECT_TRANSACTION_METADATA_KEY } from './transaction-metadata.js'
 import type { Collection, CollectionImpl } from './index.js'
 import type { StandardSchemaV1 } from '@standard-schema/spec'
@@ -193,7 +194,7 @@ export class CollectionMutationsManager<
       const globalKey = this.generateGlobalKey(key, item)
 
       const mutation: PendingMutation<TOutput, `insert`> = {
-        mutationId: crypto.randomUUID(),
+        mutationId: safeRandomUUID(),
         original: {},
         modified: validatedData,
         // Pick the values from validatedData based on what's passed in - this is for cases
@@ -366,7 +367,7 @@ export class CollectionMutationsManager<
         const globalKey = this.generateGlobalKey(modifiedItemId, modifiedItem)
 
         return {
-          mutationId: crypto.randomUUID(),
+          mutationId: safeRandomUUID(),
           original: originalItem,
           modified: modifiedItem,
           // Pick the values from modifiedItem based on what's passed in - this is for cases
@@ -497,7 +498,7 @@ export class CollectionMutationsManager<
         `delete`,
         CollectionImpl<TOutput, TKey, TUtils, TSchema, TInput>
       > = {
-        mutationId: crypto.randomUUID(),
+        mutationId: safeRandomUUID(),
         original: this.state.get(key)!,
         modified: this.state.get(key)!,
         changes: this.state.get(key)!,

--- a/packages/db/src/local-only.ts
+++ b/packages/db/src/local-only.ts
@@ -1,3 +1,4 @@
+import { safeRandomUUID } from './utils'
 import type {
   BaseCollectionConfig,
   CollectionConfig,
@@ -182,7 +183,7 @@ export function localOnlyCollectionOptions<
   const { initialData, onInsert, onUpdate, onDelete, id, ...restConfig } =
     config
 
-  const collectionId = id ?? crypto.randomUUID()
+  const collectionId = id ?? safeRandomUUID()
 
   // Create the sync configuration with transaction confirmation capability
   const syncResult = createLocalOnlySync<T, TKey>(initialData)

--- a/packages/db/src/local-storage.ts
+++ b/packages/db/src/local-storage.ts
@@ -4,6 +4,7 @@ import {
   SerializationError,
   StorageKeyRequiredError,
 } from './errors'
+import { safeRandomUUID } from './utils'
 import type {
   BaseCollectionConfig,
   CollectionConfig,
@@ -149,7 +150,7 @@ function validateJsonSerializable(
  * @returns A unique identifier string for tracking data versions
  */
 function generateUuid(): string {
-  return crypto.randomUUID()
+  return safeRandomUUID()
 }
 
 /**

--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -7,6 +7,7 @@ import {
   TransactionNotPendingMutateError,
 } from './errors'
 import { transactionScopedScheduler } from './scheduler.js'
+import { safeRandomUUID } from './utils'
 import type { Deferred } from './deferred'
 import type {
   MutationFn,
@@ -224,7 +225,7 @@ class Transaction<T extends object = Record<string, unknown>> {
     if (typeof config.mutationFn === `undefined`) {
       throw new MissingMutationFunctionError()
     }
-    this.id = config.id ?? crypto.randomUUID()
+    this.id = config.id ?? safeRandomUUID()
     this.mutationFn = config.mutationFn
     this.state = `pending`
     this.mutations = []

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -240,3 +240,53 @@ export const DEFAULT_COMPARE_OPTIONS: CompareOptions = {
   nulls: `first`,
   stringSort: `locale`,
 }
+
+/**
+ * Returns a UUID v4 string. Prefers `crypto.randomUUID()` when available and
+ * falls back to RFC 4122 v4 generation via `crypto.getRandomValues()` when it
+ * is not.
+ *
+ * Background: `crypto.randomUUID()` is restricted to secure contexts in
+ * browsers, so it is unavailable on pages served over plain HTTP from a
+ * non-localhost host (e.g. a dev server reached via a LAN IP). In those
+ * environments `crypto.getRandomValues()` remains available and is enough to
+ * produce a spec-compliant UUID v4.
+ *
+ * @throws Error when neither `crypto.randomUUID()` nor
+ *   `crypto.getRandomValues()` is available.
+ */
+export function safeRandomUUID(): string {
+  const c = globalThis.crypto as
+    | (Crypto & { randomUUID?: () => string })
+    | undefined
+  if (c?.randomUUID) {
+    return c.randomUUID()
+  }
+  if (c?.getRandomValues) {
+    const bytes = new Uint8Array(16)
+    c.getRandomValues(bytes)
+    // RFC 4122 §4.4: set the four most significant bits of the 7th byte to
+    // 0100 (version 4) and the two most significant bits of the 9th byte to
+    // 10 (variant 10xx).
+    bytes[6] = (bytes[6]! & 0x0f) | 0x40
+    bytes[8] = (bytes[8]! & 0x3f) | 0x80
+    const hex: Array<string> = []
+    for (let i = 0; i < bytes.length; i++) {
+      hex.push(bytes[i]!.toString(16).padStart(2, `0`))
+    }
+    return (
+      hex.slice(0, 4).join(``) +
+      `-` +
+      hex.slice(4, 6).join(``) +
+      `-` +
+      hex.slice(6, 8).join(``) +
+      `-` +
+      hex.slice(8, 10).join(``) +
+      `-` +
+      hex.slice(10, 16).join(``)
+    )
+  }
+  throw new Error(
+    `@tanstack/db: UUID generation requires Web Crypto (crypto.randomUUID or crypto.getRandomValues)`,
+  )
+}

--- a/packages/db/tests/safe-random-uuid.test.ts
+++ b/packages/db/tests/safe-random-uuid.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { safeRandomUUID } from '../src/utils'
+
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe(`safeRandomUUID`, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it(`delegates to crypto.randomUUID when available`, () => {
+    const randomUUID = vi.fn(() => `11111111-2222-4333-8444-555555555555`)
+    vi.stubGlobal(`crypto`, {
+      randomUUID,
+      getRandomValues: (arr: Uint8Array) => arr,
+    })
+
+    expect(safeRandomUUID()).toBe(`11111111-2222-4333-8444-555555555555`)
+    expect(randomUUID).toHaveBeenCalledOnce()
+  })
+
+  it(`falls back to crypto.getRandomValues when randomUUID is missing`, () => {
+    const getRandomValues = vi.fn((arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i++) arr[i] = i
+      return arr
+    })
+    vi.stubGlobal(`crypto`, { randomUUID: undefined, getRandomValues })
+
+    const uuid = safeRandomUUID()
+
+    expect(uuid).toMatch(UUID_V4_RE)
+    expect(getRandomValues).toHaveBeenCalledOnce()
+  })
+
+  it(`produces distinct UUIDs across calls when using the fallback`, () => {
+    let counter = 0
+    vi.stubGlobal(`crypto`, {
+      randomUUID: undefined,
+      getRandomValues: (arr: Uint8Array) => {
+        for (let i = 0; i < arr.length; i++) arr[i] = (counter + i) & 0xff
+        counter++
+        return arr
+      },
+    })
+
+    const first = safeRandomUUID()
+    const second = safeRandomUUID()
+
+    expect(first).toMatch(UUID_V4_RE)
+    expect(second).toMatch(UUID_V4_RE)
+    expect(first).not.toBe(second)
+  })
+
+  it(`throws when neither randomUUID nor getRandomValues is available`, () => {
+    vi.stubGlobal(`crypto`, {})
+
+    expect(() => safeRandomUUID()).toThrowError(/Web Crypto/)
+  })
+
+  it(`throws when crypto itself is undefined`, () => {
+    vi.stubGlobal(`crypto`, undefined)
+
+    expect(() => safeRandomUUID()).toThrowError(/Web Crypto/)
+  })
+})


### PR DESCRIPTION
## Problem

`crypto.randomUUID()` is restricted to secure contexts per the Web Crypto spec, so it is unavailable on pages served over plain HTTP from a non-localhost host (for example a dev server reached via a LAN IP). `@tanstack/db` calls it directly from collections, transactions, mutations, local-only, and local-storage, so the first write throws

```text
TypeError: crypto.randomUUID is not a function
```

before user code can handle it. `crypto.getRandomValues()` remains available in non-secure contexts, so a v4 UUID is still reachable; we just have to assemble it ourselves when the higher-level API is missing.

## Repro

```text
http://<LAN-IP>:<port>
```

```js
window.isSecureContext // false
typeof crypto.randomUUID // "undefined"
typeof crypto.getRandomValues // "function"
```

```ts
import { createCollection, localOnlyCollectionOptions } from '@tanstack/db'

const collection = createCollection(
  localOnlyCollectionOptions({
    id: 'items',
    getKey: (item) => item.id,
  }),
)

collection.insert({ id: '1' }) // throws TypeError: crypto.randomUUID is not a function
```

## Fix

Add a `safeRandomUUID()` helper in `packages/db/src/utils.ts`:

1. Use `crypto.randomUUID()` when available (the common case).
2. Fall back to RFC 4122 v4 generation via `crypto.getRandomValues()` with the version/variant bits set per spec §4.4.
3. Throw an explicit `Error` if neither Web Crypto API is available.

Replace the seven direct call sites with the helper:

- `packages/db/src/collection/index.ts` (default collection id)
- `packages/db/src/collection/mutations.ts` (insert / update / delete mutation ids; three sites)
- `packages/db/src/local-only.ts` (local-only collection id)
- `packages/db/src/local-storage.ts` (version-tracking uuid)
- `packages/db/src/transactions.ts` (transaction id)

The issue body listed four files; while replacing those I also found three additional `crypto.randomUUID()` call sites in `mutations.ts` (the per-operation `mutationId`) and one in `local-storage.ts` that have the same failure mode, and rolled them into the helper as well so the fallback is consistent across `@tanstack/db`.

## Tests

`packages/db/tests/safe-random-uuid.test.ts` covers both axes:

- **Delegate path**: when `crypto.randomUUID` exists, the helper returns its value unchanged and the stub is called exactly once.
- **Fallback path**: when only `crypto.getRandomValues` is present, the result matches a strict RFC 4122 v4 regex (`/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/`).
- **Fallback uniqueness**: two successive fallback calls with deterministic but distinct byte input produce different UUIDs, ensuring the helper does not collapse to a constant when `randomUUID` is missing.
- **No crypto at all**: throws an explicit error mentioning the Web Crypto API.
- **Partial crypto** (`{}` object, no `randomUUID`, no `getRandomValues`): same explicit error, so we never silently fall through to native crypto.

All five new tests pass with the patched helper (`pnpm --filter @tanstack/db test`). The pre-existing 163 test failures on `main` (`localStorage.getItem is not a function` in `union-all.test.ts` and related jsdom interactions) are not introduced by this change; the new test count of `2213 passed` matches `2208 baseline + 5 new`.

Lint clean (`pnpm --filter @tanstack/db lint`, no new warnings). Build clean (`pnpm --filter @tanstack/db build`).

Closes #1541

## Note on disclosure

Bug discovery and reproduction were independent of this contributor (issue author `@kj55-dev` filed a clean writeup with a suggested fix). I implemented the helper, located the additional call sites in `mutations.ts` and `local-storage.ts`, wrote the tests, and reviewed every change. AI assistance was used while drafting parts of the test cases and this PR body, in line with the AGENTS.md guidance in the repo.