### PR TITLE
chore: add changeset for materialize() helper (#1504)

### DIFF
--- a/.changeset/materialize-includes-helper.md
+++ b/.changeset/materialize-includes-helper.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Added the `materialize()` helper for includes subqueries. Multi-row subqueries produce an `Array<T>` snapshot on the parent row (equivalent to `toArray()`), and `findOne()` subqueries produce a single `T | undefined` value. The snapshot updates reactively as the underlying children change.


### PR DESCRIPTION
## Summary
- Adds the changeset that was missing from #1504 (`feat: add materialize() helper for includes subqueries`).
- Patch bump for `@tanstack/db`, matching the bump level used for the recent `caseWhen` / `unionAll` additions.

## Test plan
- [ ] CI passes (changeset-only change, no code paths touched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new helper for materializing subqueries within include operations, enabling reactive data snapshots
  * Supports both multi-row aggregate results and single-row specific queries
  * Snapshot data automatically updates reactively when underlying child records are modified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->