### PR TITLE
test(db): reproduce stale buffered sync when optimistic snapback races a persisting transaction

### DIFF
--- a/packages/db/tests/auto-index-snapback.test.ts
+++ b/packages/db/tests/auto-index-snapback.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import { createCollection } from '../src/collection/index.js'
+import { createTransaction } from '../src/transactions.js'
+import { BasicIndex } from '../src/indexes/basic-index.js'
+import { createLiveQueryCollection } from '../src/query/live-query-collection.js'
+import { inArray } from '../src/query/builder/functions.js'
+import { mockSyncCollectionOptions, stripVirtualProps } from './utils.js'
+
+type Row = { id: string; stage: string }
+
+const flushTasks = () => new Promise((r) => setTimeout(r, 0))
+
+describe(`auto-index snapback after optimistic + sync, with concurrent in-flight transactions`, () => {
+  it(`single drag, no concurrent traffic — works correctly (baseline)`, async () => {
+    const options = mockSyncCollectionOptions<Row>({
+      id: `baseline`,
+      getKey: (item) => item.id,
+      initialData: [
+        { id: `P`, stage: `A` },
+        { id: `Q`, stage: `A` },
+      ],
+      autoIndex: `eager`,
+      defaultIndexType: BasicIndex,
+    })
+    const collection = createCollection(options)
+    await collection.stateWhenReady()
+
+    const liveA = createLiveQueryCollection({
+      query: (q: any) =>
+        q
+          .from({ p: collection })
+          .where(({ p }: any) => inArray(p.stage, [`A`])),
+      startSync: true,
+    })
+    await liveA.stateWhenReady()
+
+    let resolveMutation!: () => void
+    const tx = createTransaction<Row>({
+      autoCommit: false,
+      mutationFn: async () => {
+        await new Promise<void>((r) => {
+          resolveMutation = r
+        })
+      },
+    })
+    tx.mutate(() => {
+      collection.update(`P`, (d) => {
+        d.stage = `B`
+      })
+    })
+    const committed = tx.commit()
+
+    // mutationFn resolves before sync delivers — snapback happens.
+    resolveMutation()
+    await committed
+    await tx.isPersisted.promise
+    await flushTasks()
+
+    options.utils.begin()
+    options.utils.write({ type: `update`, value: { id: `P`, stage: `B` } })
+    options.utils.commit()
+    await flushTasks()
+
+    expect(stripVirtualProps(collection.get(`P`))).toEqual({
+      id: `P`,
+      stage: `B`,
+    })
+    expect(liveA.toArray.map((r: any) => r.id).sort()).toEqual([`Q`])
+  })
+
+  // BUG REPRODUCTION
+  //
+  // Models the user's "fast successive drags" scenario:
+  //
+  //   1. User drags card P from stage A → stage B → optimistic T1 starts persisting.
+  //   2. User immediately drags card Q from stage A → stage B → optimistic T2 starts persisting.
+  //   3. T1's mutationFn resolves (server-confirmed). awaitTxId races out via the snapshot
+  //      path before the shape stream has actually delivered P's row change — so when the
+  //      optimistic delta lifts, no buffered sync exists for P, and `recomputeOptimisticState`
+  //      drops P's optimistic upsert as "stale". Visible state for P snaps from B back to A.
+  //   4. The shape stream now delivers P's row change. But T2 is still persisting, so
+  //      `commitPendingTransactions` is gated on `hasPersistingTransaction` and the sync
+  //      message sits buffered in `pendingSyncedTransactions` indefinitely.
+  //   5. While T2 keeps persisting, anyone reading the live query sees P stuck in stage A
+  //      even though the server has confirmed it as stage B.
+  //
+  // In the user's app: with continuous drag traffic, the "T2 still persisting" condition
+  // is effectively always true → the buffered sync never flushes → "stays until reload".
+  //
+  // This test asserts the *correct* behaviour and is expected to FAIL until the bug is
+  // fixed; the failing CI is intentional.
+  it(`snapback + buffered sync remains stale while another transaction is persisting`, async () => {
+      const options = mockSyncCollectionOptions<Row>({
+        id: `bug-repro`,
+        getKey: (item) => item.id,
+        initialData: [
+          { id: `P`, stage: `A` },
+          { id: `Q`, stage: `A` },
+        ],
+        autoIndex: `eager`,
+        defaultIndexType: BasicIndex,
+      })
+      const collection = createCollection(options)
+      await collection.stateWhenReady()
+
+      const liveA = createLiveQueryCollection({
+        query: (q: any) =>
+          q
+            .from({ p: collection })
+            .where(({ p }: any) => inArray(p.stage, [`A`])),
+        startSync: true,
+      })
+      await liveA.stateWhenReady()
+      expect(liveA.toArray.map((r: any) => r.id).sort()).toEqual([`P`, `Q`])
+
+      // T1: optimistic P A → B
+      let resolveT1!: () => void
+      const t1 = createTransaction<Row>({
+        autoCommit: false,
+        mutationFn: async () => {
+          await new Promise<void>((r) => {
+            resolveT1 = r
+          })
+        },
+      })
+      t1.mutate(() => {
+        collection.update(`P`, (d) => {
+          d.stage = `B`
+        })
+      })
+      const c1 = t1.commit()
+
+      // T2: optimistic Q A → B (still persisting at the moment T1's sync arrives)
+      const t2 = createTransaction<Row>({
+        autoCommit: false,
+        // Never resolves during this test — modeling a long-running transaction that
+        // keeps `hasPersistingTransaction` true while T1's sync arrives.
+        mutationFn: () => new Promise<void>(() => {}),
+      })
+      t2.mutate(() => {
+        collection.update(`Q`, (d) => {
+          d.stage = `B`
+        })
+      })
+      void t2.commit()
+
+      expect(liveA.toArray.map((r: any) => r.id)).toEqual([])
+
+      // T1's mutationFn resolves (server confirmed). awaitTxId returned via snapshot path
+      // before the row delivery — so no buffered sync exists yet. Snapback happens for P.
+      resolveT1()
+      await c1
+      await t1.isPersisted.promise
+      await flushTasks()
+
+      // After the snapback for P: visible state for P reverted to synced (stage A),
+      // because no pending sync existed at the moment T1's optimistic was lifted.
+      expect(stripVirtualProps(collection.get(`P`))).toEqual({
+        id: `P`,
+        stage: `A`,
+      })
+
+      // Shape stream finally delivers P's row change. T2 is still persisting → buffered.
+      options.utils.begin()
+      options.utils.write({ type: `update`, value: { id: `P`, stage: `B` } })
+      options.utils.commit()
+      await flushTasks()
+
+      // The assertions below describe the *correct* behaviour. They currently FAIL,
+      // demonstrating the bug — collection.get and the live query both still report
+      // P as stage A even though syncedData has the new value waiting in
+      // pendingSyncedTransactions.
+      expect(stripVirtualProps(collection.get(`P`))).toEqual({
+        id: `P`,
+        stage: `B`,
+      })
+      expect(liveA.toArray.map((r: any) => r.id).sort()).toEqual([`Q`])
+  })
+})


