### PR TITLE
feat(db): partial AND index optimization via residual predicate

### DIFF
--- a/.changeset/fix-or-partial-union.md
+++ b/.changeset/fix-or-partial-union.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+fix(db): require all or() branches to be index-optimizable before using index result

--- a/.changeset/partial-and-residual-predicate.md
+++ b/.changeset/partial-and-residual-predicate.md
@@ -1,0 +1,11 @@
+---
+"@tanstack/db": patch
+---
+
+fix(db): re-evaluate unindexed AND branches as a residual predicate against the indexed candidate set
+
+`optimizeAndExpression` previously returned the intersection of only the index-optimizable branches and treated those keys as exact matches. With one or more branches lacking an index, the caller emitted rows that did not actually satisfy those branches — a soundness bug.
+
+`OptimizationResult` now carries an optional `residualPredicate`. When set, the caller in `currentStateAsChanges` evaluates it against each candidate key and drops rows that fail. This restores correctness for partial AND optimization while keeping the index-narrowed candidate set (~120× faster than full scan in the included benchmark).
+
+OR optimization remains strict: an unindexed OR branch can match any row, so partial OR cannot be made sound without a full scan and is rejected.

--- a/packages/db/src/collection/change-events.ts
+++ b/packages/db/src/collection/change-events.ts
@@ -138,17 +138,24 @@ export function currentStateAsChanges<
     )
 
     if (optimizationResult.canOptimize) {
-      // Use index optimization
+      // Use index optimization. When the optimizer returns a residualPredicate
+      // the candidate set is a superset — re-evaluate the residual on each
+      // candidate to confirm the match.
+      const validateResidual = optimizationResult.residualPredicate
+        ? createFilterFunctionFromExpression(
+            optimizationResult.residualPredicate,
+          )
+        : undefined
       const result: Array<ChangeMessage<WithVirtualProps<T, TKey>, TKey>> = []
       for (const key of optimizationResult.matchingKeys) {
         const value = collection.get(key)
-        if (value !== undefined) {
-          result.push({
-            type: `insert`,
-            key,
-            value,
-          })
-        }
+        if (value === undefined) continue
+        if (validateResidual && !validateResidual(value)) continue
+        result.push({
+          type: `insert`,
+          key,
+          value,
+        })
       }
       return result
     } else {

--- a/packages/db/src/utils/index-optimization.ts
+++ b/packages/db/src/utils/index-optimization.ts
@@ -469,22 +469,17 @@ function optimizeOrExpression<T extends object, TKey extends string | number>(
 
   const results: Array<OptimizationResult<TKey>> = []
 
-  // Try to optimize each part, keep the optimizable ones
   for (const arg of expression.args) {
     const result = optimizeQueryRecursive(arg, collection)
-    if (result.canOptimize) {
-      results.push(result)
+    if (!result.canOptimize) {
+      return { canOptimize: false, matchingKeys: new Set() }
     }
+    results.push(result)
   }
 
-  if (results.length === expression.args.length) {
-    // Use unionSets utility for OR logic
-    const allMatchingSets = results.map((r) => r.matchingKeys)
-    const unionedKeys = unionSets(allMatchingSets)
-    return { canOptimize: true, matchingKeys: unionedKeys }
-  }
-
-  return { canOptimize: false, matchingKeys: new Set() }
+  const allMatchingSets = results.map((r) => r.matchingKeys)
+  const unionedKeys = unionSets(allMatchingSets)
+  return { canOptimize: true, matchingKeys: unionedKeys }
 }
 
 /**

--- a/packages/db/src/utils/index-optimization.ts
+++ b/packages/db/src/utils/index-optimization.ts
@@ -498,8 +498,8 @@ function canOptimizeOrExpression<
     return false
   }
 
-  // If any argument can be optimized, we can gain some speedup
-  return expression.args.some((arg) => canOptimizeExpression(arg, collection))
+  // All branches must be optimizable — partial OR optimization is unsound
+  return expression.args.every((arg) => canOptimizeExpression(arg, collection))
 }
 
 /**

--- a/packages/db/src/utils/index-optimization.ts
+++ b/packages/db/src/utils/index-optimization.ts
@@ -477,7 +477,7 @@ function optimizeOrExpression<T extends object, TKey extends string | number>(
     }
   }
 
-  if (results.length > 0) {
+  if (results.length === expression.args.length) {
     // Use unionSets utility for OR logic
     const allMatchingSets = results.map((r) => r.matchingKeys)
     const unionedKeys = unionSets(allMatchingSets)

--- a/packages/db/src/utils/index-optimization.ts
+++ b/packages/db/src/utils/index-optimization.ts
@@ -18,6 +18,7 @@
 import { DEFAULT_COMPARE_OPTIONS } from '../utils.js'
 import { ReverseIndex } from '../indexes/reverse-index.js'
 import { hasVirtualPropPath } from '../virtual-props.js'
+import { Func } from '../query/ir.js'
 import type { CompareOptions } from '../query/builder/types.js'
 import type { IndexInterface, IndexOperation } from '../indexes/base-index.js'
 import type { BasicExpression } from '../query/ir.js'
@@ -25,10 +26,18 @@ import type { CollectionLike } from '../types.js'
 
 /**
  * Result of index-based query optimization
+ *
+ * When `residualPredicate` is set, the caller MUST evaluate it against each
+ * value in `matchingKeys` and drop rows that fail. This supports partial
+ * optimization of AND expressions where some branches are indexed and the
+ * rest must be re-checked against the candidate set.
+ *
+ * When `residualPredicate` is `undefined`, `matchingKeys` is exact.
  */
 export interface OptimizationResult<TKey> {
   canOptimize: boolean
   matchingKeys: Set<TKey>
+  residualPredicate?: BasicExpression
 }
 
 /**
@@ -138,7 +147,7 @@ function optimizeQueryRecursive<T extends object, TKey extends string | number>(
 }
 
 /**
- * Checks if an expression can be optimized
+ * Checks if an expression can be optimized (possibly with a residual predicate)
  */
 export function canOptimizeExpression<
   T extends object,
@@ -168,26 +177,70 @@ export function canOptimizeExpression<
 }
 
 /**
+ * Checks if an expression can be fully optimized — i.e. matched entirely by
+ * index lookups with no residual predicate. AND children must satisfy this
+ * recursively; partial AND optimization (which produces a residual) does not
+ * count. This is the predicate the strict-OR contract uses to decide whether
+ * an OR branch is safe to union by index alone.
+ */
+function canFullyOptimizeExpression<
+  T extends object,
+  TKey extends string | number,
+>(expression: BasicExpression, collection: CollectionLike<T, TKey>): boolean {
+  if (expression.type !== `func`) return false
+
+  switch (expression.name) {
+    case `eq`:
+    case `gt`:
+    case `gte`:
+    case `lt`:
+    case `lte`:
+      return canOptimizeSimpleComparison(expression, collection)
+    case `in`:
+      return canOptimizeInArrayExpression(expression, collection)
+    case `and`:
+      return (
+        expression.args.length >= 2 &&
+        expression.args.every((arg) =>
+          canFullyOptimizeExpression(arg, collection),
+        )
+      )
+    case `or`:
+      // OR is already strict; reuse the OR predicate, which itself recurses.
+      return canOptimizeOrExpression(expression, collection)
+    default:
+      return false
+  }
+}
+
+/**
  * Optimizes compound range queries on the same field
  * Example: WHERE age > 5 AND age < 10
  */
+interface CompoundRangeQueryResult<TKey> {
+  matchingKeys: Set<TKey>
+  consumedArgs: Set<BasicExpression>
+}
+
 function optimizeCompoundRangeQuery<
   T extends object,
   TKey extends string | number,
 >(
   expression: BasicExpression,
   collection: CollectionLike<T, TKey>,
-): OptimizationResult<TKey> {
+): CompoundRangeQueryResult<TKey> | undefined {
   if (expression.type !== `func` || expression.args.length < 2) {
-    return { canOptimize: false, matchingKeys: new Set() }
+    return undefined
   }
 
-  // Group range operations by field
+  // Group range operations by field, tracking which arg produced each entry so
+  // we can report back exactly which branches the compound range consumed.
   const fieldOperations = new Map<
     string,
     Array<{
       operation: `gt` | `gte` | `lt` | `lte`
       value: any
+      arg: BasicExpression
     }>
   >()
 
@@ -238,7 +291,7 @@ function optimizeCompoundRangeQuery<
           if (!fieldOperations.has(fieldKey)) {
             fieldOperations.set(fieldKey, [])
           }
-          fieldOperations.get(fieldKey)!.push({ operation, value })
+          fieldOperations.get(fieldKey)!.push({ operation, value, arg })
         }
       }
     }
