### PR TITLE
fix(react-db): defer eager onStoreChange to a microtask in useLiveQuery + regression test (closes #1587)

### DIFF
--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -434,17 +434,36 @@ export function useLiveQuery(
         return () => {}
       }
 
+      let unsubscribed = false
+
       const subscription = collectionRef.current.subscribeChanges(() => {
+        // The subscription can outlive the React subscription window when an
+        // already-queued change arrives between `unsubscribed = true` and the
+        // underlying `subscription.unsubscribe()`. Drop the late notify so
+        // React never sees a state update post-unsubscribe.
+        if (unsubscribed) return
         // Bump version on any change; getSnapshot will rebuild next time
         versionRef.current += 1
         onStoreChange()
       })
-      // Collection may be ready and will not receive initial `subscribeChanges()`
+      // Collection may be ready and will not receive initial `subscribeChanges()`.
+      // We must notify React so it picks up the ready state — but doing it
+      // synchronously here lands during the render-to-commit window when
+      // `useSyncExternalStore`'s subscribe runs in StrictMode double-render
+      // or under cold/throttled loads, which React surfaces as:
+      //   "Can't perform a React state update on a component that hasn't
+      //    mounted yet. ... Move this work to useEffect instead."
+      // Defer to a microtask so the notify lands AFTER the current commit.
+      // See #1587 for the Lighthouse-cold-load repro.
       if (collectionRef.current.status === `ready`) {
-        versionRef.current += 1
-        onStoreChange()
+        queueMicrotask(() => {
+          if (unsubscribed) return
+          versionRef.current += 1
+          onStoreChange()
+        })
       }
       return () => {
+        unsubscribed = true
         subscription.unsubscribe()
       }
     }

