### PR TITLE
feat(offline-transactions): allow overriding the retry policy via config

### DIFF
--- a/.changeset/offline-transactions-configurable-retry-policy.md
+++ b/.changeset/offline-transactions-configurable-retry-policy.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/offline-transactions": minor
+'@tanstack/offline-transactions': minor
 ---
 
 Allow overriding the retry policy via `OfflineConfig.retryPolicy`.

--- a/.changeset/offline-transactions-configurable-retry-policy.md
+++ b/.changeset/offline-transactions-configurable-retry-policy.md
@@ -1,0 +1,7 @@
+---
+"@tanstack/offline-transactions": minor
+---
+
+Allow overriding the retry policy via `OfflineConfig.retryPolicy`.
+
+`startOfflineExecutor` previously always used the built-in `DefaultRetryPolicy`, whose `shouldRetry` hard-codes which errors are treated as non-retryable (it drops any error whose message includes `400`/`401`/`403`/`422`), with no way to change it. You can now pass a `retryPolicy` to `OfflineConfig` to control retry classification and backoff — or subclass the exported `DefaultRetryPolicy` and override `shouldRetry`. When omitted, behavior is unchanged.

--- a/packages/offline-transactions/src/executor/TransactionExecutor.ts
+++ b/packages/offline-transactions/src/executor/TransactionExecutor.ts
@@ -7,6 +7,7 @@ import type { OutboxManager } from '../outbox/OutboxManager'
 import type {
   OfflineConfig,
   OfflineTransaction,
+  RetryPolicy,
   TransactionSignaler,
 } from '../types'
 