@@ -293,12 +346,15 @@ function optimizeCompoundRangeQuery<
           toInclusive,
         })
 
-        return { canOptimize: true, matchingKeys }
+        const consumedArgs = new Set<BasicExpression>(
+          operations.map((op) => op.arg),
+        )
+        return { matchingKeys, consumedArgs }
       }
     }
   }
 
-  return { canOptimize: false, matchingKeys: new Set() }
+  return undefined
 }
 
 /**
@@ -415,30 +471,52 @@ function optimizeAndExpression<T extends object, TKey extends string | number>(
     return { canOptimize: false, matchingKeys: new Set() }
   }
 
-  // First, try to optimize compound range queries on the same field
+  // Compound range queries fuse multiple range ops on the same field into a
+  // single index lookup. When present, treat the fused result as one optimized
+  // branch and run the normal partition over the remaining args, so any
+  // non-range siblings (indexed or not) still participate in the residual.
   const compoundRangeResult = optimizeCompoundRangeQuery(expression, collection)
-  if (compoundRangeResult.canOptimize) {
-    return compoundRangeResult
+
+  const optimizedResults: Array<OptimizationResult<TKey>> = []
+  const residualBranches: Array<BasicExpression> = []
+
+  if (compoundRangeResult) {
+    optimizedResults.push({
+      canOptimize: true,
+      matchingKeys: compoundRangeResult.matchingKeys,
+    })
   }
 
-  const results: Array<OptimizationResult<TKey>> = []
-
-  // Try to optimize each part, keep the optimizable ones
+  // Partition branches into ones we can use indexes for, and ones that need to
+  // be re-evaluated as a residual predicate on the resulting candidate set.
   for (const arg of expression.args) {
+    if (compoundRangeResult?.consumedArgs.has(arg)) continue
     const result = optimizeQueryRecursive(arg, collection)
     if (result.canOptimize) {
-      results.push(result)
+      optimizedResults.push(result)
+      // A partially-optimized child carries its own residual; fold it in.
+      if (result.residualPredicate) {
+        residualBranches.push(result.residualPredicate)
+      }
+    } else {
+      residualBranches.push(arg)
     }
   }
 
-  if (results.length > 0) {
-    // Use intersectSets utility for AND logic
-    const allMatchingSets = results.map((r) => r.matchingKeys)
-    const intersectedKeys = intersectSets(allMatchingSets)
-    return { canOptimize: true, matchingKeys: intersectedKeys }
+  if (optimizedResults.length === 0) {
+    return { canOptimize: false, matchingKeys: new Set() }
   }
 
-  return { canOptimize: false, matchingKeys: new Set() }
+  const allMatchingSets = optimizedResults.map((r) => r.matchingKeys)
+  const intersectedKeys = intersectSets(allMatchingSets)
+  const residualPredicate =
+    residualBranches.length === 0
+      ? undefined
+      : residualBranches.length === 1
+        ? residualBranches[0]
+        : new Func(`and`, residualBranches)
+
+  return { canOptimize: true, matchingKeys: intersectedKeys, residualPredicate }
 }
 
 /**
@@ -467,11 +545,26 @@ function optimizeOrExpression<T extends object, TKey extends string | number>(
     return { canOptimize: false, matchingKeys: new Set() }
   }
 
-  const results: Array<OptimizationResult<TKey>> = []
+  // Strict-OR: every branch must be fully optimizable (no residual). A residual
+  // on any branch would mean some rows match only via re-evaluation against a
+  // candidate set, and candidates from OR siblings don't include those. Check
+  // up front using the cheap predicate so we don't run wasted index lookups on
+  // earlier branches before discovering a later one cannot be optimized.
+  if (
+    !expression.args.every((arg) =>
+      canFullyOptimizeExpression(arg, collection),
+    )
+  ) {
+    return { canOptimize: false, matchingKeys: new Set() }
+  }
 
+  const results: Array<OptimizationResult<TKey>> = []
   for (const arg of expression.args) {
     const result = optimizeQueryRecursive(arg, collection)
-    if (!result.canOptimize) {
+    // Defensive: canFullyOptimizeExpression guarantees both invariants above,
+    // but assert here so any future divergence between the two paths surfaces
+    // as a soft fallback rather than an unsound union.
+    if (!result.canOptimize || result.residualPredicate !== undefined) {
       return { canOptimize: false, matchingKeys: new Set() }
     }
     results.push(result)
@@ -493,8 +586,12 @@ function canOptimizeOrExpression<
     return false
   }
 
-  // All branches must be optimizable — partial OR optimization is unsound
-  return expression.args.every((arg) => canOptimizeExpression(arg, collection))
+  // Strict OR: every branch must be FULLY optimizable (no residual). Using
+  // canOptimizeExpression here would let partial-AND children slip through,
+  // disagreeing with optimizeOrExpression's runtime contract.
+  return expression.args.every((arg) =>
+    canFullyOptimizeExpression(arg, collection),
+  )
 }
 
 /**

--- a/packages/db/tests/collection-indexes.test.ts
+++ b/packages/db/tests/collection-indexes.test.ts
@@ -1048,6 +1048,172 @@ describe(`Collection Indexes`, () => {
       })
     })
 
+    it(`should narrow via multiple indexed AND branches and re-filter unindexed`, () => {
+      // status='active' matches Alice, Charlie, Eve (3 rows).
+      // age>=25 matches Alice, Bob, Charlie, Diana (4 rows).
+      // Intersection of indexed branches: Alice, Charlie.
+      // name='Alice' residual filters to: Alice.
+      withIndexTracking(collection, (tracker) => {
+        const result = collection.currentStateAsChanges({
+          where: and(
+            eq(new PropRef([`status`]), `active`),
+            gte(new PropRef([`age`]), 25),
+            eq(new PropRef([`name`]), `Alice`),
+          ),
+        })!
+
+        expect(result).toHaveLength(1)
+        expect(result[0]?.value.name).toBe(`Alice`)
+
+        // Both indexed branches used; name re-filtered.
+        expectIndexUsage(tracker.stats, {
+          shouldUseIndex: true,
+          shouldUseFullScan: false,
+          indexCallCount: 2,
+          fullScanCallCount: 0,
+        })
+      })
+    })
+
+    it(`should hoist nested-OR result into AND with unindexed residual`, () => {
+      // or(status='active', status='pending') is fully indexed → 4 candidates.
+      // name='Alice' is the AND residual, narrows to Alice only.
+      const result = collection.currentStateAsChanges({
+        where: and(
+          or(
+            eq(new PropRef([`status`]), `active`),
+            eq(new PropRef([`status`]), `pending`),
+          ),
+          eq(new PropRef([`name`]), `Alice`),
+        ),
+      })!
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.value.name).toBe(`Alice`)
+    })
+
+    it(`should reject OR when a child AND would return a residual (strict OR)`, () => {
+      // and(status='active', name='Alice') is partially optimizable — produces
+      // canOptimize:true with a residual on name. OR must reject children with
+      // residuals: a candidate set narrowed by partial AND would be incomplete
+      // for the OR's union semantics, so the whole OR falls back to full scan.
+      withIndexTracking(collection, (tracker) => {
+        const result = collection.currentStateAsChanges({
+          where: or(
+            and(
+              eq(new PropRef([`status`]), `active`),
+              eq(new PropRef([`name`]), `Alice`),
+            ),
+            eq(new PropRef([`age`]), 30),
+          ),
+        })!
+
+        // Alice (active+Alice) ∪ Bob (age=30) = 2 rows
+        expect(result).toHaveLength(2)
+        const names = result.map((r) => r.value.name).sort()
+        expect(names).toEqual([`Alice`, `Bob`])
+
+        // Strict OR rejects up front — no index lookups should run.
+        expectIndexUsage(tracker.stats, {
+          shouldUseIndex: false,
+          shouldUseFullScan: true,
+          indexCallCount: 0,
+          fullScanCallCount: 1,
+        })
+      })
+    })
+
+    it(`should reject partial optimization inside OR (strict OR)`, () => {
+      // or(status='active', name='Alice'): name has no index. OR cannot be
+      // partially optimized — must fall back to full scan to remain sound.
+      withIndexTracking(collection, (tracker) => {
+        const result = collection.currentStateAsChanges({
+          where: or(
+            eq(new PropRef([`status`]), `active`),
+            eq(new PropRef([`name`]), `Alice`),
+          ),
+        })!
+
+        // 3 active rows ∪ {Alice} = 3 (Alice is already active)
+        expect(result).toHaveLength(3)
+        const names = result.map((r) => r.value.name).sort()
+        expect(names).toEqual([`Alice`, `Charlie`, `Eve`])
+
+        expectIndexUsage(tracker.stats, {
+          shouldUseIndex: false,
+          shouldUseFullScan: true,
+          indexCallCount: 0,
+          fullScanCallCount: 1,
+        })
+      })
+    })
+
+    it(`should not produce a residual when all AND branches are indexed`, () => {
+      // Regression guard: fully indexed AND must not trigger unnecessary
+      // residual composition or re-evaluation.
+      withIndexTracking(collection, (tracker) => {
+        const result = collection.currentStateAsChanges({
+          where: and(
+            eq(new PropRef([`status`]), `active`),
+            eq(new PropRef([`age`]), 25),
+          ),
+        })!
+
+        expect(result).toHaveLength(1)
+        expect(result[0]?.value.name).toBe(`Alice`)
+
+        expectIndexUsage(tracker.stats, {
+          shouldUseIndex: true,
+          shouldUseFullScan: false,
+          indexCallCount: 2,
+          fullScanCallCount: 0,
+        })
+      })
+    })
+
+    it(`should re-filter candidates after compound-range optimization (soundness)`, () => {
+      // age in [25, 35] matches Alice(25), Bob(30), Charlie(35), Diana(28) — 4 rows.
+      // name='Alice' should narrow to 1 row.
+      // Bug: optimizeCompoundRangeQuery short-circuits in optimizeAndExpression
+      // and returns the age-range candidates with no residual on name.
+      const result = collection.currentStateAsChanges({
+        where: and(
+          gte(new PropRef([`age`]), 25),
+          lte(new PropRef([`age`]), 35),
+          eq(new PropRef([`name`]), `Alice`),
+        ),
+      })!
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.value.name).toBe(`Alice`)
+    })
+
+    it(`should re-filter candidates against unindexed AND branch (soundness)`, () => {
+      // status='active' matches 3 rows: Alice, Charlie, Eve.
+      // name='Alice' matches 1 row: Alice. No index on name.
+      // Pre-fix: returns all 3 active rows (intersected only the indexed branch).
+      // Post-fix: returns only Alice (residual predicate re-checked on candidates).
+      withIndexTracking(collection, (tracker) => {
+        const result = collection.currentStateAsChanges({
+          where: and(
+            eq(new PropRef([`status`]), `active`),
+            eq(new PropRef([`name`]), `Alice`),
+          ),
+        })!
+
+        expect(result).toHaveLength(1)
+        expect(result[0]?.value.name).toBe(`Alice`)
+
+        // Index used once on status; name re-filtered in JS against candidates.
+        expectIndexUsage(tracker.stats, {
+          shouldUseIndex: true,
+          shouldUseFullScan: false,
+          indexCallCount: 1,
+          fullScanCallCount: 0,
+        })
+      })
+    })
+
     it(`should fall back to full scan when no conditions can be optimized`, () => {
       withIndexTracking(collection, (tracker) => {
         // Only complex expressions that can't be optimized

--- a/packages/db/tests/index-optimization.bench.ts
+++ b/packages/db/tests/index-optimization.bench.ts
@@ -1,0 +1,113 @@
+import { bench, describe } from 'vitest'
+import mitt from 'mitt'
+import { createCollection } from '../src/collection/index.js'
+import { and, eq } from '../src/query/builder/functions'
+import { PropRef } from '../src/query/ir'
+import { BTreeIndex } from '../src/indexes/btree-index.js'
+import type { Collection } from '../src/collection/index.js'
+
+interface Row {
+  id: string
+  age: number
+  status: 'active' | 'inactive' | 'pending' | 'archived'
+  name: string
+}
+
+const COLLECTION_SIZE = 10_000
+const TARGET_AGE = 25
+const TARGET_NAME = `user-2500`
+
+function buildData(): Array<Row> {
+  const statuses: Array<Row['status']> = [
+    `active`,
+    `inactive`,
+    `pending`,
+    `archived`,
+  ]
+  const rows: Array<Row> = []
+  for (let i = 0; i < COLLECTION_SIZE; i++) {
+    rows.push({
+      id: String(i),
+      age: i % 100,
+      status: statuses[i % 4]!,
+      name: `user-${i}`,
+    })
+  }
+  return rows
+}
+
+function buildCollection(
+  data: Array<Row>,
+  indexFields: Array<keyof Row>,
+): Collection<Row, string> {
+  const emitter = mitt()
+  const collection = createCollection<Row, string>({
+    getKey: (item) => item.id,
+    startSync: true,
+    sync: {
+      sync: ({ begin, write, commit, markReady }) => {
+        begin()
+        for (const item of data) {
+          write({ type: `insert`, value: item })
+        }
+        commit()
+        markReady()
+        if (!emitter.all.has(`sync`)) {
+          emitter.on(`sync`, () => {})
+        }
+      },
+    },
+  })
+  for (const field of indexFields) {
+    collection.createIndex((row: Row) => row[field], {
+      indexType: BTreeIndex,
+    })
+  }
+  return collection
+}
+
+const data = buildData()
+const expectedMatches = data.filter(
+  (r) => r.age === TARGET_AGE && r.name === TARGET_NAME,
+).length
+
+const whereExpr = and(
+  eq(new PropRef([`age`]), TARGET_AGE),
+  eq(new PropRef([`name`]), TARGET_NAME),
+)
+
+// Sanity-check the scenarios return identical results before benching.
+const collections = {
+  fullScan: buildCollection(data, []),
+  partialIndex: buildCollection(data, [`age`]),
+  fullIndex: buildCollection(data, [`age`, `name`]),
+}
+for (const [label, col] of Object.entries(collections)) {
+  const result = col.currentStateAsChanges({ where: whereExpr })
+  if (result === undefined) {
+    throw new Error(
+      `Bench setup soundness check failed for ${label}: ` +
+        `currentStateAsChanges returned undefined`,
+    )
+  }
+  if (result.length !== expectedMatches) {
+    throw new Error(
+      `Bench setup soundness check failed for ${label}: ` +
+        `expected ${expectedMatches} match(es), got ${result.length}`,
+    )
+  }
+}
+
+describe(`index-optimization: AND with mixed indexed/unindexed branches`, () => {
+  bench(`full scan (no indexes)`, () => {
+    collections.fullScan.currentStateAsChanges({ where: whereExpr })
+  })
+
+  bench(`partial index (age only — residual on name)`, () => {
+    collections.partialIndex.currentStateAsChanges({ where: whereExpr })
+  })
+
+  bench(`full index (age + name)`, () => {
+    collections.fullIndex.currentStateAsChanges({ where: whereExpr })
+  })
+})

--- a/packages/db/tests/query/or-partial-optimization.test.ts
+++ b/packages/db/tests/query/or-partial-optimization.test.ts
@@ -36,13 +36,13 @@ describe(`or() with partially indexed branches`, () => {
     })
 
     const liveQuery = createLiveQueryCollection({
-      query: (q: any) =>
+      query: (q) =>
         q
           .from({ item: collection })
-          .where(({ item }: any) =>
+          .where(({ item }) =>
             or(eq(item.category, `A`), eq(item.tag, `x`)),
           )
-          .select(({ item }: any) => ({
+          .select(({ item }) => ({
             id: item.id,
             category: item.category,
             tag: item.tag,

--- a/packages/db/tests/query/or-partial-optimization.test.ts
+++ b/packages/db/tests/query/or-partial-optimization.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { createCollection } from '../../src/collection/index.js'
+import { BasicIndex } from '../../src/indexes/basic-index.js'
+import { createLiveQueryCollection } from '../../src/query/live-query-collection'
+import { eq, or } from '../../src/query/builder/functions'
+import { mockSyncCollectionOptions } from '../utils'
+
+interface TestItem {
+  id: string
+  category: string
+  tag: string
+}
+
+const testData: Array<TestItem> = [
+  { id: `1`, category: `A`, tag: `x` },
+  { id: `2`, category: `B`, tag: `y` },
+  { id: `3`, category: `A`, tag: `z` },
+  { id: `4`, category: `C`, tag: `x` },
+]
+
+describe(`or() with partially indexed branches`, () => {
+  it(`returns all matching rows when only one or() branch is indexed`, async () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<TestItem>({
+        id: `or-partial-index`,
+        getKey: (item) => item.id,
+        initialData: testData,
+        autoIndex: `off`,
+      }),
+    )
+
+    await collection.stateWhenReady()
+
+    collection.createIndex((row) => row.category, {
+      indexType: BasicIndex,
+    })
+
+    const liveQuery = createLiveQueryCollection({
+      query: (q: any) =>
+        q
+          .from({ item: collection })
+          .where(({ item }: any) =>
+            or(eq(item.category, `A`), eq(item.tag, `x`)),
+          )
+          .select(({ item }: any) => ({
+            id: item.id,
+            category: item.category,
+            tag: item.tag,
+          })),
+      startSync: true,
+    })
+
+    await liveQuery.stateWhenReady()
+
+    const ids = liveQuery.toArray.map((r) => r.id).sort()
+    expect(ids).toEqual([`1`, `3`, `4`])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

> Stacks on #1550 — that PR should land first; the OR-strictness commits show in this diff until then.

Fixes a soundness bug in `optimizeAndExpression` where partial AND optimization returned the intersection of only the index-optimizable branches and the caller treated those keys as exact matches, silently dropping the constraint from unindexed branches. The bug was masked today by the existing partial-AND test only because the test data had a single row per `age` value.

The fix adds candidate-set semantics: indexed branches narrow the candidate set; unindexed branches are re-evaluated as a residual predicate against that set. Standard query-optimizer pattern, and for the in-memory case it preserves the index speedup almost entirely.

**API change** — additive, non-breaking:

```ts
export interface OptimizationResult<TKey> {
  canOptimize: boolean
  matchingKeys: Set<TKey>
  residualPredicate?: BasicExpression // new
}
```

When `residualPredicate` is set, the caller MUST evaluate it against each `matchingKeys` entry and drop rows that fail. When `undefined`, `matchingKeys` is exact.

**Optimizer:**

- **AND** — partitions branches into optimizable / non-optimizable. `matchingKeys` = intersection of optimizable branches' key sets. Residual = `and(...childResiduals, ...nonOptimizableBranches)` (or the single element directly, or `undefined`).
- **Compound range** — when `optimizeCompoundRangeQuery` fuses range ops on one field inside a larger AND, the args it consumed are tracked, and the remaining AND args participate in the residual. Previously the compound-range path short-circuited and bypassed residual composition entirely (e.g. `and(gte(age, 18), lte(age, 65), eq(name, 'Alice'))` silently dropped the name constraint).
- **OR** — strict: every branch must be fully optimizable, no residual. A new `canFullyOptimizeExpression` helper expresses the strict-OR contract (an AND child must have **all** branches optimizable, not just one); `canOptimizeOrExpression` and `optimizeOrExpression` both use it. The runtime path now short-circuits up front via this predicate, so no wasted index lookups occur when the OR will ultimately reject — strict-OR tests assert `shouldUseIndex: false, fullScanCallCount: 1`.
- **Leaf optimizers** unchanged; never produce a residual.

**Caller** (`currentStateAsChanges`) builds a filter from `residualPredicate` (if any) and drops candidates that fail it.

**Why this shape for an in-memory DB**: dominant cost is per-row JS predicate evaluation, not I/O. Index lookups against in-memory `Map`/`BTree` are cheap enough that taking the full intersection up front is fine — no cost-based "most-selective driver" needed. The saving comes from skipping residual evaluation on the `N − |matchingKeys|` rows the index already eliminated. For OR with a non-indexed branch, you'd still have to scan the complement to find matches, so partial OR is intentionally out of scope.

**Benchmark** (`tests/index-optimization.bench.ts`, 10k rows, `and(eq(age, 25), eq(name, 'user-2500'))`):

| Scenario                                    | ops/sec     | vs full scan |
| ------------------------------------------- | ----------- | ------------ |
| Full scan (no indexes)                      | 142         | 1×           |
| Partial index (age only, name as residual)  | 17,755      | ~125× faster |
| Full index (age + name)                     | 289,535     | ~2,046× faster |

**Tests** (added to `tests/collection-indexes.test.ts`): hardened soundness for partial AND, multi-arity AND, compound-range with non-range residual, nested OR-inside-AND with residual, strict-OR rejecting both leaf-unindexed and AND-with-residual children (both assert no index calls + 1 full scan), and a regression guard that fully indexed AND produces no residual. All 2379 tests pass (5 skipped); 0 lint errors; types clean.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query results now correctly re-filter candidates when only part of an AND can use indexes, preventing over-inclusive results.
  * OR optimization now requires all branches to be fully index-optimizable, avoiding incorrect partial optimizations.
  * Change events now re-evaluate residual predicates before emitting inserts to ensure emitted rows truly match.

* **Tests**
  * Added regression tests and benchmarks covering mixed indexed/unindexed query scenarios and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/db/pull/1562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->