--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -446,7 +446,7 @@ export function useLiveQuery(
       // Already-ready collections won't emit an initial change. Notify React
       // ourselves, but defer to a microtask — calling onStoreChange synchronously
       // here lands during the render-to-commit window and trips React's
-      // "state update on a component that hasn't mounted yet" warning (#1587).
+      // "state update on a component that hasn't mounted yet" warning.
       if (collectionRef.current.status === `ready`) {
         queueMicrotask(() => {
           if (unsubscribed) return

--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -437,24 +437,16 @@ export function useLiveQuery(
       let unsubscribed = false
 
       const subscription = collectionRef.current.subscribeChanges(() => {
-        // The subscription can outlive the React subscription window when an
-        // already-queued change arrives between `unsubscribed = true` and the
-        // underlying `subscription.unsubscribe()`. Drop the late notify so
-        // React never sees a state update post-unsubscribe.
+        // Drop late notifies that race with unsubscribe.
         if (unsubscribed) return
         // Bump version on any change; getSnapshot will rebuild next time
         versionRef.current += 1
         onStoreChange()
       })
-      // Collection may be ready and will not receive initial `subscribeChanges()`.
-      // We must notify React so it picks up the ready state — but doing it
-      // synchronously here lands during the render-to-commit window when
-      // `useSyncExternalStore`'s subscribe runs in StrictMode double-render
-      // or under cold/throttled loads, which React surfaces as:
-      //   "Can't perform a React state update on a component that hasn't
-      //    mounted yet. ... Move this work to useEffect instead."
-      // Defer to a microtask so the notify lands AFTER the current commit.
-      // See #1587 for the Lighthouse-cold-load repro.
+      // Already-ready collections won't emit an initial change. Notify React
+      // ourselves, but defer to a microtask — calling onStoreChange synchronously
+      // here lands during the render-to-commit window and trips React's
+      // "state update on a component that hasn't mounted yet" warning (#1587).
       if (collectionRef.current.status === `ready`) {
         queueMicrotask(() => {
           if (unsubscribed) return

--- a/packages/react-db/tests/useLiveQuery.eager-onstorechange.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.eager-onstorechange.test.tsx
@@ -7,9 +7,8 @@ import { mockSyncCollectionOptions } from '../../db/tests/utils'
 import type * as ReactNS from 'react'
 
 // Intercept React.useSyncExternalStore so we can capture the `subscribe`
-// callback that `useLiveQuery` registers and observe whether it invokes
-// `onStoreChange` synchronously (the bug in #1587) or defers it (the fix
-// in #1588).
+// callback that `useLiveQuery` registers and assert that it does not invoke
+// `onStoreChange` synchronously when the collection is already ready.
 let capturedSubscribe: ((cb: () => void) => () => void) | null = null
 
 vi.mock('react', async () => {
@@ -31,11 +30,11 @@ const initialPersons: Array<Person> = [
   { id: `2`, name: `B`, age: 20 },
 ]
 
-describe(`issue #1587: eager onStoreChange must not fire synchronously during subscribe`, () => {
+describe(`useLiveQuery: eager onStoreChange must not fire synchronously during subscribe`, () => {
   it(`defers the initial ready-state onStoreChange to a microtask`, async () => {
     const base = createCollection(
       mockSyncCollectionOptions<Person>({
-        id: `issue-1587-persons`,
+        id: `eager-onstorechange-persons`,
         getKey: (p) => p.id,
         initialData: initialPersons,
       }),
@@ -55,8 +54,8 @@ describe(`issue #1587: eager onStoreChange must not fire synchronously during su
     const onStoreChange = vi.fn()
     const unsub = capturedSubscribe!(onStoreChange)
 
-    // BUG (main): onStoreChange is called synchronously here because the
-    // collection is already ready. FIX (#1588): defers via queueMicrotask.
+    // onStoreChange must not be invoked synchronously inside subscribe;
+    // it should be deferred to a microtask so it lands after React commits.
     expect(onStoreChange).not.toHaveBeenCalled()
 
     await Promise.resolve()

--- a/packages/react-db/tests/useLiveQuery.issue-1587.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.issue-1587.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { renderHook } from '@testing-library/react'
+import { createCollection, createLiveQueryCollection } from '@tanstack/db'
+import { useLiveQuery } from '../src/useLiveQuery'
+import { mockSyncCollectionOptions } from '../../db/tests/utils'
+import type * as ReactNS from 'react'
+
+// Intercept React.useSyncExternalStore so we can capture the `subscribe`
+// callback that `useLiveQuery` registers and observe whether it invokes
+// `onStoreChange` synchronously (the bug in #1587) or defers it (the fix
+// in #1588).
+let capturedSubscribe: ((cb: () => void) => () => void) | null = null
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof ReactNS>('react')
+  return {
+    ...actual,
+    default: (actual as any).default ?? actual,
+    useSyncExternalStore: (subscribe: any, getSnapshot: any) => {
+      capturedSubscribe = subscribe
+      return getSnapshot()
+    },
+  }
+})
+
+type Person = { id: string; name: string; age: number }
+
+const initialPersons: Array<Person> = [
+  { id: `1`, name: `A`, age: 10 },
+  { id: `2`, name: `B`, age: 20 },
+]
+
+describe(`issue #1587: eager onStoreChange must not fire synchronously during subscribe`, () => {
+  it(`defers the initial ready-state onStoreChange to a microtask`, async () => {
+    const base = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `issue-1587-persons`,
+        getKey: (p) => p.id,
+        initialData: initialPersons,
+      }),
+    )
+
+    const lqc = createLiveQueryCollection({
+      startSync: true,
+      query: (q) => q.from({ persons: base }),
+    })
+    await lqc.preload()
+    expect(lqc.status).toBe(`ready`)
+
+    capturedSubscribe = null
+    renderHook(() => useLiveQuery(lqc))
+    expect(capturedSubscribe).toBeTypeOf(`function`)
+
+    const onStoreChange = vi.fn()
+    const unsub = capturedSubscribe!(onStoreChange)
+
+    // BUG (main): onStoreChange is called synchronously here because the
+    // collection is already ready. FIX (#1588): defers via queueMicrotask.
+    expect(onStoreChange).not.toHaveBeenCalled()
+
+    await Promise.resolve()
+    expect(onStoreChange).toHaveBeenCalledTimes(1)
+
+    unsub()
+  })
+})


### PR DESCRIPTION
Closes #1587. Supersedes / re-applies #1588.

## What

Two commits:

1. **`fix(react-db): defer eager onStoreChange to a microtask in useLiveQuery`** — cherry-picked from #1588 by @tsushanth (authorship preserved). When `useLiveQuery`'s `subscribe` callback runs against a collection whose `status` is already `ready`, it used to call `onStoreChange()` synchronously. Under React 19's `useSyncExternalStore` (and especially in StrictMode double-render or on cold/throttled loads), that notify lands during the render-to-commit window and React surfaces:

   > Can't perform a React state update on a component that hasn't mounted yet. ... Move this work to useEffect instead.

   The fix wraps the eager notify in `queueMicrotask(...)` so it lands after commit, and adds an `unsubscribed` guard to drop late notifies if React tears down between scheduling and firing.

2. **`test(react-db): add regression test for useLiveQuery eager onStoreChange (#1587)`** — new. Mocks `react`'s `useSyncExternalStore` to capture the `subscribe` callback `useLiveQuery` registers, invokes it directly against an already-`ready` `LiveQueryCollection`, and asserts:

   - `onStoreChange` is NOT called synchronously inside `subscribe()`,
   - `onStoreChange` IS called exactly once after one microtask.

   I verified that test fails on `main` (synchronous call, 1 invocation observed) and passes after the fix.

## Verification

- Full `packages/react-db` suite: **95/95 passing** (94 existing + 1 new).
- No other packages touched.

## Credit

Fix commit is cherry-picked with original authorship from @tsushanth (PR #1588). Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where live query notification callbacks could be triggered after React component cleanup, which could cause memory leaks and unpredictable behavior. Initial notifications for already-loaded data are now properly deferred.

* **Tests**
  * Added test coverage for live query subscription behavior with synchronous data sources to ensure callbacks are properly deferred and cleanup occurs correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->