### PR TITLE
fix(solid-db): set key option to $key when calling reconcile

### DIFF
--- a/.changeset/solid-id-rendering.md
+++ b/.changeset/solid-id-rendering.md
@@ -2,5 +2,5 @@
 '@tanstack/solid-db': patch
 ---
 
-Fix reconcile usage in useLiveQuery by setting the key field to "$key" so that items are matched correctly during reconcilation. Fixes #1524.
+Fix reconcile usage in useLiveQuery by setting the key field to "$key" so that items are matched correctly during reconciliation. Fixes #1524.
 

--- a/.changeset/solid-id-rendering.md
+++ b/.changeset/solid-id-rendering.md
@@ -2,5 +2,5 @@
 '@tanstack/solid-db': patch
 ---
 
-Fix reconcile usage in useLiveQuery by setting the key field to "$key" so that that items are matched correctly during reconcilation. Fixes #1524.
+Fix reconcile usage in useLiveQuery by setting the key field to "$key" so that items are matched correctly during reconcilation. Fixes #1524.
 

--- a/.changeset/solid-id-rendering.md
+++ b/.changeset/solid-id-rendering.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/solid-db': patch
+---
+
+Fix reconcile usage in useLiveQuery by setting the key field to "$key" so that that items are matched correctly during reconcilation. Fixes #1524.
+

--- a/.changeset/solid-id-rendering.md
+++ b/.changeset/solid-id-rendering.md
@@ -3,4 +3,3 @@
 ---
 
 Fix reconcile usage in useLiveQuery by setting the key field to "$key" so that items are matched correctly during reconciliation. Fixes #1524.
-

--- a/packages/solid-db/src/useLiveQuery.ts
+++ b/packages/solid-db/src/useLiveQuery.ts
@@ -346,7 +346,9 @@ export function useLiveQuery(
     currentCollection: Collection<any, any, any>,
   ) => {
     setData((prev) =>
-      reconcile(Array.from(currentCollection.values()), { key: "$key" })(prev).filter(Boolean),
+      reconcile(Array.from(currentCollection.values()), { key: '$key' })(
+        prev,
+      ).filter(Boolean),
     )
   }
 

--- a/packages/solid-db/src/useLiveQuery.ts
+++ b/packages/solid-db/src/useLiveQuery.ts
@@ -346,7 +346,7 @@ export function useLiveQuery(
     currentCollection: Collection<any, any, any>,
   ) => {
     setData((prev) =>
-      reconcile(Array.from(currentCollection.values()))(prev).filter(Boolean),
+      reconcile(Array.from(currentCollection.values()), { key: "$key" })(prev).filter(Boolean),
     )
   }
 

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2612,11 +2612,6 @@ it(`should keep all existing items when using a custom id field and reordering`,
         .orderBy(({ items }) => items.name, `asc`),
     )
 
-
-   await waitFor(() => {
-     expect(query.isReady).toBe(true)
-   })
-
   expect(
     Array.from(query()).map((item) => item.name),
   ).toEqual([`Bob`, `Kevin`, `Stuart`])
@@ -2631,11 +2626,9 @@ it(`should keep all existing items when using a custom id field and reordering`,
   })
   collection.utils.commit()
 
-  await waitFor(() => {
     expect(
       Array.from(query()).map((item) => item.name),
     ).toEqual([`Alvin`, `Bob`, `Kevin`])
-  })
 })
   })
 })

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2587,6 +2587,7 @@ describe(`Query Collections`, () => {
       expect(rendered.result()).toBeUndefined()
     })
   })
