### PR TITLE
fix(expo-db-sqlite-persistence): resolve TS2322 when passing SQLiteDatabase to createExpoSQLitePersistence

### DIFF
--- a/.changeset/six-ties-leave.md
+++ b/.changeset/six-ties-leave.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/expo-db-sqlite-persistence-e2e-app': patch
+'@tanstack/expo-db-sqlite-persistence': patch
+---
+
+fixes a TS2322 type error when passing a SQLiteDatabase from expo-sqlite to createExpoSQLitePersistence

--- a/packages/expo-db-sqlite-persistence/e2e/expo-runtime-app/App.tsx
+++ b/packages/expo-db-sqlite-persistence/e2e/expo-runtime-app/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ScrollView, Text, View } from 'react-native'
 import * as SQLite from 'expo-sqlite'
 import { createCollection } from '@tanstack/db'
@@ -14,20 +14,12 @@ import type {
 } from '../runtime-protocol'
 
 type DatabaseHandle = Awaited<ReturnType<typeof SQLite.openDatabaseAsync>>
-type TransactionHandleLike = {
-  execAsync: (sql: string) => Promise<void>
-  getAllAsync: (
-    sql: string,
-    params?: ReadonlyArray<unknown> | Record<string, unknown>,
-  ) => Promise<ReadonlyArray<unknown>>
-  runAsync: (
-    sql: string,
-    params?: ReadonlyArray<unknown> | Record<string, unknown>,
-  ) => Promise<unknown>
-}
+type TransactionHandle = Parameters<
+  Parameters<DatabaseHandle['withExclusiveTransactionAsync']>[0]
+>[0]
 
 type ActiveTransaction = {
-  transaction: TransactionHandleLike
+  transaction: TransactionHandle
   complete: {
     resolve: () => void
     reject: (error?: unknown) => void
@@ -61,12 +53,6 @@ async function postJson<TBody extends object>(
   if (!response.ok) {
     throw new Error(`POST ${url} failed with status ${response.status}`)
   }
-}
-
-function normalizeSqliteParams(
-  params?: ReadonlyArray<unknown> | Record<string, unknown>,
-): ReadonlyArray<unknown> | Record<string, unknown> | undefined {
-  return params === undefined ? undefined : params
 }
 
 async function closeDatabaseHandle(database: DatabaseHandle): Promise<void> {
@@ -129,14 +115,7 @@ export default function App() {
     ): Promise<ExpoRuntimeSmokeTestResult> => {
       const database = await SQLite.openDatabaseAsync(databaseName)
       const collectionId = `expo-runtime-smoke-${Date.now().toString(36)}`
-      const persistence = createExpoSQLitePersistence<
-        {
-          id: string
-          title: string
-          score: number
-        },
-        string
-      >({
+      const persistence = createExpoSQLitePersistence({
         database,
       })
       const collection = createCollection(
@@ -198,20 +177,18 @@ export default function App() {
             command.databaseId,
             command.databaseName,
           )
-          const params = normalizeSqliteParams(command.params)
-          return params === undefined
+          return command.params === undefined
             ? database.getAllAsync(command.sql)
-            : database.getAllAsync(command.sql, params)
+            : database.getAllAsync(command.sql, command.params)
         }
         case `db:run`: {
           const database = await getDatabase(
             command.databaseId,
             command.databaseName,
           )
-          const params = normalizeSqliteParams(command.params)
-          return params === undefined
+          return command.params === undefined
             ? database.runAsync(command.sql)
-            : database.runAsync(command.sql, params)
+            : database.runAsync(command.sql, command.params)
         }
         case `db:close`: {
           const database = databaseHandles.get(command.databaseId)
@@ -270,20 +247,18 @@ export default function App() {
           if (!transaction) {
             throw new Error(`Unknown transaction id`)
           }
-          const params = normalizeSqliteParams(command.params)
-          return params === undefined
+          return command.params === undefined
             ? transaction.transaction.getAllAsync(command.sql)
-            : transaction.transaction.getAllAsync(command.sql, params)
+            : transaction.transaction.getAllAsync(command.sql, command.params)
         }
         case `tx:run`: {
           const transaction = activeTransactions.get(command.transactionId)
           if (!transaction) {
             throw new Error(`Unknown transaction id`)
           }
-          const params = normalizeSqliteParams(command.params)
-          return params === undefined
+          return command.params === undefined
             ? transaction.transaction.runAsync(command.sql)
-            : transaction.transaction.runAsync(command.sql, params)
+            : transaction.transaction.runAsync(command.sql, command.params)
         }
         case `tx:commit`: {
           const transaction = activeTransactions.get(command.transactionId)

--- a/packages/expo-db-sqlite-persistence/e2e/runtime-protocol.ts
+++ b/packages/expo-db-sqlite-persistence/e2e/runtime-protocol.ts
@@ -1,6 +1,6 @@
 export type ExpoRuntimeSQLiteBindValue = string | number | boolean | null
 export type ExpoRuntimeSQLiteBindParams =
-  | ReadonlyArray<ExpoRuntimeSQLiteBindValue>
+  | Array<ExpoRuntimeSQLiteBindValue>
   | Record<string, ExpoRuntimeSQLiteBindValue>
 
 export type ExpoRuntimeCommand =

--- a/packages/expo-db-sqlite-persistence/e2e/runtime-protocol.ts
+++ b/packages/expo-db-sqlite-persistence/e2e/runtime-protocol.ts
@@ -1,3 +1,8 @@
+export type ExpoRuntimeSQLiteBindValue = string | number | boolean | null
+export type ExpoRuntimeSQLiteBindParams =
+  | ReadonlyArray<ExpoRuntimeSQLiteBindValue>
+  | Record<string, ExpoRuntimeSQLiteBindValue>
+
 export type ExpoRuntimeCommand =
   | {
       id: string
@@ -12,7 +17,7 @@ export type ExpoRuntimeCommand =
       databaseId: string
       databaseName: string
       sql: string
-      params?: ReadonlyArray<unknown> | Record<string, unknown>
+      params?: ExpoRuntimeSQLiteBindParams
     }
   | {
       id: string
@@ -20,7 +25,7 @@ export type ExpoRuntimeCommand =
       databaseId: string
       databaseName: string
       sql: string
-      params?: ReadonlyArray<unknown> | Record<string, unknown>
+      params?: ExpoRuntimeSQLiteBindParams
     }
   | {
       id: string
@@ -46,14 +51,14 @@ export type ExpoRuntimeCommand =
       type: `tx:getAll`
       transactionId: string
       sql: string
-      params?: ReadonlyArray<unknown> | Record<string, unknown>
+      params?: ExpoRuntimeSQLiteBindParams
     }
   | {
       id: string
       type: `tx:run`
       transactionId: string
       sql: string
-      params?: ReadonlyArray<unknown> | Record<string, unknown>
+      params?: ExpoRuntimeSQLiteBindParams
     }
   | {
       id: string

--- a/packages/expo-db-sqlite-persistence/src/expo-sqlite-driver.ts
+++ b/packages/expo-db-sqlite-persistence/src/expo-sqlite-driver.ts
@@ -8,11 +8,14 @@ import type {
 
 export type ExpoSQLiteQueryable = {
   execAsync: (sql: string) => Promise<void>
-  getAllAsync: <T>(
-    sql: string,
-    params?: SQLiteBindParams,
-  ) => Promise<ReadonlyArray<T>>
-  runAsync: (sql: string, params?: SQLiteBindParams) => Promise<SQLiteRunResult>
+  getAllAsync: {
+    <T>(sql: string, params: SQLiteBindParams): Promise<ReadonlyArray<T>>
+    <T>(sql: string): Promise<ReadonlyArray<T>>
+  }
+  runAsync: {
+    (sql: string, params: SQLiteBindParams): Promise<SQLiteRunResult>
+    (sql: string): Promise<SQLiteRunResult>
+  }
 }
 
 export type ExpoSQLiteTransaction = ExpoSQLiteQueryable

--- a/packages/expo-db-sqlite-persistence/src/expo-sqlite-driver.ts
+++ b/packages/expo-db-sqlite-persistence/src/expo-sqlite-driver.ts
@@ -12,10 +12,7 @@ export type ExpoSQLiteQueryable = {
     sql: string,
     params?: SQLiteBindParams,
   ) => Promise<ReadonlyArray<T>>
-  runAsync: (
-    sql: string,
-    params?: SQLiteBindParams,
-  ) => Promise<SQLiteRunResult>
+  runAsync: (sql: string, params?: SQLiteBindParams) => Promise<SQLiteRunResult>
 }
 
 export type ExpoSQLiteTransaction = ExpoSQLiteQueryable

--- a/packages/expo-db-sqlite-persistence/src/expo-sqlite-driver.ts
+++ b/packages/expo-db-sqlite-persistence/src/expo-sqlite-driver.ts
@@ -1,33 +1,29 @@
 import { InvalidPersistedCollectionConfigError } from '@tanstack/db-sqlite-persistence-core'
 import type { SQLiteDriver } from '@tanstack/db-sqlite-persistence-core'
-
-export type ExpoSQLiteBindParams =
-  | ReadonlyArray<unknown>
-  | Record<string, unknown>
-
-export type ExpoSQLiteRunResult = {
-  changes: number
-  lastInsertRowId: number
-}
+import type {
+  SQLiteBindParams,
+  SQLiteBindValue,
+  SQLiteRunResult,
+} from 'expo-sqlite'
 
 export type ExpoSQLiteQueryable = {
   execAsync: (sql: string) => Promise<void>
   getAllAsync: <T>(
     sql: string,
-    params?: ExpoSQLiteBindParams,
+    params?: SQLiteBindParams,
   ) => Promise<ReadonlyArray<T>>
   runAsync: (
     sql: string,
-    params?: ExpoSQLiteBindParams,
-  ) => Promise<ExpoSQLiteRunResult>
+    params?: SQLiteBindParams,
+  ) => Promise<SQLiteRunResult>
 }
 
 export type ExpoSQLiteTransaction = ExpoSQLiteQueryable
 
 export type ExpoSQLiteDatabaseLike = ExpoSQLiteQueryable & {
-  withExclusiveTransactionAsync: <T>(
-    task: (transaction: ExpoSQLiteTransaction) => Promise<T>,
-  ) => Promise<T>
+  withExclusiveTransactionAsync: (
+    task: (transaction: ExpoSQLiteTransaction) => Promise<void>,
+  ) => Promise<void>
   closeAsync?: () => Promise<void>
 }
 
@@ -144,10 +140,12 @@ export class ExpoSQLiteDriver implements SQLiteDriver {
   ): Promise<T> {
     return this.enqueue(async () => {
       const database = await this.getDatabase()
-      return database.withExclusiveTransactionAsync(async (transaction) => {
+      let result: T | undefined
+      await database.withExclusiveTransactionAsync(async (transaction) => {
         const transactionDriver = this.createTransactionDriver(transaction)
-        return fn(transactionDriver)
+        result = await fn(transactionDriver)
       })
+      return result as T
     })
   }
 
@@ -225,10 +223,24 @@ export class ExpoSQLiteDriver implements SQLiteDriver {
   }
 }
 
-function normalizeParams(
-  params: ReadonlyArray<unknown>,
-): ExpoSQLiteBindParams | undefined {
-  return params.length > 0 ? [...params] : undefined
+function normalizeBindValue(value: unknown): SQLiteBindValue {
+  if (
+    value === null ||
+    typeof value === `string` ||
+    typeof value === `number` ||
+    typeof value === `boolean` ||
+    value instanceof Uint8Array
+  ) {
+    return value
+  }
+
+  throw new TypeError(
+    `Expo SQLite bind parameters must be strings, numbers, booleans, null, or Uint8Array values`,
+  )
+}
+
+function normalizeParams(params: ReadonlyArray<unknown>): SQLiteBindParams {
+  return params.map(normalizeBindValue)
 }
 
 export function createExpoSQLiteDriver(

--- a/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-database-factory.ts
+++ b/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-database-factory.ts
@@ -45,9 +45,13 @@ export function createMobileSQLiteTestDatabaseFactory(): ExpoSQLiteTestDatabaseF
         await (await getDatabase()).execAsync(sql)
       },
       getAllAsync: async <T>(sql: string, params?: SQLiteBindParams) =>
-        (await getDatabase()).getAllAsync<T>(sql, params),
+        params !== undefined
+          ? (await getDatabase()).getAllAsync<T>(sql, params)
+          : (await getDatabase()).getAllAsync<T>(sql),
       runAsync: async (sql: string, params?: SQLiteBindParams) =>
-        (await getDatabase()).runAsync(sql, params),
+        params !== undefined
+          ? (await getDatabase()).runAsync(sql, params)
+          : (await getDatabase()).runAsync(sql),
       withExclusiveTransactionAsync: async (
         task: (transaction: ExpoSQLiteTransaction) => Promise<void>,
       ): Promise<void> =>

--- a/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-database-factory.ts
+++ b/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-database-factory.ts
@@ -3,10 +3,8 @@ import type {
   ExpoSQLiteTestDatabase,
   ExpoSQLiteTestDatabaseFactory,
 } from './expo-sqlite-test-db'
-import type {
-  ExpoSQLiteBindParams,
-  ExpoSQLiteTransaction,
-} from '../../src/expo-sqlite-driver'
+import type { SQLiteBindParams } from 'expo-sqlite'
+import type { ExpoSQLiteTransaction } from '../../src/expo-sqlite-driver'
 
 function resolvePlatform(): `ios` | `android` {
   const platform = process.env.TANSTACK_DB_EXPO_RUNTIME_PLATFORM?.trim()
@@ -46,13 +44,13 @@ export function createMobileSQLiteTestDatabaseFactory(): ExpoSQLiteTestDatabaseF
       execAsync: async (sql: string) => {
         await (await getDatabase()).execAsync(sql)
       },
-      getAllAsync: async <T>(sql: string, params?: ExpoSQLiteBindParams) =>
+      getAllAsync: async <T>(sql: string, params?: SQLiteBindParams) =>
         (await getDatabase()).getAllAsync<T>(sql, params),
-      runAsync: async (sql: string, params?: ExpoSQLiteBindParams) =>
+      runAsync: async (sql: string, params?: SQLiteBindParams) =>
         (await getDatabase()).runAsync(sql, params),
-      withExclusiveTransactionAsync: async <T>(
-        task: (transaction: ExpoSQLiteTransaction) => Promise<T>,
-      ): Promise<T> =>
+      withExclusiveTransactionAsync: async (
+        task: (transaction: ExpoSQLiteTransaction) => Promise<void>,
+      ): Promise<void> =>
         (await getDatabase()).withExclusiveTransactionAsync(task),
       closeAsync: async () => {
         if (!databasePromise) {

--- a/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-runtime.ts
+++ b/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-runtime.ts
@@ -198,7 +198,9 @@ function normalizeRuntimeSqliteValue(
   value: SQLiteBindValue,
 ): ExpoRuntimeSQLiteBindValue {
   if (value instanceof Uint8Array) {
-    throw new TypeError(`Expo runtime bridge does not support binary SQLite params`)
+    throw new TypeError(
+      `Expo runtime bridge does not support binary SQLite params`,
+    )
   }
 
   return value

--- a/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-runtime.ts
+++ b/packages/expo-db-sqlite-persistence/tests/helpers/expo-emulator-runtime.ts
@@ -7,15 +7,20 @@ import { spawn } from 'node:child_process'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import type {
-  ExpoSQLiteBindParams,
+  SQLiteBindParams,
+  SQLiteBindValue,
+  SQLiteRunResult,
+} from 'expo-sqlite'
+import type {
   ExpoSQLiteDatabaseLike,
-  ExpoSQLiteRunResult,
   ExpoSQLiteTransaction,
 } from '../../src/expo-sqlite-driver'
 import type {
   ExpoRuntimeCommand,
   ExpoRuntimeCommandResult,
   ExpoRuntimeRegistration,
+  ExpoRuntimeSQLiteBindParams,
+  ExpoRuntimeSQLiteBindValue,
   ExpoRuntimeSmokeTestResult,
 } from '../../e2e/runtime-protocol'
 
@@ -189,6 +194,34 @@ function parseCommandOverride(rawCommand: string): Array<string> {
     .filter((part) => part.length > 0)
 }
 
+function normalizeRuntimeSqliteValue(
+  value: SQLiteBindValue,
+): ExpoRuntimeSQLiteBindValue {
+  if (value instanceof Uint8Array) {
+    throw new TypeError(`Expo runtime bridge does not support binary SQLite params`)
+  }
+
+  return value
+}
+
+function normalizeRuntimeSqliteParams(
+  params?: SQLiteBindParams,
+): ExpoRuntimeSQLiteBindParams | undefined {
+  if (params === undefined) {
+    return undefined
+  }
+
+  if (Array.isArray(params)) {
+    return params.map(normalizeRuntimeSqliteValue)
+  }
+
+  const normalized: Record<string, ExpoRuntimeSQLiteBindValue> = {}
+  for (const [key, value] of Object.entries(params)) {
+    normalized[key] = normalizeRuntimeSqliteValue(value)
+  }
+  return normalized
+}
+
 class ExpoEmulatorRuntime {
   private static readonly instances = new Map<
     RuntimePlatform,
@@ -239,29 +272,29 @@ class ExpoEmulatorRuntime {
       },
       getAllAsync: async <T>(
         sql: string,
-        params?: ExpoSQLiteBindParams,
+        params?: SQLiteBindParams,
       ): Promise<ReadonlyArray<T>> =>
         (await this.sendCommand({
           type: `db:getAll`,
           databaseId,
           databaseName,
           sql,
-          params,
+          params: normalizeRuntimeSqliteParams(params),
         })) as ReadonlyArray<T>,
       runAsync: async (
         sql: string,
-        params?: ExpoSQLiteBindParams,
-      ): Promise<ExpoSQLiteRunResult> =>
+        params?: SQLiteBindParams,
+      ): Promise<SQLiteRunResult> =>
         (await this.sendCommand({
           type: `db:run`,
           databaseId,
           databaseName,
           sql,
-          params,
-        })) as ExpoSQLiteRunResult,
-      withExclusiveTransactionAsync: async <T>(
-        task: (transaction: ExpoSQLiteTransaction) => Promise<T>,
-      ): Promise<T> => {
+          params: normalizeRuntimeSqliteParams(params),
+        })) as SQLiteRunResult,
+      withExclusiveTransactionAsync: async (
+        task: (transaction: ExpoSQLiteTransaction) => Promise<void>,
+      ): Promise<void> => {
         const transactionId = randomUUID()
         await this.sendCommand({
           type: `tx:start`,
@@ -279,33 +312,32 @@ class ExpoEmulatorRuntime {
           },
           getAllAsync: async <TRow>(
             sql: string,
-            params?: ExpoSQLiteBindParams,
+            params?: SQLiteBindParams,
           ): Promise<ReadonlyArray<TRow>> =>
             (await this.sendCommand({
               type: `tx:getAll`,
               transactionId,
               sql,
-              params,
+              params: normalizeRuntimeSqliteParams(params),
             })) as ReadonlyArray<TRow>,
           runAsync: async (
             sql: string,
-            params?: ExpoSQLiteBindParams,
-          ): Promise<ExpoSQLiteRunResult> =>
+            params?: SQLiteBindParams,
+          ): Promise<SQLiteRunResult> =>
             (await this.sendCommand({
               type: `tx:run`,
               transactionId,
               sql,
-              params,
-            })) as ExpoSQLiteRunResult,
+              params: normalizeRuntimeSqliteParams(params),
+            })) as SQLiteRunResult,
         }
 
         try {
-          const result = await task(transaction)
+          await task(transaction)
           await this.sendCommand({
             type: `tx:commit`,
             transactionId,
           })
-          return result
         } catch (error) {
           await this.sendCommand({
             type: `tx:rollback`,

--- a/packages/expo-db-sqlite-persistence/tests/helpers/expo-sqlite-test-db.ts
+++ b/packages/expo-db-sqlite-persistence/tests/helpers/expo-sqlite-test-db.ts
@@ -1,8 +1,11 @@
 import BetterSqlite3 from 'better-sqlite3'
 import type {
-  ExpoSQLiteBindParams,
+  SQLiteBindParams,
+  SQLiteBindValue,
+  SQLiteRunResult,
+} from 'expo-sqlite'
+import type {
   ExpoSQLiteDatabaseLike,
-  ExpoSQLiteRunResult,
   ExpoSQLiteTransaction,
 } from '../../src/expo-sqlite-driver'
 
@@ -23,7 +26,7 @@ declare global {
 
 function normalizeRunResult(
   result: BetterSqlite3.RunResult,
-): ExpoSQLiteRunResult {
+): SQLiteRunResult {
   return {
     changes: result.changes,
     lastInsertRowId:
@@ -34,15 +37,15 @@ function normalizeRunResult(
 }
 
 function hasNamedParameters(
-  params: ExpoSQLiteBindParams | undefined,
-): params is Record<string, unknown> {
+  params: SQLiteBindParams | undefined,
+): params is Record<string, SQLiteBindValue> {
   return params !== undefined && !Array.isArray(params)
 }
 
 function executeAll<T>(
   database: InstanceType<typeof BetterSqlite3>,
   sql: string,
-  params?: ExpoSQLiteBindParams,
+  params?: SQLiteBindParams,
 ): ReadonlyArray<T> {
   const statement = database.prepare(sql)
 
@@ -60,8 +63,8 @@ function executeAll<T>(
 function executeRun(
   database: InstanceType<typeof BetterSqlite3>,
   sql: string,
-  params?: ExpoSQLiteBindParams,
-): ExpoSQLiteRunResult {
+  params?: SQLiteBindParams,
+): SQLiteRunResult {
   const statement = database.prepare(sql)
   const result =
     params === undefined
@@ -83,13 +86,13 @@ function createTransactionHandle(
     },
     getAllAsync: <T>(
       sql: string,
-      params?: ExpoSQLiteBindParams,
+      params?: SQLiteBindParams,
     ): Promise<ReadonlyArray<T>> =>
       Promise.resolve(executeAll<T>(database, sql, params)),
     runAsync: (
       sql: string,
-      params?: ExpoSQLiteBindParams,
-    ): Promise<ExpoSQLiteRunResult> =>
+      params?: SQLiteBindParams,
+    ): Promise<SQLiteRunResult> =>
       Promise.resolve(executeRun(database, sql, params)),
   }
 }
@@ -123,13 +126,13 @@ export function createExpoSQLiteTestDatabase(options: {
     },
     getAllAsync: async <T>(
       sql: string,
-      params?: ExpoSQLiteBindParams,
+      params?: SQLiteBindParams,
     ): Promise<ReadonlyArray<T>> =>
       enqueue(() => executeAll<T>(nativeDatabase, sql, params)),
     runAsync: async (
       sql: string,
-      params?: ExpoSQLiteBindParams,
-    ): Promise<ExpoSQLiteRunResult> =>
+      params?: SQLiteBindParams,
+    ): Promise<SQLiteRunResult> =>
       enqueue(() => executeRun(nativeDatabase, sql, params)),
     withExclusiveTransactionAsync: async <T>(
       task: (transaction: ExpoSQLiteTransaction) => Promise<T>,

--- a/packages/expo-db-sqlite-persistence/tests/helpers/expo-sqlite-test-db.ts
+++ b/packages/expo-db-sqlite-persistence/tests/helpers/expo-sqlite-test-db.ts
@@ -24,9 +24,7 @@ declare global {
     | undefined
 }
 
-function normalizeRunResult(
-  result: BetterSqlite3.RunResult,
-): SQLiteRunResult {
+function normalizeRunResult(result: BetterSqlite3.RunResult): SQLiteRunResult {
   return {
     changes: result.changes,
     lastInsertRowId:


### PR DESCRIPTION
## 🎯 Changes

The basic usage pattern for `createExpoSQLitePersistence` produced a TS2322 error:

```tsx
import * as SQLite from 'expo-sqlite'
import { createExpoSQLitePersistence } from '@tanstack/expo-db-sqlite-persistence'

const database = await SQLite.openDatabaseAsync('database.sqlite')

export const persistence = createExpoSQLitePersistence({
  database,
  ^^^^^^^^
})
```

```
TS2322: Type SQLiteDatabase is not assignable to type ExpoSQLiteDatabaseLike
    Type SQLiteDatabase is not assignable to type ExpoSQLiteQueryable
        Types of property getAllAsync are incompatible.
            Type '{ <T>(source: string, params: SQLiteBindParams): Promise<T[]>; <T>(source: string, ...params SQLiteVariadicBindParams): Promise<T[]>; }' is not assignable to type '<T>(sql: string, params?: ExpoSQLiteBindParams | undefined) => Promise<readonly T[]>'.
                Types of parameters params and params are incompatible.
                    Type ExpoSQLiteBindParams | undefined is not assignable to type SQLiteBindParams
                        Type undefined is not assignable to type SQLiteBindParams
                        
expo.d.ts(7, 5): The expected type comes from property database which is declared here on type ExpoSQLitePersistenceOptions
```

The root cause was that `ExpoSQLiteQueryable` defined `getAllAsync` and `runAsync` with locally-defined loose types (`ReadonlyArray<unknown> | Record<string, unknown>`) for bind params. expo-sqlite's `SQLiteDatabase` defines these methods using strict TypeScript overloads, which TypeScript treats as incompatible with the optional params form using a different type, making `SQLiteDatabase` unassignable to `ExpoSQLiteQueryable`.

### What changed
- Replaced the locally-defined `ExpoSQLiteBindParams` and `ExpoSQLiteRunResult` types in the driver with direct imports of `SQLiteBindParams` and `SQLiteRunResult` from `expo-sqlite`, making `ExpoSQLiteQueryable` structurally compatible with the real `SQLiteDatabase`.

- Changed `withExclusiveTransactionAsync` to match expo-sqlite's actual signature which returns `Promise<void>`, not a generic `Promise<T>`. The driver captures the transaction result via a local variable to preserve the return value.

- Added `normalizeBindValue` to validate bind parameter types at the driver boundary, replacing the previous untyped spread. Also added `normalizeRuntimeSqliteParams` in the emulator runtime to explicitly reject `Uint8Array` values before they get JSON-serialized as {} over the HTTP bridge.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact
- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a TypeScript type error when using Expo SQLite database instances with the persistence layer.

* **Refactor**
  * Tightened validation and handling of SQL bind parameters for more predictable behavior.
  * Made transaction handling and runtime persistence behavior more consistent and reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->