### PR TITLE
fix(solid-db): clone rows in syncDataFromCollection so reconcile sees in-place mutations

### DIFF
--- a/.changeset/solid-db-reconcile-clone-rows.md
+++ b/.changeset/solid-db-reconcile-clone-rows.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/solid-db": patch
+---
+
+Fix `useLiveQuery` not propagating `toArray` include changes. When the upstream collection mutated parent rows in place (as it does when flushing `toArray` include values), Solid's `reconcile` short-circuited on the stable parent reference and the rendered `data` array kept showing the old include content. `syncDataFromCollection` now shallow-clones each row (and any array-valued field on it) before handing it to `reconcile`, so field-level diffing actually runs.

--- a/packages/solid-db/src/useLiveQuery.ts
+++ b/packages/solid-db/src/useLiveQuery.ts
@@ -341,12 +341,35 @@ export function useLiveQuery(
     },
   )
 
-  // Helper to sync data array from collection in correct order
+  // Helper to sync data array from collection in correct order.
+  //
+  // `reconcile` short-circuits on `next === target` (both at the array-item
+  // level and at the field level), so when the collection mutates a row in
+  // place — as it does for `toArray` include values flushed by
+  // `flushIncludesState` in `packages/db/src/query/live/collection-config-builder.ts`
+  // — downstream consumers never see the change. Shallow-clone each row (and
+  // any array-valued field on it) so `reconcile` recurses into the field-level
+  // diff instead of bailing on the stable parent / include reference.
+  // Tracking issue: https://github.com/TanStack/db/issues/1571
+  const cloneRowForReconcile = <T,>(v: T): T => {
+    if (v === null || typeof v !== `object` || Array.isArray(v)) {
+      return v
+    }
+    const source = v as Record<string, unknown>
+    const out: Record<string, unknown> = {}
+    for (const key in source) {
+      const val = source[key]
+      out[key] = Array.isArray(val) ? [...val] : val
+    }
+    return out as T
+  }
   const syncDataFromCollection = (
     currentCollection: Collection<any, any, any>,
   ) => {
     setData((prev) =>
-      reconcile(Array.from(currentCollection.values()))(prev).filter(Boolean),
+      reconcile(
+        Array.from(currentCollection.values(), cloneRowForReconcile),
+      )(prev).filter(Boolean),
     )
   }
 

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -2544,6 +2544,62 @@ describe(`Query Collections`, () => {
       }
       expect(beta.issueTitles).toEqual([`Bug in Beta`])
     })
