### PR TITLE
feat(sqlite-persistence): prune applied_tx by default with safe replay recovery

### DIFF
--- a/.changeset/node-default-applied-tx-pruning.md
+++ b/.changeset/node-default-applied-tx-pruning.md
@@ -1,8 +1,14 @@
 ---
+'@tanstack/browser-db-sqlite-persistence': minor
+'@tanstack/capacitor-db-sqlite-persistence': minor
+'@tanstack/cloudflare-durable-objects-db-sqlite-persistence': minor
+'@tanstack/db-sqlite-persistence-core': minor
+'@tanstack/expo-db-sqlite-persistence': minor
 '@tanstack/node-db-sqlite-persistence': minor
-'@tanstack/db-sqlite-persistence-core': patch
+'@tanstack/react-native-db-sqlite-persistence': minor
+'@tanstack/tauri-db-sqlite-persistence': minor
 ---
 
-`createNodeSQLitePersistence` now prunes the `applied_tx` log by default so the SQLite file no longer grows without bound. When prune options are omitted, the node driver applies `appliedTxPruneMaxRows: 1_000` and `appliedTxPruneMaxAgeSeconds: 86_400` (24h). Both remain overridable, and passing `0` disables that limit. The defaults are exported as `DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS` and `DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS`.
+SQLite persistence wrappers now prune the `applied_tx` replay log by default so SQLite files no longer grow without bound. When prune options are omitted, wrappers that construct the shared SQLite core adapter apply `appliedTxPruneMaxRows: 1_000` and `appliedTxPruneMaxAgeSeconds: 86_400` (24h). Both remain overridable, and passing `0` disables that limit. The defaults are exported as `DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS` and `DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS` from the shared SQLite core package and re-exported by wrapper packages.
 
-The shared SQLite core adapter now treats `applied_tx` as a bounded replay cache during `pullSince` recovery. If a recovery request starts before the retained replay window, `pullSince` returns `requiresFullReload: true` instead of returning partial deltas. This safety fix applies to every SQLite persistence wrapper that opts into `applied_tx` pruning; this changeset only enables pruning by default for the Node wrapper.
+The shared SQLite core adapter now treats `applied_tx` as a bounded replay cache during `pullSince` recovery. If a recovery request starts before the retained replay window, `pullSince` returns `requiresFullReload: true` instead of returning partial deltas.

--- a/.changeset/node-default-applied-tx-pruning.md
+++ b/.changeset/node-default-applied-tx-pruning.md
@@ -1,5 +1,8 @@
 ---
 '@tanstack/node-db-sqlite-persistence': minor
+'@tanstack/db-sqlite-persistence-core': patch
 ---
 
 `createNodeSQLitePersistence` now prunes the `applied_tx` log by default so the SQLite file no longer grows without bound. When prune options are omitted, the node driver applies `appliedTxPruneMaxRows: 1_000` and `appliedTxPruneMaxAgeSeconds: 86_400` (24h). Both remain overridable, and passing `0` disables that limit. The defaults are exported as `DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS` and `DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS`.
+
+The shared SQLite core adapter now treats `applied_tx` as a bounded replay cache during `pullSince` recovery. If a recovery request starts before the retained replay window, `pullSince` returns `requiresFullReload: true` instead of returning partial deltas. This safety fix applies to every SQLite persistence wrapper that opts into `applied_tx` pruning; this changeset only enables pruning by default for the Node wrapper.

--- a/.changeset/node-default-applied-tx-pruning.md
+++ b/.changeset/node-default-applied-tx-pruning.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/node-db-sqlite-persistence': minor
+---
+
+`createNodeSQLitePersistence` now prunes the `applied_tx` log by default so the SQLite file no longer grows without bound. When prune options are omitted, the node driver applies `appliedTxPruneMaxRows: 1_000` and `appliedTxPruneMaxAgeSeconds: 86_400` (24h). Both remain overridable, and passing `0` disables that limit. The defaults are exported as `DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS` and `DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS`.

--- a/packages/browser-db-sqlite-persistence/src/browser-persistence.ts
+++ b/packages/browser-db-sqlite-persistence/src/browser-persistence.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
   SingleProcessCoordinator,
   createSQLiteCorePersistenceAdapter,
 } from '@tanstack/db-sqlite-persistence-core'
