### PR TITLE
fix: reconcile duplicate live query child inserts

### DIFF
--- a/.changeset/fix-sync-duplicate-key-utils.md
+++ b/.changeset/fix-sync-duplicate-key-utils.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Fix duplicate-key sync reconciliation for collection configs without live query internals so it reports the intended duplicate key error instead of throwing a TypeError.

--- a/.changeset/fix-sync-duplicate-key-utils.md
+++ b/.changeset/fix-sync-duplicate-key-utils.md
@@ -2,4 +2,4 @@
 '@tanstack/db': patch
 ---
 
-Fix duplicate-key sync reconciliation for collection configs without live query internals so it reports the intended duplicate key error instead of throwing a TypeError.
+Fix live query includes reconciliation so updates that re-emit existing child rows update internal child collections instead of attempting duplicate inserts, and ensure duplicate-key sync errors handle collection configs without live query internals.

--- a/packages/db/src/collection/sync.ts
+++ b/packages/db/src/collection/sync.ts
@@ -151,9 +151,10 @@ export class CollectionSyncManager<
                   // throwing a duplicate-key error during reconciliation.
                   messageType = `update`
                 } else {
-                  const utils = this.config
-                    .utils as Partial<LiveQueryCollectionUtils>
-                  const internal = utils[LIVE_QUERY_INTERNAL]
+                  const utils = this.config.utils as
+                    | Partial<LiveQueryCollectionUtils>
+                    | undefined
+                  const internal = utils?.[LIVE_QUERY_INTERNAL]
                   throw new DuplicateKeySyncError(key, this.id, {
                     hasCustomGetKey: internal?.hasCustomGetKey ?? false,
                     hasJoins: internal?.hasJoins ?? false,

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -1671,14 +1671,19 @@ function flushIncludesState(
             if (entry.orderByIndices && change.orderByIndex !== undefined) {
               entry.orderByIndices.set(change.value, change.orderByIndex)
             }
+            const key = entry.syncMethods.collection.getKeyFromItem(
+              change.value,
+            )
+            const childAlreadyExists = entry.syncMethods.collection.has(key)
+
             if (change.inserts > 0 && change.deletes === 0) {
-              entry.syncMethods.write({ value: change.value, type: `insert` })
+              entry.syncMethods.write({
+                value: change.value,
+                type: childAlreadyExists ? `update` : `insert`,
+              })
             } else if (
               change.inserts > change.deletes ||
-              (change.inserts === change.deletes &&
-                entry.syncMethods.collection.has(
-                  entry.syncMethods.collection.getKeyFromItem(change.value),
-                ))
+              (change.inserts === change.deletes && childAlreadyExists)
             ) {
               entry.syncMethods.write({ value: change.value, type: `update` })
             } else if (change.deletes > 0) {

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -51,7 +51,7 @@ describe(`Collection`, () => {
   it(`throws DuplicateKeySyncError instead of TypeError when config has no utils`, async () => {
     let begin!: () => void
     let write!: Parameters<
-      SyncConfig<{ id: number; text: string }>[`sync`]
+      SyncConfig<{ id: number; text: string }, number>[`sync`]
     >[0][`write`]
 
     const collection = createCollection<{ id: number; text: string }, number>({

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -4,6 +4,7 @@ import { createCollection } from '../src/collection/index.js'
 import {
   CollectionRequiresConfigError,
   DuplicateKeyError,
+  DuplicateKeySyncError,
   InvalidKeyError,
   KeyUpdateNotAllowedError,
   MissingDeleteHandlerError,
@@ -18,7 +19,12 @@ import {
   stripVirtualProps,
   withExpectedRejection,
 } from './utils'
-import type { ChangeMessage, MutationFn, PendingMutation } from '../src/types'
+import type {
+  ChangeMessage,
+  MutationFn,
+  PendingMutation,
+  SyncConfig,
+} from '../src/types'
 
 const getStateValue = <T extends object, TKey extends string | number>(
   collection: { state: Map<TKey, T> },
@@ -40,6 +46,35 @@ describe(`Collection`, () => {
   it(`should throw if there's no sync config`, () => {
     // @ts-expect-error we're testing for throwing when there's no config passed in
     expect(() => createCollection()).toThrow(CollectionRequiresConfigError)
+  })
+
+  it(`throws DuplicateKeySyncError instead of TypeError when config has no utils`, async () => {
+    let begin!: () => void
+    let write!: Parameters<
+      SyncConfig<{ id: number; text: string }>[`sync`]
+    >[0][`write`]
+
+    const collection = createCollection<{ id: number; text: string }, number>({
+      id: `duplicate-key-no-utils-test`,
+      getKey: (item) => item.id,
+      sync: {
+        sync: (params) => {
+          begin = params.begin
+          write = params.write
+          params.begin()
+          params.write({ type: `insert`, value: { id: 1, text: `one` } })
+          params.commit()
+          params.markReady()
+        },
+      },
+    })
+
+    await collection.stateWhenReady()
+
+    begin()
+    expect(() =>
+      write({ type: `insert`, value: { id: 1, text: `changed` } }),
+    ).toThrow(DuplicateKeySyncError)
   })
 
   it(`removes optimistic insert when sync confirms with a different server-generated key`, async () => {

--- a/packages/db/tests/query/includes.test.ts
+++ b/packages/db/tests/query/includes.test.ts
@@ -567,6 +567,60 @@ describe(`includes subqueries`, () => {
   })
 
   describe(`change propagation`, () => {
+    it(`Collection includes: joined child update does not duplicate insert into child collection`, async () => {
+      type LineItem = { id: number; productId: number; qty: number }
+      type Product = { id: number; categoryId: number; name: string }
+
+      const lineItems = createCollection(
+        mockSyncCollectionOptions<LineItem>({
+          id: `includes-line-items`,
+          getKey: (lineItem) => lineItem.id,
+          initialData: [{ id: 1, productId: 10, qty: 1 }],
+        }),
+      )
+      const products = createCollection(
+        mockSyncCollectionOptions<Product>({
+          id: `includes-products`,
+          getKey: (product) => product.id,
+          initialData: [{ id: 10, categoryId: 1, name: `Widget` }],
+        }),
+      )
+
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ lineItem: lineItems }).select(({ lineItem }) => ({
+          id: lineItem.id,
+          product: q
+            .from({ product: products })
+            .where(({ product }) => eq(product.id, lineItem.productId))
+            .select(({ product }) => ({
+              id: product.id,
+              categoryId: product.categoryId,
+              name: product.name,
+            })),
+        })),
+      )
+      await collection.preload()
+
+      lineItems.utils.begin()
+      expect(() => {
+        lineItems.utils.write({
+          type: `delete`,
+          value: { id: 1, productId: 10, qty: 1 },
+        })
+        lineItems.utils.write({
+          type: `insert`,
+          value: { id: 1, productId: 10, qty: 2 },
+        })
+      }).not.toThrow()
+      lineItems.utils.commit()
+
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      expect(childItems((collection.get(1) as any).product)).toEqual([
+        { id: 10, categoryId: 1, name: `Widget` },
+      ])
+    })
+
     it(`Collection includes: child change does not re-emit the parent row`, async () => {
       const collection = buildIncludesQuery()
       await collection.preload()

--- a/packages/db/tests/query/includes.test.ts
+++ b/packages/db/tests/query/includes.test.ts
@@ -614,11 +614,11 @@ describe(`includes subqueries`, () => {
       }).not.toThrow()
       lineItems.utils.commit()
 
-      await new Promise((resolve) => setTimeout(resolve, 10))
-
-      expect(childItems((collection.get(1) as any).product)).toEqual([
-        { id: 10, categoryId: 1, name: `Widget` },
-      ])
+      await vi.waitFor(() => {
+        expect(childItems((collection.get(1) as any).product)).toEqual([
+          { id: 10, categoryId: 1, name: `Widget` },
+        ])
+      })
     })
 
     it(`Collection includes: child change does not re-emit the parent row`, async () => {

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -260,9 +260,7 @@ describe(`QueryCollection`, () => {
         onUpdate: async ({ transaction }) => {
           for (const mutation of transaction.mutations) {
             productsData = productsData.map((product) =>
-              product.id === mutation.key
-                ? (mutation.modified)
-                : product,
+              product.id === mutation.key ? mutation.modified : product,
             )
           }
         },

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -9,7 +9,10 @@ import {
   inArray,
   or,
 } from '@tanstack/db'
-import { stripVirtualProps } from '../../db/tests/utils'
+import {
+  mockSyncCollectionOptions,
+  stripVirtualProps,
+} from '../../db/tests/utils'
 import { persistedCollectionOptions } from '../../db-sqlite-persistence-core/src'
 import { queryCollectionOptions } from '../src/query'
 import type { QueryFunctionContext } from '@tanstack/query-core'
@@ -226,6 +229,75 @@ describe(`QueryCollection`, () => {
     expect(collection._state.syncedData.size).toBe(initialItems.length)
     expect(collection._state.syncedData.get(`1`)).toEqual(initialItems[0])
     expect(collection._state.syncedData.get(`2`)).toEqual(initialItems[1])
+  })
+
+  it(`should not duplicate insert into includes child collection after update refetch`, async () => {
+    type LineItem = { id: string; productId: string }
+    type Product = { id: string; categoryId: number; name: string }
+
+    const lineItems = createCollection(
+      mockSyncCollectionOptions<LineItem>({
+        id: `query-collection-line-items`,
+        getKey: (lineItem) => lineItem.id,
+        initialData: [{ id: `line-1`, productId: `product-1` }],
+      }),
+    )
+
+    let productsData: Array<Product> = [
+      { id: `product-1`, categoryId: 1, name: `Widget` },
+    ]
+
+    const products = createCollection(
+      queryCollectionOptions<Product>({
+        id: `query-collection-products`,
+        queryClient,
+        queryKey: [`products`],
+        queryFn: vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(productsData)),
+        getKey: (product) => product.id,
+        startSync: true,
+        onUpdate: async ({ transaction }) => {
+          for (const mutation of transaction.mutations) {
+            productsData = productsData.map((product) =>
+              product.id === mutation.key
+                ? (mutation.modified)
+                : product,
+            )
+          }
+        },
+      }),
+    )
+
+    const collection = createLiveQueryCollection((q) =>
+      q.from({ lineItem: lineItems }).select(({ lineItem }) => ({
+        id: lineItem.id,
+        product: q
+          .from({ product: products })
+          .where(({ product }) => eq(product.id, lineItem.productId))
+          .select(({ product }) => ({
+            id: product.id,
+            categoryId: product.categoryId,
+            name: product.name,
+          })),
+      })),
+    )
+
+    await collection.preload()
+
+    expect(() => {
+      products.update(`product-1`, (draft) => {
+        draft.categoryId = 2
+      })
+    }).not.toThrow()
+
+    await vi.waitFor(() => {
+      expect(stripVirtualProps(products.get(`product-1`) as any)).toEqual({
+        id: `product-1`,
+        categoryId: 2,
+        name: `Widget`,
+      })
+    })
   })
 
   it(`should update collection when query data changes`, async () => {

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -290,7 +290,9 @@ describe(`QueryCollection`, () => {
     }).not.toThrow()
 
     await vi.waitFor(() => {
-      expect(stripVirtualProps(products.get(`product-1`) as any)).toEqual({
+      expect(
+        stripVirtualProps((collection.get(`line-1`) as any).product.toArray[0]),
+      ).toEqual({
         id: `product-1`,
         categoryId: 2,
         name: `Widget`,


### PR DESCRIPTION
Fix live-query includes reconciliation so `.update()` flows that re-emit an existing joined child row update the internal child collection instead of attempting a duplicate insert.

User-visible impact: updating a `queryCollectionOptions` source used in a live query with joined/included child rows no longer crashes with either the secondary `LIVE_QUERY_INTERNAL` `TypeError` or the underlying duplicate child insert error.

## Root Cause

The user action is `.update()`, but that update triggers live-query graph reconciliation. During reconciliation, `flushIncludesState` writes changes into internal child collections such as:

```text
__child-collection:detailed-surplus-agreement-line-items-product-30587
```

From that internal collection's perspective, a derived/joined row can be emitted as an `insert` even though the user operation was an update. When the child collection already contained that key, sync correctly rejected the duplicate insert:

```text
Cannot insert document with key "302935" from sync because it already exists in the collection "__child-collection:..."
```

There was also a secondary issue in the duplicate-key error path: generic/internal collection configs do not necessarily have live-query internals in `config.utils`, but `sync.ts` assumed they did while constructing `DuplicateKeySyncError` context.

## Approach

The fix has two parts:

1. In `flushIncludesState`, compute whether the internal child collection already has the child key before writing an insert-only child change. If the child already exists, write an internal `update` instead of an `insert`.

   ```ts
   const key = entry.syncMethods.collection.getKeyFromItem(change.value)
   const childAlreadyExists = entry.syncMethods.collection.has(key)

   if (change.inserts > 0 && change.deletes === 0) {
     entry.syncMethods.write({
       value: change.value,
       type: childAlreadyExists ? `update` : `insert`,
     })
   }
   ```

2. In the duplicate-key sync error path, guard optional `config.utils` before reading `LIVE_QUERY_INTERNAL`, preserving enhanced context when present and defaulting the flags when absent.

## Key Invariants

- Existing internal child rows must not receive duplicate sync inserts during live-query includes reconciliation.
- New internal child rows should still be inserted normally.
- Existing live-query-specific duplicate-key diagnostics should be preserved when `LIVE_QUERY_INTERNAL` is present.
- Collection configs without `utils` must not throw a secondary `TypeError` while constructing duplicate-key errors.

## Non-goals

- This does not change public `.update()` semantics.
- This does not change query collection refetch behavior.
- This does not redesign includes materialization or child collection identity.

## Trade-offs

The targeted fix keeps reconciliation local to the internal child collection write decision. A broader alternative would be changing upstream D2/includes change classification, but the child collection is the place with direct knowledge of whether a given child key is already materialized.

## Verification

```bash
cd packages/db
pnpm vitest run tests/collection.test.ts -t "config has no utils" --coverage.enabled=false
pnpm vitest run tests/query/includes.test.ts --coverage.enabled=false --pool-options.threads.maxThreads=2
```

```bash
cd packages/query-db-collection
pnpm vitest run tests/query.test.ts -t "duplicate insert into includes child" --coverage.enabled=false
```

CI is green for PR #1600, including:

- Test
- Run E2E Tests
- Build Example Site
- Preview

## Files changed

- `packages/db/src/collection/sync.ts`
  - Guard access to optional `config.utils` before reading `LIVE_QUERY_INTERNAL`.
- `packages/db/src/query/live/collection-config-builder.ts`
  - Convert insert-only internal child changes to updates when the child key already exists.
- `packages/db/tests/collection.test.ts`
  - Add regression coverage for duplicate-key sync errors when collection config has no `utils`.
- `packages/db/tests/query/includes.test.ts`
  - Add coverage for joined includes child reconciliation.
- `packages/query-db-collection/tests/query.test.ts`
  - Add coverage for query collection update/refetch feeding a live-query includes child collection.
- `.changeset/fix-sync-duplicate-key-utils.md`
  - Add patch changeset for `@tanstack/db`.

---

Fixes #1599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved duplicate-key sync failure handling in live queries, preventing unexpected TypeErrors and ensuring the correct duplicate-key error is raised.
* Refined live query includes propagation for joined child collections to avoid duplicate child-row insertions during update flows.
* Improved child write behavior to correctly choose between inserts and updates based on whether the child already exists.

## Tests
* Added regression tests covering duplicate-key sync behavior and joined include update scenarios.
* Extended existing test assertions and imports to validate the new error and propagation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