+  describe(`custom id field`, () => {
 it(`should render correctly when using a custom key field and reordering`, async () => {
   type Item = {
     _id: string
@@ -2651,4 +2652,5 @@ it(`should render correctly when using a custom key field and reordering`, async
     ).toEqual([`Alvin`, `Bob`, `Kevin`])
   })
 })
+  })
 })

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2588,52 +2588,57 @@ describe(`Query Collections`, () => {
     })
   })
   describe(`custom id field`, () => {
-it(`should keep all existing items when using a custom id field and reordering`, async () => {
-  type Item = {
-    _id: string
-    name: string
-  }
+    it(`should keep all existing items when using a custom id field and reordering`, async () => {
+      type Item = {
+        _id: string
+        name: string
+      }
 
-  const collection = createCollection(
-    mockSyncCollectionOptions<Item>({
-      id: `custom-key-reorder-test`,
-      getKey: (item) => item._id,
-      initialData: [
-        { _id: `bob1`, name: `Bob` },
-        { _id: `kevin1`, name: `Kevin` },
-        { _id: `stuart1`, name: `Stuart` },
-      ],
-    }),
-  )
+      const collection = createCollection(
+        mockSyncCollectionOptions<Item>({
+          id: `custom-key-reorder-test`,
+          getKey: (item) => item._id,
+          initialData: [
+            { _id: `bob1`, name: `Bob` },
+            { _id: `kevin1`, name: `Kevin` },
+            { _id: `stuart1`, name: `Stuart` },
+          ],
+        }),
+      )
 
-  const rendered = renderHook(() => useLiveQuery((q) =>
-      q
-        .from({ items: collection })
-        .orderBy(({ items }) => items.name, `asc`),
-    ),
-  )
+      const rendered = renderHook(() =>
+        useLiveQuery((q) =>
+          q
+            .from({ items: collection })
+            .orderBy(({ items }) => items.name, `asc`),
+        ),
+      )
 
-  await waitFor(() => {
-    expect(rendered.result.isReady).toBe(true) 
-  });
+      await waitFor(() => {
+        expect(rendered.result.isReady).toBe(true)
+      })
 
-  expect(
-    Array.from(rendered.result()).map((item) => item.name),
-  ).toEqual([`Bob`, `Kevin`, `Stuart`])
+      expect(Array.from(rendered.result()).map((item) => item.name)).toEqual([
+        `Bob`,
+        `Kevin`,
+        `Stuart`,
+      ])
 
-  collection.utils.begin()
-  collection.utils.write({
-    type: `update`,
-    value: {
-      _id: `stuart1`,
-      name: `Alvin`,
-    },
-  })
-  collection.utils.commit()
+      collection.utils.begin()
+      collection.utils.write({
+        type: `update`,
+        value: {
+          _id: `stuart1`,
+          name: `Alvin`,
+        },
+      })
+      collection.utils.commit()
 
-    expect(
-      Array.from(rendered.result()).map((item) => item.name),
-    ).toEqual([`Alvin`, `Bob`, `Kevin`])
-})
+      expect(Array.from(rendered.result()).map((item) => item.name)).toEqual([
+        `Alvin`,
+        `Bob`,
+        `Kevin`,
+      ])
+    })
   })
 })

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2588,7 +2588,7 @@ describe(`Query Collections`, () => {
     })
   })
   describe(`custom id field`, () => {
-it(`should render correctly when using a custom id field and reordering`, async () => {
+it(`should keep all existing items when using a custom id field and reordering`, async () => {
   type Item = {
     _id: string
     name: string
@@ -2606,32 +2606,19 @@ it(`should render correctly when using a custom id field and reordering`, async 
     }),
   )
 
-  function TestComponent() {
     const query = useLiveQuery((q) =>
       q
         .from({ items: collection })
         .orderBy(({ items }) => items.name, `asc`),
     )
 
-    return (
-      <ol data-testid="list">
-        <For each={query()}>
-          {(item) => <li>{item.name}</li>}
-        </For>
-      </ol>
-    )
-  }
 
-  const { findByTestId } = render(() => <TestComponent />)
+   await waitFor(() => {
+     expect(query.isReady).toBe(true)
+   })
 
-  await waitFor(async () => {
-    const list = await findByTestId(`list`)
-    expect(list.children).toHaveLength(3)
-  })
-
-  let list = await findByTestId(`list`)
   expect(
-    Array.from(list.children).map((el) => el.textContent),
+    Array.from(query()).map((item) => item.name),
   ).toEqual([`Bob`, `Kevin`, `Stuart`])
 
   collection.utils.begin()
@@ -2644,11 +2631,9 @@ it(`should render correctly when using a custom id field and reordering`, async 
   })
   collection.utils.commit()
 
-  await waitFor(async () => {
-    list = await findByTestId(`list`)
-
+  await waitFor(() => {
     expect(
-      Array.from(list.children).map((el) => el.textContent),
+      Array.from(query()).map((item) => item.name),
     ).toEqual([`Alvin`, `Bob`, `Kevin`])
   })
 })

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2588,7 +2588,7 @@ describe(`Query Collections`, () => {
     })
   })
   describe(`custom id field`, () => {
-it(`should render correctly when using a custom key field and reordering`, async () => {
+it(`should render correctly when using a custom id field and reordering`, async () => {
   type Item = {
     _id: string
     name: string

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2606,14 +2606,19 @@ it(`should keep all existing items when using a custom id field and reordering`,
     }),
   )
 
-    const query = useLiveQuery((q) =>
+  const rendered = renderHook(() => useLiveQuery((q) =>
       q
         .from({ items: collection })
         .orderBy(({ items }) => items.name, `asc`),
-    )
+    ),
+  )
+
+  await waitFor(() => {
+    expect(rendered.result.isReady).toBe(true) 
+  });
 
   expect(
-    Array.from(query()).map((item) => item.name),
+    Array.from(rendered.result()).map((item) => item.name),
   ).toEqual([`Bob`, `Kevin`, `Stuart`])
 
   collection.utils.begin()
@@ -2627,7 +2632,7 @@ it(`should keep all existing items when using a custom id field and reordering`,
   collection.utils.commit()
 
     expect(
-      Array.from(query()).map((item) => item.name),
+      Array.from(rendered.result()).map((item) => item.name),
     ).toEqual([`Alvin`, `Bob`, `Kevin`])
 })
   })

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2587,4 +2587,68 @@ describe(`Query Collections`, () => {
       expect(rendered.result()).toBeUndefined()
     })
   })
+it(`should render correctly when using a custom key field and reordering`, async () => {
+  type Item = {
+    _id: string
+    name: string
+  }
+
+  const collection = createCollection(
+    mockSyncCollectionOptions<Item>({
+      id: `custom-key-reorder-test`,
+      getKey: (item) => item._id,
+      initialData: [
+        { _id: `bob1`, name: `Bob` },
+        { _id: `kevin1`, name: `Kevin` },
+        { _id: `stuart1`, name: `Stuart` },
+      ],
+    }),
+  )
+
+  function TestComponent() {
+    const query = useLiveQuery((q) =>
+      q
+        .from({ items: collection })
+        .orderBy(({ items }) => items.name, `asc`),
+    )
+
+    return (
+      <ol data-testid="list">
+        <For each={query()}>
+          {(item) => <li>{item.name}</li>}
+        </For>
+      </ol>
+    )
+  }
+
+  const { findByTestId } = render(() => <TestComponent />)
+
+  await waitFor(async () => {
+    const list = await findByTestId(`list`)
+    expect(list.children).toHaveLength(3)
+  })
+
+  let list = await findByTestId(`list`)
+  expect(
+    Array.from(list.children).map((el) => el.textContent),
+  ).toEqual([`Bob`, `Kevin`, `Stuart`])
+
+  collection.utils.begin()
+  collection.utils.write({
+    type: `update`,
+    value: {
+      _id: `stuart1`,
+      name: `Alvin`,
+    },
+  })
+  collection.utils.commit()
+
+  await waitFor(async () => {
+    list = await findByTestId(`list`)
+
+    expect(
+      Array.from(list.children).map((el) => el.textContent),
+    ).toEqual([`Alvin`, `Bob`, `Kevin`])
+  })
+})
 })


### PR DESCRIPTION
Fixes  #1524.

## 🎯 Changes

Add `key` option when calling `reconcile` which is set to `$key`, which makes it so items are matched correctly even when the `id` property doesn't exist. 

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed live query reconciliation to match list items using the correct key field, preventing incorrect item reuse during updates and reordering.

* **Tests**
  * Added coverage for custom item keys, confirming that sorted results update to the expected order after an item changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->