@@ -16,7 +17,7 @@ export class TransactionExecutor {
   private scheduler: KeyScheduler
   private outbox: OutboxManager
   private config: OfflineConfig
-  private retryPolicy: DefaultRetryPolicy
+  private retryPolicy: RetryPolicy
   private isExecuting = false
   private executionPromise: Promise<void> | null = null
   private offlineExecutor: TransactionSignaler
@@ -31,10 +32,9 @@ export class TransactionExecutor {
     this.scheduler = scheduler
     this.outbox = outbox
     this.config = config
-    this.retryPolicy = new DefaultRetryPolicy(
-      Number.POSITIVE_INFINITY,
-      config.jitter ?? true,
-    )
+    this.retryPolicy =
+      config.retryPolicy ??
+      new DefaultRetryPolicy(Number.POSITIVE_INFINITY, config.jitter ?? true)
     this.offlineExecutor = offlineExecutor
   }
 

--- a/packages/offline-transactions/src/types.ts
+++ b/packages/offline-transactions/src/types.ts
@@ -95,6 +95,17 @@ export interface OfflineConfig {
   storage?: StorageAdapter
   maxConcurrency?: number
   jitter?: boolean
+  /**
+   * Custom retry policy controlling whether a failed transaction is retried and
+   * how long to back off between attempts.
+   *
+   * Defaults to {@link DefaultRetryPolicy} (infinite retries with exponential
+   * backoff; `jitter` is forwarded to it). Provide your own implementation — or
+   * subclass `DefaultRetryPolicy` and override `shouldRetry` — to customize the
+   * classification of non-retryable errors (e.g. treat a 401 as transient and
+   * keep retrying instead of dropping the transaction).
+   */
+  retryPolicy?: RetryPolicy
   beforeRetry?: (
     transactions: Array<OfflineTransaction>,
   ) => Array<OfflineTransaction>

--- a/packages/offline-transactions/tests/offline-e2e.test.ts
+++ b/packages/offline-transactions/tests/offline-e2e.test.ts
@@ -185,6 +185,71 @@ describe(`offline executor end-to-end`, () => {
     )
   })
 
+  it(`uses a custom retryPolicy provided via config`, async () => {
+    // The DefaultRetryPolicy classifies any error whose message includes "401"
+    // as a permanent failure. A custom policy passed via config overrides that:
+    // here it keeps retrying, so the transaction survives the 401 and succeeds
+    // once the backend recovers.
+    let online = false
+    let shouldRetryCalled = false
+
+    const env = createTestOfflineEnvironment({
+      config: {
+        retryPolicy: {
+          // Large delay so retries only fire when we force them via
+          // notifyOnline(), keeping the test deterministic.
+          calculateDelay: () => 60_000,
+          shouldRetry: () => {
+            shouldRetryCalled = true
+            return true
+          },
+        },
+      },
+      mutationFn: async (params) => {
+        const mutations = params.transaction.mutations as Array<
+          PendingMutation<TestItem>
+        >
+        if (!online) {
+          throw new Error(`HTTP 401 Unauthorized`)
+        }
+        env.applyMutations(mutations)
+        return { ok: true, mutations }
+      },
+    })
+
+    await env.waitForLeader()
+
+    const offlineTx = env.executor.createOfflineTransaction({
+      mutationFnName: env.mutationFnName,
+      autoCommit: false,
+    })
+    offlineTx.mutate(() => {
+      env.collection.insert({
+        id: `custom-retry-item`,
+        value: `kept`,
+        completed: false,
+        updatedAt: new Date(),
+      })
+    })
+    const commitPromise = offlineTx.commit()
+
+    // Despite the 401 (non-retryable under the default policy), the custom
+    // policy is consulted and keeps the transaction queued for retry.
+    await waitUntil(() => env.mutationCalls.length >= 1)
+    expect(shouldRetryCalled).toBe(true)
+    expect(await env.executor.peekOutbox()).toHaveLength(1)
+
+    // Backend recovers; the retries the custom policy allowed now succeed.
+    online = true
+    env.executor.getOnlineDetector().notifyOnline()
+
+    await expect(commitPromise).resolves.toBeDefined()
+    expect(await env.executor.peekOutbox()).toEqual([])
+    expect(env.serverState.get(`custom-retry-item`)?.value).toBe(`kept`)
+
+    env.executor.dispose()
+  })
+
   it(`does not execute mutations while offline`, async () => {
     const onlineDetector = new ManualOnlineDetector(false)
     const env = createTestOfflineEnvironment({


### PR DESCRIPTION
## 🎯 Changes

`startOfflineExecutor` always constructed the built-in `DefaultRetryPolicy`, and `OfflineConfig` exposed no way to replace it. `DefaultRetryPolicy.shouldRetry` hard-codes which errors are non-retryable — notably it drops any error whose **message** contains `400`/`401`/`403`/`422`:

```ts
if (error.message.includes(`401`) || error.message.includes(`403`)) return false
if (error.message.includes(`422`) || error.message.includes(`400`)) return false
```

So a consumer can't, for example, treat a `401` as transient (auth token not ready yet) and keep the transaction queued for retry — the only workarounds today are patching the published package or reaching into executor internals.

This PR adds an optional `retryPolicy` to `OfflineConfig`:

- `TransactionExecutor` uses `config.retryPolicy` when provided, and otherwise falls back to `new DefaultRetryPolicy(Infinity, config.jitter ?? true)` — **behavior is unchanged when the option is omitted**.
- `RetryPolicy` and `DefaultRetryPolicy` are already exported, so consumers can either implement the `RetryPolicy` interface or subclass `DefaultRetryPolicy` and override just `shouldRetry`:

```ts
import { DefaultRetryPolicy, startOfflineExecutor } from '@tanstack/offline-transactions'

class AuthAwareRetryPolicy extends DefaultRetryPolicy {
  shouldRetry(error: Error, retryCount: number): boolean {
    // 401 is transient (token not ready yet) — keep retrying.
    if (error.message.includes(`401`)) return true
    return super.shouldRetry(error, retryCount)
  }
}

startOfflineExecutor({
  collections,
  mutationFns,
  retryPolicy: new AuthAwareRetryPolicy(),
})
```

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing a custom `retryPolicy` in offline transactions to control whether and how retries are classified and how long to back off between attempts. Default behavior remains unchanged when `retryPolicy` is not set.
* **Tests**
  * Added an end-to-end test covering use of a custom `retryPolicy`, including retry behavior while offline and eventual success after returning online.
* **Documentation**
  * Updated release notes to describe the new `OfflineConfig.retryPolicy` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->