@@ -78,8 +80,11 @@ function resolveAdapterBaseOptions(
   `driver` | `schemaVersion` | `schemaMismatchPolicy`
 > {
   return {
-    appliedTxPruneMaxRows: options.appliedTxPruneMaxRows,
-    appliedTxPruneMaxAgeSeconds: options.appliedTxPruneMaxAgeSeconds,
+    appliedTxPruneMaxRows:
+      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+    appliedTxPruneMaxAgeSeconds:
+      options.appliedTxPruneMaxAgeSeconds ??
+      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }

--- a/packages/browser-db-sqlite-persistence/src/index.ts
+++ b/packages/browser-db-sqlite-persistence/src/index.ts
@@ -8,7 +8,11 @@ export type {
 } from './browser-persistence'
 export type { OpenBrowserWASQLiteOPFSDatabaseOptions } from './opfs-database'
 export type { BrowserCollectionCoordinatorOptions } from './browser-coordinator'
-export { persistedCollectionOptions } from '@tanstack/db-sqlite-persistence-core'
+export {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+  persistedCollectionOptions,
+} from '@tanstack/db-sqlite-persistence-core'
 export type {
   PersistedCollectionCoordinator,
   PersistedCollectionPersistence,

--- a/packages/capacitor-db-sqlite-persistence/src/capacitor-persistence.ts
+++ b/packages/capacitor-db-sqlite-persistence/src/capacitor-persistence.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
   SingleProcessCoordinator,
   createSQLiteCorePersistenceAdapter,
 } from '@tanstack/db-sqlite-persistence-core'
@@ -81,8 +83,11 @@ function resolveAdapterBaseOptions(
   `driver` | `schemaVersion` | `schemaMismatchPolicy`
 > {
   return {
-    appliedTxPruneMaxRows: options.appliedTxPruneMaxRows,
-    appliedTxPruneMaxAgeSeconds: options.appliedTxPruneMaxAgeSeconds,
+    appliedTxPruneMaxRows:
+      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+    appliedTxPruneMaxAgeSeconds:
+      options.appliedTxPruneMaxAgeSeconds ??
+      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }

--- a/packages/capacitor-db-sqlite-persistence/src/index.ts
+++ b/packages/capacitor-db-sqlite-persistence/src/index.ts
@@ -5,7 +5,11 @@ export type {
   CapacitorSQLiteSchemaMismatchPolicy,
   SQLiteDBConnection,
 } from './capacitor'
-export { persistedCollectionOptions } from '@tanstack/db-sqlite-persistence-core'
+export {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+  persistedCollectionOptions,
+} from '@tanstack/db-sqlite-persistence-core'
 export type {
   PersistedCollectionCoordinator,
   PersistedCollectionPersistence,

--- a/packages/cloudflare-durable-objects-db-sqlite-persistence/src/do-persistence.ts
+++ b/packages/cloudflare-durable-objects-db-sqlite-persistence/src/do-persistence.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
   SingleProcessCoordinator,
   createSQLiteCorePersistenceAdapter,
 } from '@tanstack/db-sqlite-persistence-core'
@@ -79,8 +81,11 @@ function resolveAdapterBaseOptions(
   `driver` | `schemaVersion` | `schemaMismatchPolicy`
 > {
   return {
-    appliedTxPruneMaxRows: options.appliedTxPruneMaxRows,
-    appliedTxPruneMaxAgeSeconds: options.appliedTxPruneMaxAgeSeconds,
+    appliedTxPruneMaxRows:
+      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+    appliedTxPruneMaxAgeSeconds:
+      options.appliedTxPruneMaxAgeSeconds ??
+      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }

--- a/packages/cloudflare-durable-objects-db-sqlite-persistence/src/index.ts
+++ b/packages/cloudflare-durable-objects-db-sqlite-persistence/src/index.ts
@@ -4,7 +4,11 @@ export type {
   CloudflareDOSQLitePersistenceOptions,
   DurableObjectStorageLike,
 } from './do-persistence'
-export { persistedCollectionOptions } from '@tanstack/db-sqlite-persistence-core'
+export {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+  persistedCollectionOptions,
+} from '@tanstack/db-sqlite-persistence-core'
 export type {
   PersistedCollectionCoordinator,
   PersistedCollectionPersistence,

--- a/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
+++ b/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
@@ -73,6 +73,21 @@ export type SQLitePullSinceResult<TKey extends string | number> =
 
 const DEFAULT_SCHEMA_VERSION = 1
 const DEFAULT_PULL_SINCE_RELOAD_THRESHOLD = 128
+
+/**
+ * Default cap on retained `applied_tx` rows per collection. The log is a
+ * replayable cache, so a bounded row count keeps SQLite files from growing
+ * without limit. Pass `appliedTxPruneMaxRows: 0` to disable the row cap.
+ */
+export const DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS = 1_000
+
+/**
+ * Default age backstop for retained `applied_tx` rows, in seconds (24h). Rows
+ * older than this are pruned on the next write. Pass
+ * `appliedTxPruneMaxAgeSeconds: 0` to disable the age backstop.
+ */
+export const DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS = 24 * 60 * 60
+
 const SQLITE_MAX_IN_BATCH_SIZE = 900
 const SAFE_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 const FORBIDDEN_SQL_FRAGMENT_PATTERN = /(;|--|\/\*)/

--- a/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
+++ b/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
@@ -1540,8 +1540,13 @@ export class SQLiteCorePersistenceAdapter implements PersistenceAdapter {
     const collectionTableSql = quoteIdentifier(tableMapping.tableName)
     const tombstoneTableSql = quoteIdentifier(tableMapping.tombstoneTableName)
 
-    const [changedRows, deletedRows, latestVersionRows, replayRows] =
-      await Promise.all([
+    const [
+      changedRows,
+      deletedRows,
+      latestVersionRows,
+      replayRows,
+      replayAvailabilityRows,
+    ] = await Promise.all([
         this.driver.query<{ key: string }>(
           `SELECT key
          FROM ${collectionTableSql}
@@ -1573,9 +1578,26 @@ export class SQLiteCorePersistenceAdapter implements PersistenceAdapter {
          ORDER BY term ASC, seq ASC`,
           [collectionId, fromRowVersion],
         ),
+        this.driver.query<{ min_row_version: number | null }>(
+          `SELECT MIN(row_version) AS min_row_version
+         FROM applied_tx
+         WHERE collection_id = ?`,
+          [collectionId],
+        ),
       ])
 
     const latestRowVersion = latestVersionRows[0]?.latest_row_version ?? 0
+    const replayFloor = replayAvailabilityRows[0]?.min_row_version
+    if (
+      latestRowVersion > fromRowVersion &&
+      (replayFloor == null || replayFloor > fromRowVersion + 1)
+    ) {
+      return {
+        latestRowVersion,
+        requiresFullReload: true,
+      }
+    }
+
     const changedKeyCount = changedRows.length + deletedRows.length
 
     if (changedKeyCount > this.pullSinceReloadThreshold) {

--- a/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
+++ b/packages/db-sqlite-persistence-core/src/sqlite-core-adapter.ts
@@ -1547,44 +1547,44 @@ export class SQLiteCorePersistenceAdapter implements PersistenceAdapter {
       replayRows,
       replayAvailabilityRows,
     ] = await Promise.all([
-        this.driver.query<{ key: string }>(
-          `SELECT key
+      this.driver.query<{ key: string }>(
+        `SELECT key
          FROM ${collectionTableSql}
          WHERE row_version > ?`,
-          [fromRowVersion],
-        ),
-        this.driver.query<{ key: string }>(
-          `SELECT key
+        [fromRowVersion],
+      ),
+      this.driver.query<{ key: string }>(
+        `SELECT key
          FROM ${tombstoneTableSql}
          WHERE row_version > ?`,
-          [fromRowVersion],
-        ),
-        this.driver.query<{ latest_row_version: number }>(
-          `SELECT latest_row_version
+        [fromRowVersion],
+      ),
+      this.driver.query<{ latest_row_version: number }>(
+        `SELECT latest_row_version
          FROM collection_version
          WHERE collection_id = ?
          LIMIT 1`,
-          [collectionId],
-        ),
-        this.driver.query<{
-          tx_id: string
-          row_version: number
-          replay_json: string | null
-          replay_requires_full_reload: number
-        }>(
-          `SELECT tx_id, row_version, replay_json, replay_requires_full_reload
+        [collectionId],
+      ),
+      this.driver.query<{
+        tx_id: string
+        row_version: number
+        replay_json: string | null
+        replay_requires_full_reload: number
+      }>(
+        `SELECT tx_id, row_version, replay_json, replay_requires_full_reload
          FROM applied_tx
          WHERE collection_id = ? AND row_version > ?
          ORDER BY term ASC, seq ASC`,
-          [collectionId, fromRowVersion],
-        ),
-        this.driver.query<{ min_row_version: number | null }>(
-          `SELECT MIN(row_version) AS min_row_version
+        [collectionId, fromRowVersion],
+      ),
+      this.driver.query<{ min_row_version: number | null }>(
+        `SELECT MIN(row_version) AS min_row_version
          FROM applied_tx
          WHERE collection_id = ?`,
-          [collectionId],
-        ),
-      ])
+        [collectionId],
+      ),
+    ])
 
     const latestRowVersion = latestVersionRows[0]?.latest_row_version ?? 0
     const replayFloor = replayAvailabilityRows[0]?.min_row_version

--- a/packages/expo-db-sqlite-persistence/src/expo.ts
+++ b/packages/expo-db-sqlite-persistence/src/expo.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
   SingleProcessCoordinator,
   createSQLiteCorePersistenceAdapter,
 } from '@tanstack/db-sqlite-persistence-core'
@@ -77,8 +79,11 @@ function resolveAdapterBaseOptions(
   `driver` | `schemaVersion` | `schemaMismatchPolicy`
 > {
   return {
-    appliedTxPruneMaxRows: options.appliedTxPruneMaxRows,
-    appliedTxPruneMaxAgeSeconds: options.appliedTxPruneMaxAgeSeconds,
+    appliedTxPruneMaxRows:
+      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+    appliedTxPruneMaxAgeSeconds:
+      options.appliedTxPruneMaxAgeSeconds ??
+      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }

--- a/packages/expo-db-sqlite-persistence/src/index.ts
+++ b/packages/expo-db-sqlite-persistence/src/index.ts
@@ -4,7 +4,11 @@ export type {
   ExpoSQLitePersistenceOptions,
   ExpoSQLiteSchemaMismatchPolicy,
 } from './expo'
-export { persistedCollectionOptions } from '@tanstack/db-sqlite-persistence-core'
+export {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+  persistedCollectionOptions,
+} from '@tanstack/db-sqlite-persistence-core'
 export type {
   PersistedCollectionCoordinator,
   PersistedCollectionPersistence,

--- a/packages/node-db-sqlite-persistence/README.md
+++ b/packages/node-db-sqlite-persistence/README.md
@@ -58,8 +58,9 @@ the node driver applies:
 - `appliedTxPruneMaxAgeSeconds: 86_400` (24h age backstop)
 
 Pruning runs inside each write transaction, so every collection self-trims on
-its next sync. Override either value to tune retention, or pass `0` to disable
-that limit:
+its next sync. If a process asks to recover from a point older than the retained
+replay window, recovery falls back to a full reload. Override either value to
+tune retention, or pass `0` to disable that limit:
 
 ```ts
 const persistence = createNodeSQLitePersistence({
@@ -68,6 +69,10 @@ const persistence = createNodeSQLitePersistence({
   appliedTxPruneMaxAgeSeconds: 0, // disable the age backstop
 })
 ```
+
+Pruning removes rows from `applied_tx`, but SQLite may not immediately shrink
+the database file on disk. Use `VACUUM`, `auto_vacuum`, or your own maintenance
+process if you need to reclaim disk space.
 
 The defaults are exported as `DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS` and
 `DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS`.

--- a/packages/node-db-sqlite-persistence/README.md
+++ b/packages/node-db-sqlite-persistence/README.md
@@ -47,3 +47,27 @@ export const todosCollection = createCollection(
   mode-specific behavior (`sync-present` vs `sync-absent`) automatically.
 - `schemaVersion` is specified per collection via `persistedCollectionOptions`.
 - Call `database.close()` when your app shuts down.
+
+## Applied transaction pruning
+
+The `applied_tx` log is a replayable cache, so it is pruned by default to keep
+the SQLite file from growing without bound. When you don't pass prune options,
+the node driver applies:
+
+- `appliedTxPruneMaxRows: 1_000` (per-collection row cap)
+- `appliedTxPruneMaxAgeSeconds: 86_400` (24h age backstop)
+
+Pruning runs inside each write transaction, so every collection self-trims on
+its next sync. Override either value to tune retention, or pass `0` to disable
+that limit:
+
+```ts
+const persistence = createNodeSQLitePersistence({
+  database,
+  appliedTxPruneMaxRows: 5_000, // higher row cap
+  appliedTxPruneMaxAgeSeconds: 0, // disable the age backstop
+})
+```
+
+The defaults are exported as `DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS` and
+`DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS`.

--- a/packages/node-db-sqlite-persistence/src/index.ts
+++ b/packages/node-db-sqlite-persistence/src/index.ts
@@ -1,4 +1,8 @@
-export { createNodeSQLitePersistence } from './node-persistence'
+export {
+  createNodeSQLitePersistence,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+} from './node-persistence'
 export type {
   BetterSqlite3Database,
   NodeSQLitePersistenceOptions,

--- a/packages/node-db-sqlite-persistence/src/node-persistence.ts
+++ b/packages/node-db-sqlite-persistence/src/node-persistence.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS as CORE_DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS as CORE_DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
   SingleProcessCoordinator,
   createSQLiteCorePersistenceAdapter,
 } from '@tanstack/db-sqlite-persistence-core'
@@ -37,17 +39,19 @@ export type NodeSQLitePersistenceOptions = NodeSQLitePersistenceBaseOptions
 
 /**
  * Default cap on retained `applied_tx` rows per collection. The log is a
- * replayable cache, so a bounded row count keeps the SQLite file from growing
+ * replayable cache, so a bounded row count keeps SQLite files from growing
  * without limit. Pass `appliedTxPruneMaxRows: 0` to disable the row cap.
  */
-export const DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS = 1_000
+export const DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS =
+  CORE_DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS
 
 /**
  * Default age backstop for retained `applied_tx` rows, in seconds (24h). Rows
  * older than this are pruned on the next write. Pass
  * `appliedTxPruneMaxAgeSeconds: 0` to disable the age backstop.
  */
-export const DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS = 24 * 60 * 60
+export const DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS =
+  CORE_DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS
 
 function normalizeSchemaMismatchPolicy(
   policy: NodeSQLiteSchemaMismatchPolicy,
@@ -96,10 +100,10 @@ function resolveAdapterBaseOptions(
 > {
   return {
     appliedTxPruneMaxRows:
-      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+      options.appliedTxPruneMaxRows ?? CORE_DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
     appliedTxPruneMaxAgeSeconds:
       options.appliedTxPruneMaxAgeSeconds ??
-      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+      CORE_DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }

--- a/packages/node-db-sqlite-persistence/src/node-persistence.ts
+++ b/packages/node-db-sqlite-persistence/src/node-persistence.ts
@@ -35,6 +35,20 @@ type NodeSQLitePersistenceBaseOptions = Omit<
 
 export type NodeSQLitePersistenceOptions = NodeSQLitePersistenceBaseOptions
 
+/**
+ * Default cap on retained `applied_tx` rows per collection. The log is a
+ * replayable cache, so a bounded row count keeps the SQLite file from growing
+ * without limit. Pass `appliedTxPruneMaxRows: 0` to disable the row cap.
+ */
+export const DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS = 1_000
+
+/**
+ * Default age backstop for retained `applied_tx` rows, in seconds (24h). Rows
+ * older than this are pruned on the next write. Pass
+ * `appliedTxPruneMaxAgeSeconds: 0` to disable the age backstop.
+ */
+export const DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS = 24 * 60 * 60
+
 function normalizeSchemaMismatchPolicy(
   policy: NodeSQLiteSchemaMismatchPolicy,
 ): NodeSQLiteCoreSchemaMismatchPolicy {
@@ -81,8 +95,11 @@ function resolveAdapterBaseOptions(
   `driver` | `schemaVersion` | `schemaMismatchPolicy`
 > {
   return {
-    appliedTxPruneMaxRows: options.appliedTxPruneMaxRows,
-    appliedTxPruneMaxAgeSeconds: options.appliedTxPruneMaxAgeSeconds,
+    appliedTxPruneMaxRows:
+      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+    appliedTxPruneMaxAgeSeconds:
+      options.appliedTxPruneMaxAgeSeconds ??
+      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }

--- a/packages/node-db-sqlite-persistence/tests/node-persistence.test.ts
+++ b/packages/node-db-sqlite-persistence/tests/node-persistence.test.ts
@@ -185,7 +185,9 @@ describe(`node persistence helpers`, () => {
   })
 
   it(`forces full reload when pullSince starts before pruned replay rows`, async () => {
-    const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-pruned-pull-since-`))
+    const tempDirectory = mkdtempSync(
+      join(tmpdir(), `db-node-pruned-pull-since-`),
+    )
     const dbPath = join(tempDirectory, `state.sqlite`)
     const collectionId = `pruned-pull-since`
     const database = new BetterSqlite3(dbPath)

--- a/packages/node-db-sqlite-persistence/tests/node-persistence.test.ts
+++ b/packages/node-db-sqlite-persistence/tests/node-persistence.test.ts
@@ -127,6 +127,121 @@ describe(`node persistence helpers`, () => {
     }
   })
 
+  it(`prunes applied_tx rows past the default age backstop`, async () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-default-prune-`))
+    const dbPath = join(tempDirectory, `state.sqlite`)
+    const collectionId = `default-prune`
+    const database = new BetterSqlite3(dbPath)
+
+    try {
+      const persistence = createNodeSQLitePersistence({ database })
+
+      await persistence.adapter.applyCommittedTx(collectionId, {
+        txId: `tx-1`,
+        term: 1,
+        seq: 1,
+        rowVersion: 1,
+        mutations: [
+          {
+            type: `insert`,
+            key: `1`,
+            value: { id: `1`, title: `old`, score: 1 },
+          },
+        ],
+      })
+
+      // Backdate the first row well beyond the 24h default age backstop.
+      database
+        .prepare(
+          `UPDATE applied_tx SET applied_at = 0 WHERE collection_id = ? AND seq = 1`,
+        )
+        .run(collectionId)
+
+      await persistence.adapter.applyCommittedTx(collectionId, {
+        txId: `tx-2`,
+        term: 1,
+        seq: 2,
+        rowVersion: 2,
+        mutations: [
+          {
+            type: `insert`,
+            key: `2`,
+            value: { id: `2`, title: `new`, score: 2 },
+          },
+        ],
+      })
+
+      const appliedRows = database
+        .prepare(
+          `SELECT seq FROM applied_tx WHERE collection_id = ? ORDER BY seq ASC`,
+        )
+        .all(collectionId) as Array<{ seq: number }>
+      expect(appliedRows.map((row) => row.seq)).toEqual([2])
+    } finally {
+      database.close()
+      rmSync(tempDirectory, { recursive: true, force: true })
+    }
+  })
+
+  it(`leaves applied_tx rows untouched when pruning is disabled`, async () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-no-prune-`))
+    const dbPath = join(tempDirectory, `state.sqlite`)
+    const collectionId = `no-prune`
+    const database = new BetterSqlite3(dbPath)
+
+    try {
+      const persistence = createNodeSQLitePersistence({
+        database,
+        appliedTxPruneMaxRows: 0,
+        appliedTxPruneMaxAgeSeconds: 0,
+      })
+
+      await persistence.adapter.applyCommittedTx(collectionId, {
+        txId: `tx-1`,
+        term: 1,
+        seq: 1,
+        rowVersion: 1,
+        mutations: [
+          {
+            type: `insert`,
+            key: `1`,
+            value: { id: `1`, title: `old`, score: 1 },
+          },
+        ],
+      })
+
+      database
+        .prepare(
+          `UPDATE applied_tx SET applied_at = 0 WHERE collection_id = ? AND seq = 1`,
+        )
+        .run(collectionId)
+
+      await persistence.adapter.applyCommittedTx(collectionId, {
+        txId: `tx-2`,
+        term: 1,
+        seq: 2,
+        rowVersion: 2,
+        mutations: [
+          {
+            type: `insert`,
+            key: `2`,
+            value: { id: `2`, title: `new`, score: 2 },
+          },
+        ],
+      })
+
+      const appliedRows = database
+        .prepare(
+          `SELECT seq FROM applied_tx WHERE collection_id = ? ORDER BY seq ASC`,
+        )
+        .all(collectionId) as Array<{ seq: number }>
+      expect(appliedRows.map((row) => row.seq)).toEqual([1, 2])
+    } finally {
+      database.close()
+      rmSync(tempDirectory, { recursive: true, force: true })
+    }
+  })
+
   it(`infers schema policy from sync mode`, async () => {
     const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-schema-infer-`))
     const dbPath = join(tempDirectory, `state.sqlite`)

--- a/packages/node-db-sqlite-persistence/tests/node-persistence.test.ts
+++ b/packages/node-db-sqlite-persistence/tests/node-persistence.test.ts
@@ -7,6 +7,7 @@ import { createNodeSQLitePersistence, persistedCollectionOptions } from '../src'
 import { BetterSqlite3SQLiteDriver } from '../src/node-driver'
 import { SingleProcessCoordinator } from '../../db-sqlite-persistence-core/src'
 import { runRuntimePersistenceContractSuite } from '../../db-sqlite-persistence-core/tests/contracts/runtime-persistence-contract'
+import type { SQLitePullSinceResult } from '../../db-sqlite-persistence-core/src'
 import type {
   RuntimePersistenceContractTodo,
   RuntimePersistenceDatabaseHarness,
@@ -177,6 +178,91 @@ describe(`node persistence helpers`, () => {
         )
         .all(collectionId) as Array<{ seq: number }>
       expect(appliedRows.map((row) => row.seq)).toEqual([2])
+    } finally {
+      database.close()
+      rmSync(tempDirectory, { recursive: true, force: true })
+    }
+  })
+
+  it(`forces full reload when pullSince starts before pruned replay rows`, async () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-pruned-pull-since-`))
+    const dbPath = join(tempDirectory, `state.sqlite`)
+    const collectionId = `pruned-pull-since`
+    const database = new BetterSqlite3(dbPath)
+
+    try {
+      const persistence = createNodeSQLitePersistence({
+        database,
+        appliedTxPruneMaxRows: 2,
+        appliedTxPruneMaxAgeSeconds: 0,
+      })
+
+      for (const seq of [1, 2, 3]) {
+        await persistence.adapter.applyCommittedTx(collectionId, {
+          txId: `tx-${seq}`,
+          term: 1,
+          seq,
+          rowVersion: seq,
+          mutations: [
+            {
+              type: `insert`,
+              key: String(seq),
+              value: { id: String(seq), title: `todo-${seq}`, score: seq },
+            },
+          ],
+        })
+      }
+
+      const adapter = persistence.adapter as typeof persistence.adapter & {
+        pullSince: (
+          collectionId: string,
+          fromRowVersion: number,
+        ) => Promise<SQLitePullSinceResult<string | number>>
+      }
+      const result = await adapter.pullSince(collectionId, 0)
+
+      expect(result.requiresFullReload).toBe(true)
+    } finally {
+      database.close()
+      rmSync(tempDirectory, { recursive: true, force: true })
+    }
+  })
+
+  it(`prunes applied_tx rows past explicit row cap`, async () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), `db-node-row-prune-`))
+    const dbPath = join(tempDirectory, `state.sqlite`)
+    const collectionId = `row-prune`
+    const database = new BetterSqlite3(dbPath)
+
+    try {
+      const persistence = createNodeSQLitePersistence({
+        database,
+        appliedTxPruneMaxRows: 2,
+        appliedTxPruneMaxAgeSeconds: 0,
+      })
+
+      for (const seq of [1, 2, 3]) {
+        await persistence.adapter.applyCommittedTx(collectionId, {
+          txId: `tx-${seq}`,
+          term: 1,
+          seq,
+          rowVersion: seq,
+          mutations: [
+            {
+              type: `insert`,
+              key: String(seq),
+              value: { id: String(seq), title: `todo-${seq}`, score: seq },
+            },
+          ],
+        })
+      }
+
+      const appliedRows = database
+        .prepare(
+          `SELECT seq FROM applied_tx WHERE collection_id = ? ORDER BY seq ASC`,
+        )
+        .all(collectionId) as Array<{ seq: number }>
+      expect(appliedRows.map((row) => row.seq)).toEqual([2, 3])
     } finally {
       database.close()
       rmSync(tempDirectory, { recursive: true, force: true })

--- a/packages/react-native-db-sqlite-persistence/src/index.ts
+++ b/packages/react-native-db-sqlite-persistence/src/index.ts
@@ -4,7 +4,11 @@ export type {
   ReactNativeSQLitePersistenceOptions,
   ReactNativeSQLiteSchemaMismatchPolicy,
 } from './react-native'
-export { persistedCollectionOptions } from '@tanstack/db-sqlite-persistence-core'
+export {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+  persistedCollectionOptions,
+} from '@tanstack/db-sqlite-persistence-core'
 export type {
   PersistedCollectionCoordinator,
   PersistedCollectionPersistence,

--- a/packages/react-native-db-sqlite-persistence/src/mobile-persistence.ts
+++ b/packages/react-native-db-sqlite-persistence/src/mobile-persistence.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
   SingleProcessCoordinator,
   createSQLiteCorePersistenceAdapter,
 } from '@tanstack/db-sqlite-persistence-core'
@@ -79,8 +81,11 @@ function resolveAdapterBaseOptions(
   `driver` | `schemaVersion` | `schemaMismatchPolicy`
 > {
   return {
-    appliedTxPruneMaxRows: options.appliedTxPruneMaxRows,
-    appliedTxPruneMaxAgeSeconds: options.appliedTxPruneMaxAgeSeconds,
+    appliedTxPruneMaxRows:
+      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+    appliedTxPruneMaxAgeSeconds:
+      options.appliedTxPruneMaxAgeSeconds ??
+      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }

--- a/packages/tauri-db-sqlite-persistence/src/index.ts
+++ b/packages/tauri-db-sqlite-persistence/src/index.ts
@@ -4,7 +4,11 @@ export type {
   TauriSQLitePersistenceOptions,
   TauriSQLiteSchemaMismatchPolicy,
 } from './tauri'
-export { persistedCollectionOptions } from '@tanstack/db-sqlite-persistence-core'
+export {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+  persistedCollectionOptions,
+} from '@tanstack/db-sqlite-persistence-core'
 export type {
   PersistedCollectionCoordinator,
   PersistedCollectionPersistence,

--- a/packages/tauri-db-sqlite-persistence/src/tauri-persistence.ts
+++ b/packages/tauri-db-sqlite-persistence/src/tauri-persistence.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
+  DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
   SingleProcessCoordinator,
   createSQLiteCorePersistenceAdapter,
 } from '@tanstack/db-sqlite-persistence-core'
@@ -91,8 +93,11 @@ function resolveAdapterBaseOptions(
   `driver` | `schemaVersion` | `schemaMismatchPolicy`
 > {
   return {
-    appliedTxPruneMaxRows: options.appliedTxPruneMaxRows,
-    appliedTxPruneMaxAgeSeconds: options.appliedTxPruneMaxAgeSeconds,
+    appliedTxPruneMaxRows:
+      options.appliedTxPruneMaxRows ?? DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS,
+    appliedTxPruneMaxAgeSeconds:
+      options.appliedTxPruneMaxAgeSeconds ??
+      DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS,
     pullSinceReloadThreshold: options.pullSinceReloadThreshold,
   }
 }


### PR DESCRIPTION
## Problem

The SQLite core adapter supports `appliedTxPruneMaxRows` / `appliedTxPruneMaxAgeSeconds`, but most SQLite persistence wrappers left them unset by default. That means the `applied_tx` replay log can grow without bound for consumers that don't opt in.

This bit a downstream Electron app (Superset): the local sync DB (`~/.superset/tanstack-db.sqlite`) bloated to **hundreds of MB** (501k `applied_tx` rows / 428 MB / 34 days on one real machine, ~97% no-op writes), which made endpoint-security agents continuously re-hash the file. The app fixed it by passing the two prune options, but this isn't app-specific — SQLite-backed persistence should not grow its replay cache forever by default.

## Change

SQLite persistence wrappers that construct the shared SQLite core adapter now default the prune options when the caller omits them:

- `appliedTxPruneMaxRows: 1_000` — per-collection row cap (safety ceiling)
- `appliedTxPruneMaxAgeSeconds: 86_400` — 24h age backstop

This applies to:

- `@tanstack/browser-db-sqlite-persistence`
- `@tanstack/capacitor-db-sqlite-persistence`
- `@tanstack/cloudflare-durable-objects-db-sqlite-persistence`
- `@tanstack/expo-db-sqlite-persistence`
- `@tanstack/node-db-sqlite-persistence`
- `@tanstack/react-native-db-sqlite-persistence`
- `@tanstack/tauri-db-sqlite-persistence`

The existing per-collection prune already runs inside each write transaction, so every collection self-trims on its next sync. Both values stay fully overridable, and passing `0` disables that limit (explicit `0` is preserved via `??`). The defaults are exported as `DEFAULT_APPLIED_TX_PRUNE_MAX_ROWS` and `DEFAULT_APPLIED_TX_PRUNE_MAX_AGE_SECONDS` from `@tanstack/db-sqlite-persistence-core` and re-exported by wrappers.

This PR also makes the shared SQLite core adapter retention-aware during `pullSince` recovery. Since `applied_tx` is a bounded replay cache, `pullSince` now forces `requiresFullReload: true` when the requested `fromRowVersion` predates the retained replay window, instead of returning partial replay deltas. This preserves correctness when pruning removes older replay entries.

Note: the Electron package is an IPC bridge around a main-process persistence adapter, so there is no separate SQLite adapter construction point there to default; it inherits the behavior of whichever main-process SQLite persistence adapter is supplied.

## Verification

The downstream fix was verified on a copy of a real 448 MB / 503k-row DB: prune brought it to ~14k rows (`integrity_check: ok`, all collections registered, no data loss). In this repo:

- New tests in `node-persistence.test.ts` cover default age pruning, explicit row-cap pruning, disabled pruning, and full-reload fallback when `pullSince` starts before pruned replay rows.
- `pnpm --filter @tanstack/node-db-sqlite-persistence test -- node-persistence.test.ts --runInBand`
- Built the affected SQLite packages:
  - `@tanstack/db-sqlite-persistence-core`
  - `@tanstack/browser-db-sqlite-persistence`
  - `@tanstack/capacitor-db-sqlite-persistence`
  - `@tanstack/cloudflare-durable-objects-db-sqlite-persistence`
  - `@tanstack/expo-db-sqlite-persistence`
  - `@tanstack/react-native-db-sqlite-persistence`
  - `@tanstack/tauri-db-sqlite-persistence`
  - `@tanstack/electron-db-sqlite-persistence`

> Note: pruning bounds growth but does not shrink an already-bloated file (`auto_vacuum=0`); existing bloated DBs still need a one-time `VACUUM`. That's out of scope here.

Changeset included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applied transaction pruning is now enabled by default for SQLite persistence, automatically managing the replay log to prevent unbounded file growth. Default settings retain up to 1,000 rows and transactions from the last 24 hours, both fully configurable.

* **Behavior Changes**
  * Recovery operations now correctly signal when a full data reload is required if the requested starting point precedes retained transaction history.

* **Documentation**
  * Updated guidance on transaction pruning behavior and configuration options for overriding or disabling defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->