### PR TITLE
fix: preload hangs forever after cleanup (#1576)

### DIFF
--- a/.changeset/preload-after-cleanup-1576.md
+++ b/.changeset/preload-after-cleanup-1576.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/db': patch
+---
+
+Fix live query `preload()` hanging forever after a source collection was cleaned up (#1576)
+
+When a source collection is cleaned up while a live query depends on it, the live query transitions to an error state and latches an internal `isInErrorState` flag. That flag was never reset, so restarting sync (e.g. calling `preload()` again after cleanup when switching profiles) left the live query unable to become ready and the returned promise never resolved. The flag is now cleared at the start of each sync session so the live query can recover.

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -596,6 +596,8 @@ export class CollectionConfigBuilder<
   private syncFn(config: SyncMethods<TResult>) {
     // Store reference to the live query collection for error state transitions
     this.liveQueryCollection = config.collection
+    // Reset error state from any previous sync session so a restarted sync can become ready again.
+    this.isInErrorState = false
     // Store config and syncState as instance properties for the duration of this sync session
     this.currentSyncConfig = config
 

--- a/packages/db/tests/query/live-query-collection.test.ts
+++ b/packages/db/tests/query/live-query-collection.test.ts
@@ -594,6 +594,33 @@ describe(`createLiveQueryCollection`, () => {
     finalSubscription.unsubscribe()
   })
 
+  it(`loads its data again when preloaded after the live query and its source collection were cleaned up`, async () => {
+    const activeUsers = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) => eq(user.active, true)),
+    })
+
+    await activeUsers.preload()
+    expect(activeUsers.status).toBe(`ready`)
+    expect(activeUsers.size).toBe(2)
+
+    // Tear down the source collection and the live query, e.g. when switching
+    // to a different data set at runtime. Cleaning up a source collection puts
+    // the dependent live query into an error state.
+    await usersCollection.cleanup()
+    expect(activeUsers.status).toBe(`error`)
+
+    await activeUsers.cleanup()
+    expect(activeUsers.status).toBe(`cleaned-up`)
+
+    // Preloading again restarts sync and resolves once the data is loaded.
+    await activeUsers.preload()
+    expect(activeUsers.status).toBe(`ready`)
+    expect(activeUsers.size).toBe(2)
+  })
+
   it(`should handle temporal values correctly in live queries`, async () => {
     // Define a type with temporal values
     type Task = {


### PR DESCRIPTION
## Fix for #1576

Follow-up to #1605 (the failing-repro PR). **Stacked on top of that branch**, so this PR's diff currently contains both the regression test and the fix; once #1605 merges it reduces to just the fix.

### Problem
`preload` after `cleanup` on a collection hangs forever. When a source collection is cleaned up while a live query depends on it, `handleSourceStatusChange()` transitions the live query into an error state via `transitionToError()`, which latches `isInErrorState = true`.

The `LiveQueryCollectionConfigBuilder` instance is reused across sync sessions, and that flag was never reset. So when sync restarts (e.g. `preload()` again after cleanup — the "switching profiles without a page refresh" use case in the issue), `updateLiveQueryStatus()` returns early at the `isInErrorState` guard, `markReady()` is never called, and the preload promise never resolves.

### Fix
Reset `isInErrorState = false` at the start of each sync session in `syncFn()`. Re-subscribing to the source collections restarts them, the live query observes them becoming ready, and `markReady()` fires as expected.

`packages/db/src/query/live/collection-config-builder.ts`

### Verification
- The regression test from #1605 now passes.
- Full `packages/db` query suite passes (1587 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where live query `preload()` could hang indefinitely after cleanup/error events.
  * Live queries now properly recover across subsequent preload attempts, returning to the expected ready state and resuming synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->