### PR DESCRIPTION
## Summary

Adds a failing reproduction test for a stale-data bug originally reported as "auto-index returns the row in the wrong bucket after an optimistic→synced update", and confirms that the same symptom still reproduces against the fix in #1517.

The repro narrows the bug down to a different mechanism than the index-bucket lifecycle issue #1517 addressed: it lives in `commitPendingTransactions`'s gating on `hasPersistingTransaction`, not in `BasicIndex`/`BTreeIndex` or in `isRedundantSync`.

CI is intentionally red: the failing test describes the *correct* behaviour, and stays failing until the bug is fixed.

## What the test reproduces

Models the user's "fast successive drags" kanban scenario:

1. User drags card P from stage A → stage B → optimistic transaction `T1` starts persisting.
2. User immediately drags card Q from stage A → stage B → optimistic transaction `T2` starts persisting.
3. `T1`'s `mutationFn` resolves (server-confirmed). In the user's app, `awaitTxId` races out via the snapshot path before the shape stream has delivered P's row change — so when the optimistic delta lifts, no buffered sync exists for P, and `recomputeOptimisticState` drops P's optimistic upsert as "stale". Visible state for P snaps from B back to A.
4. The shape stream now delivers P's row change. But `T2` is still persisting, so `commitPendingTransactions` is gated on `hasPersistingTransaction` and the sync message sits buffered in `pendingSyncedTransactions` indefinitely.
5. While `T2` keeps persisting, anyone reading the live query sees P stuck in stage A — even though the server has confirmed it as stage B, and the sync message for that change is sitting in `pendingSyncedTransactions`.

In the user's app, with continuous drag traffic the "another transaction is persisting" condition is essentially always true, so the buffered sync never flushes → "stays until reload".

The test also includes a baseline case (single drag, no concurrent traffic) that passes — demonstrating that the bug only surfaces when a concurrent persisting transaction is blocking sync application for unrelated keys.

## Relationship to #1517

The user originally suspected `BasicIndex` was leaving keys in stale buckets; #1517 addressed that by tracking key→bucket and dropping prior buckets on `add`. They retested with #1517 applied and the snapback still reproduced. I ran this repro on both `main` and `kevin/stale-index-bucket-repro` (the #1517 branch) — same failure mode either way. So this is a separate bug; the user's `awaitMatch` workaround sidesteps it by preventing the premature optimistic lift in step 3.

This PR does not propose a fix. The probable direction is for `commitPendingTransactions` to be able to apply syncs for keys not touched by any currently-persisting transaction, instead of all-or-nothing gating on `hasPersistingTransaction`.

## Test plan

- [x] Run `tests/auto-index-snapback.test.ts` locally — baseline passes, bug-repro fails as expected.
- [x] Confirm same failure mode on the `kevin/stale-index-bucket-repro` (#1517) branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for database concurrent transaction behavior with optimistic updates, including baseline scenarios and edge case validation.
  * Identified and documented a known issue with specific concurrent transaction sequences that requires resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->