### PR TITLE
perf(electric-db-collection): compile array-column membership to @> (GIN-eligible)

### DIFF
--- a/.changeset/array-column-containment.md
+++ b/.changeset/array-column-containment.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/electric-db-collection": patch
+---
+
+Compile array-column membership (`inArray(value, arrayColumn)`) to `arrayColumn @> ARRAY[value]` instead of `value = ANY(arrayColumn)`. The two are equivalent, but only the containment form can use a GIN index, letting Postgres index-seek rather than scan. Membership in a literal value list (`inArray(column, [a, b])`) is unchanged and still compiles to `= ANY`.

--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -361,6 +361,17 @@ function compileFunction(
       // equivalent, but only containment can use a GIN index. Emit @> when the
       // array operand is a column; keep = ANY for a literal value list.
       if (args[1]?.type === `ref`) {
+        // @> wraps a single scalar into ARRAY[...]; an array-valued left
+        // operand would nest into ARRAY[<array>] and silently change the
+        // membership semantics, so reject it.
+        const valueArg = args[0]
+        if (valueArg && valueArg.type === `val` && Array.isArray(valueArg.value)) {
+          throw new Error(
+            `Cannot use an array value as the left operand of 'in' against an ` +
+              `array column. Pass a scalar value to test membership ` +
+              `(e.g. inArray(value, arrayColumn)).`,
+          )
+        }
         return `${rhs} @> ARRAY[${lhs}]`
       }
       return `${lhs} ${opName}(${rhs})`

--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -393,7 +393,7 @@ function isBinaryOp(name: string): boolean {
  * (null comparisons in SQL always evaluate to UNKNOWN)
  */
 function isComparisonOp(name: string): boolean {
-  const comparisonOps = [`eq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`]
+  const comparisonOps = [`eq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `in`]
   return comparisonOps.includes(name)
 }
 

--- a/packages/electric-db-collection/src/sql-compiler.ts
+++ b/packages/electric-db-collection/src/sql-compiler.ts
@@ -356,8 +356,13 @@ function compileFunction(
       }
     }
 
-    // Special case for = ANY operator which needs parentheses around the array parameter
     if (name === `in`) {
+      // `value = ANY(arrayColumn)` and `arrayColumn @> ARRAY[value]` are
+      // equivalent, but only containment can use a GIN index. Emit @> when the
+      // array operand is a column; keep = ANY for a literal value list.
+      if (args[1]?.type === `ref`) {
+        return `${rhs} @> ARRAY[${lhs}]`
+      }
       return `${lhs} ${opName}(${rhs})`
     }
     return `${lhs} ${opName} ${rhs}`

--- a/packages/electric-db-collection/tests/sql-compiler.test.ts
+++ b/packages/electric-db-collection/tests/sql-compiler.test.ts
@@ -214,6 +214,14 @@ describe(`sql-compiler`, () => {
           compileSQL({ where: func(`in`, [val(undefined), ref(`roles`)]) }),
         ).toThrow(`Cannot use null/undefined value with 'in' operator`)
       })
+
+      it(`should throw for an array left operand against an array column`, () => {
+        expect(() =>
+          compileSQL({
+            where: func(`in`, [val([`admin`, `user`]), ref(`roles`)]),
+          }),
+        ).toThrow(`Cannot use an array value as the left operand of 'in'`)
+      })
     })
 
     describe(`null/undefined value handling`, () => {

--- a/packages/electric-db-collection/tests/sql-compiler.test.ts
+++ b/packages/electric-db-collection/tests/sql-compiler.test.ts
@@ -156,6 +156,38 @@ describe(`sql-compiler`, () => {
       })
     })
 
+    describe(`in operator`, () => {
+      it(`should compile membership in a literal value list as = ANY`, () => {
+        const result = compileSQL({
+          where: func(`in`, [ref(`status`), val([`active`, `pending`])]),
+        })
+        expect(result.where).toBe(`"status" = ANY($1)`)
+        expect(result.params).toEqual({ '1': `{"active","pending"}` })
+      })
+
+      it(`should compile membership in an array column as @> (GIN-eligible)`, () => {
+        const result = compileSQL({
+          where: func(`in`, [val(`admin`), ref(`roles`)]),
+        })
+        expect(result.where).toBe(`"roles" @> ARRAY[$1]`)
+        expect(result.params).toEqual({ '1': `admin` })
+      })
+
+      it(`should compile array-column membership inside AND`, () => {
+        const result = compileSQL({
+          where: func(`and`, [
+            func(`in`, [val(`admin`), ref(`roles`)]),
+            func(`in`, [ref(`status`), val([`active`, `pending`])]),
+          ]),
+        })
+        expect(result.where).toBe(`"roles" @> ARRAY[$1] AND "status" = ANY($2)`)
+        expect(result.params).toEqual({
+          '1': `admin`,
+          '2': `{"active","pending"}`,
+        })
+      })
+    })
+
     describe(`null/undefined value handling`, () => {
       it(`should throw error for eq(col, null)`, () => {
         // Users should use isNull() instead of eq(col, null)

--- a/packages/electric-db-collection/tests/sql-compiler.test.ts
+++ b/packages/electric-db-collection/tests/sql-compiler.test.ts
@@ -186,6 +186,34 @@ describe(`sql-compiler`, () => {
           '2': `{"active","pending"}`,
         })
       })
+
+      it(`should compile membership in an empty value list`, () => {
+        const result = compileSQL({
+          where: func(`in`, [ref(`status`), val([])]),
+        })
+        expect(result.where).toBe(`"status" = ANY($1)`)
+        expect(result.params).toEqual({ '1': `{}` })
+      })
+
+      it(`should compile membership in a single-element value list`, () => {
+        const result = compileSQL({
+          where: func(`in`, [ref(`status`), val([`active`])]),
+        })
+        expect(result.where).toBe(`"status" = ANY($1)`)
+        expect(result.params).toEqual({ '1': `{"active"}` })
+      })
+
+      it(`should throw for a null operand`, () => {
+        expect(() =>
+          compileSQL({ where: func(`in`, [val(null), ref(`roles`)]) }),
+        ).toThrow(`Cannot use null/undefined value with 'in' operator`)
+      })
+
+      it(`should throw for an undefined operand`, () => {
+        expect(() =>
+          compileSQL({ where: func(`in`, [val(undefined), ref(`roles`)]) }),
+        ).toThrow(`Cannot use null/undefined value with 'in' operator`)
+      })
     })
 
     describe(`null/undefined value handling`, () => {


### PR DESCRIPTION
# perf(electric-db-collection): compile array-column membership to `@>` (GIN-eligible)

## Summary

`inArray(value, arrayColumn)` currently compiles to `value = ANY(arrayColumn)`. That's correct, but Postgres **cannot use a GIN index** for `scalar = ANY(array_column)` — only for the containment operator `array_column @> ARRAY[scalar]`. The two expressions are logically equivalent, so this PR emits the containment form when the array operand is a column, letting the planner index-seek instead of scanning.

Membership in a **literal value list** (`inArray(column, [a, b, c])`) is unchanged — it still compiles to `= ANY`, which is correct there.

## Why it matters

For a **low-cardinality** value in an array column, the `= ANY` form is pathological in the common `ORDER BY ... LIMIT N` shape: the planner walks an ordering index and filters row-by-row, and because few rows match, it can never fill the `LIMIT` — so it scans the entire table.

Concrete case from a ~2M-row table with a `tags text[]` column and a GIN index on it:

```sql
-- before: 'ipo' = ANY(tags)  → cannot use the GIN index → full index walk (~2M rows)
-- after:  tags @> ARRAY['ipo'] → Bitmap Index Scan on the GIN index → ~7 rows
SELECT ... FROM news_item
WHERE tags @> ARRAY['ipo']
ORDER BY first_created DESC LIMIT 25;
```

A tag matching 7 of 2,000,000 rows went from a full-table scan to an index seek. Dense values (e.g. a tag on 25% of rows) are unaffected — the planner still picks the ordering-index walk, now adaptively, because `@>` *exposes* the GIN option rather than removing it.

## Change

In `compileFunction`'s `in` branch, when the RHS is a column reference (`args[1].type === 'ref'`), emit `${rhs} @> ARRAY[${lhs}]`; otherwise keep `${lhs} = ANY(${rhs})`.

```ts
if (name === `in`) {
  if (args[1]?.type === `ref`) {
    return `${rhs} @> ARRAY[${lhs}]`
  }
  return `${lhs} ${opName}(${rhs})`
}
```

The two shapes are distinguishable without column type info:
- `inArray(value, arrayColumn)` → `args[1]` is a `ref` → containment.
- `inArray(column, [literal, list])` → `args[1]` is a `val` → `= ANY`.

## Tests

Added an `in operator` describe block in `sql-compiler.test.ts` covering: literal value list → `= ANY`, array column → `@>`, and a mixed compound (`@>` AND `= ANY`) to confirm both paths coexist with correct param indices.

## Notes

- Result rows are identical; this is purely an index-eligibility (and therefore planner) improvement.
- No public API change — existing `inArray` callers benefit transparently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Array membership checks now compile into a Postgres-friendly form, enabling index-backed lookups and improving query performance.

* **Tests**
  * Added comprehensive tests for array membership compilation, parameter binding/sequencing, combined cases, and edge conditions.

* **Bug Fix**
  * Membership operator now validates null/undefined inputs and rejects invalid array-on-array membership.

* **Documentation**
  * Updated release metadata to reflect the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->