+
+    it(`should update when a toArray include starts empty and gets first child`, async () => {
+      // Empty-include variant — the parent's `issueTitles` array starts at
+      // `[]` and must reflect a first child insert. The clone-on-sync path
+      // has to widen the existing empty array to a new one so reconcile sees
+      // the change.
+      const projects = createCollection(
+        mockSyncCollectionOptions<IncludeProject>({
+          id: `toarray-include-projects-empty`,
+          getKey: (p) => p.id,
+          initialData: [{ id: 3, name: `Gamma` }],
+        }),
+      )
+      const issues = createCollection(
+        mockSyncCollectionOptions<IncludeIssue>({
+          id: `toarray-include-issues-empty`,
+          getKey: (i) => i.id,
+          initialData: [],
+        }),
+      )
+
+      const rendered = renderHook(() => {
+        return useLiveQuery((q) =>
+          q.from({ p: projects }).select(({ p }) => ({
+            id: p.id,
+            issueTitles: toArray(
+              q
+                .from({ i: issues })
+                .where(({ i }) => eq(i.projectId, p.id))
+                .select(({ i }) => i.title),
+            ),
+          })),
+        )
+      })
+
+      await waitFor(() => {
+        const gamma = rendered.result().find((r: any) => r.id === 3) as
+          | { issueTitles: Array<string> }
+          | undefined
+        expect(gamma?.issueTitles).toEqual([])
+      })
+
+      issues.utils.begin()
+      issues.utils.write({
+        type: `insert`,
+        value: { id: 30, projectId: 3, title: `First Gamma issue` },
+      })
+      issues.utils.commit()
+
+      await waitFor(() => {
+        const gamma = rendered.result().find((r: any) => r.id === 3) as {
+          issueTitles: Array<string>
+        }
+        expect(gamma.issueTitles).toEqual([`First Gamma issue`])
+      })
+    })
   })
 
   describe(`findOne`, () => {

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -8,6 +8,7 @@ import {
   createOptimisticAction,
   eq,
   gt,
+  toArray,
 } from '@tanstack/db'
 import {
   For,
@@ -2451,6 +2452,97 @@ describe(`Query Collections`, () => {
       // Verify ordering
       const finalIds = rendered.result().map((p: any) => p.id)
       expect(finalIds).toEqual([`1`, `2`, `3`, `4`])
+    })
+  })
+
+  /**
+   * @see https://github.com/TanStack/db/issues/1571
+   *
+   * Regression: when an include (e.g. `toArray`) is updated, the parent row
+   * held by the collection is mutated in place. Solid's `reconcile`
+   * short-circuits on `next === target`, so without a clone-on-sync the
+   * `data` array never reflected the new child rows even though the
+   * underlying collection had them.
+   */
+  describe(`toArray include reactivity (#1571)`, () => {
+    type IncludeProject = { id: number; name: string }
+    type IncludeIssue = { id: number; projectId: number; title: string }
+
+    const initialIncludeProjects: Array<IncludeProject> = [
+      { id: 1, name: `Alpha` },
+      { id: 2, name: `Beta` },
+    ]
+    const initialIncludeIssues: Array<IncludeIssue> = [
+      { id: 10, projectId: 1, title: `Bug in Alpha` },
+      { id: 20, projectId: 2, title: `Bug in Beta` },
+    ]
+
+    it(`should reflect child inserts in the parent row's toArray include`, async () => {
+      const projects = createCollection(
+        mockSyncCollectionOptions<IncludeProject>({
+          id: `toarray-include-projects`,
+          getKey: (p) => p.id,
+          initialData: initialIncludeProjects,
+        }),
+      )
+      const issues = createCollection(
+        mockSyncCollectionOptions<IncludeIssue>({
+          id: `toarray-include-issues`,
+          getKey: (i) => i.id,
+          initialData: initialIncludeIssues,
+        }),
+      )
+
+      const rendered = renderHook(() => {
+        return useLiveQuery((q) =>
+          q.from({ p: projects }).select(({ p }) => ({
+            id: p.id,
+            name: p.name,
+            issueTitles: toArray(
+              q
+                .from({ i: issues })
+                .where(({ i }) => eq(i.projectId, p.id))
+                .select(({ i }) => i.title),
+            ),
+          })),
+        )
+      })
+
+      await waitFor(() => {
+        expect(rendered.result().length).toBe(2)
+      })
+
+      const alphaBefore = rendered
+        .result()
+        .find((r: any) => r.id === 1) as { issueTitles: Array<string> }
+      expect(alphaBefore.issueTitles).toEqual([`Bug in Alpha`])
+
+      // Insert a child issue tied to project Alpha. Upstream mutates the
+      // parent row's `issueTitles` field in place; without the clone-on-sync
+      // fix the parent row reference stays stable and reconcile bails before
+      // recursing into the array.
+      issues.utils.begin()
+      issues.utils.write({
+        type: `insert`,
+        value: { id: 11, projectId: 1, title: `Feature for Alpha` },
+      })
+      issues.utils.commit()
+
+      await waitFor(() => {
+        const alphaAfter = rendered
+          .result()
+          .find((r: any) => r.id === 1) as { issueTitles: Array<string> }
+        expect(alphaAfter.issueTitles).toEqual(
+          expect.arrayContaining([`Bug in Alpha`, `Feature for Alpha`]),
+        )
+        expect(alphaAfter.issueTitles.length).toBe(2)
+      })
+
+      // Beta is untouched.
+      const beta = rendered.result().find((r: any) => r.id === 2) as {
+        issueTitles: Array<string>
+      }
+      expect(beta.issueTitles).toEqual([`Bug in Beta`])
     })
   })
 


### PR DESCRIPTION
Fixes part of #1571.

## What

`useLiveQuery`'s rendered `data` array missed updates whenever the underlying collection mutated a row in place. The upstream pipeline does exactly that — `flushIncludesState` in [`packages/db/src/query/live/collection-config-builder.ts`](https://github.com/TanStack/db/blob/main/packages/db/src/query/live/collection-config-builder.ts) writes new `toArray` include values onto the parent row via `setIncludedValue(parentResult, …)` without changing its identity. When `syncDataFromCollection` then called

```ts
reconcile(Array.from(currentCollection.values()))(prev).filter(Boolean)
```

Solid's `reconcile` short-circuited on `next === target` at the parent-row level (and again on the include array reference if reached). The reactive `state` `ReactiveMap` still updated correctly — `subscribeChanges` hands `state.set` a fresh row reference per change event — but the `data` array fell out of sync.

The reporter @Tarmean documented this for `toArray` includes specifically, with `flushIncludesState` cloning rows for the events but mutating the rows the collection itself returns from `.values()`.

## How

`syncDataFromCollection` now shallow-clones each row (and any array-valued field on it) before handing the snapshot to `reconcile`. The wrapper is small and lives next to the sync helper so the rationale is local:

```ts
const cloneRowForReconcile = <T,>(v: T): T => {
  if (v === null || typeof v !== 'object' || Array.isArray(v)) return v
  const source = v as Record<string, unknown>
  const out: Record<string, unknown> = {}
  for (const key in source) {
    const val = source[key]
    out[key] = Array.isArray(val) ? [...val] : val
  }
  return out as T
}
```

Field-level diffing then actually runs and `toArray` include arrays propagate. Non-object values (primitives) pass through; arrays at the top level pass through (`reconcile` already iterates them); object values get a one-level copy with arrays inside them also copied so the include-array reference changes.

The `state` `ReactiveMap` path is untouched — `subscribeChanges` was already getting fresh row references per change event, so only the `Array.from(currentCollection.values())` sync needed help.

## Tests

Adds `toArray include reactivity (#1571)` describe block in `packages/solid-db/tests/useLiveQuery.test.tsx`:

- Set up two collections (`projects`, `issues`) and a `useLiveQuery` that projects `{ id, name, issueTitles: toArray(...) }`.
- Insert a new child issue tied to project Alpha.
- Assert the parent row's `issueTitles` array grows from `['Bug in Alpha']` to `['Bug in Alpha', 'Feature for Alpha']` in the rendered `data` array (not just in the `state` map).
- Asserts Beta's include is untouched.

Without the clone, the rendered `data` array stays at the original include content; the test would fail on `expect(alphaAfter.issueTitles.length).toBe(2)`. All 39 tests in `packages/solid-db/tests/useLiveQuery.test.tsx` pass. Lint clean (per AGENTS.md).

## Scope

This addresses the **clone-in-reconcile half** of #1571. @Tarmean's report flagged a second, related case:

> If an include is initially empty, the proxy is not attached to the parent. It remains null. This is why the initial child field can be null, breaking reactivity for collection includes as well.

That one lives at `packages/db/src/query/live/collection-config-builder.ts:1851-1867` and is a different code path (proxy attachment, not consumer-side reconcile). Happy to file it as a separate issue and take a look if maintainers agree it's the same bug class.

## Notes for maintainers

- The clone-on-sync trades a small allocation per row per sync for correctness. For typical UIs (hundreds of rows) this is far cheaper than the missed-update bug. If the perf trade-off is unwelcome, the alternative is to fix this upstream in `flushIncludesState` so include writes produce new parent row identities — happy to switch directions on guidance.
- I considered using `state.values()` instead of `currentCollection.values()` (since `state` already holds fresh references per `subscribeChanges` event), but `state`'s insertion order doesn't match the collection's sort order on inserts, so the `data` array would drift. Cloning preserved the sort order from `currentCollection.values()`.

## Changeset

`@tanstack/solid-db: patch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed live queries not updating correctly when included related data changed (such as after inserting a new child entry). Included fields now refresh reliably so the displayed arrays reflect the most recent matching records.
- Added regression coverage to ensure `toArray`-based includes update as expected, including cases where an initially empty include expands after the first matching child insert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->