### PR TITLE
FIX solid-db, db: bug with solid not remounting with current data due to proxy issues

### DIFF
--- a/.changeset/loose-flies-sell.md
+++ b/.changeset/loose-flies-sell.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/solid-db': patch
+'@tanstack/db': patch
+---
+
+Fixed a bug where cloning non enumerable properties causes solid store to get stuck in a non current state

--- a/packages/db/src/proxy.ts
+++ b/packages/db/src/proxy.ts
@@ -603,6 +603,8 @@ function deepClone<T extends unknown>(
 
   const symbolProps = Object.getOwnPropertySymbols(obj)
   for (const sym of symbolProps) {
+    if (!Object.prototype.propertyIsEnumerable.call(obj, sym)) continue
+
     clone[sym] = deepClone(
       (obj as Record<string | symbol, unknown>)[sym],
       visited,

--- a/packages/db/tests/proxy.test.ts
+++ b/packages/db/tests/proxy.test.ts
@@ -101,6 +101,34 @@ describe(`Proxy Library`, () => {
       })
     })
 
+    it(`should not clone non-enumerable symbol metatdata into nested changes`, () => {
+      const metadata = Symbol(`metadata`)
+      const domainSymbol = Symbol(`domain`)
+
+      const obj = {
+        user: {
+          name: `John`,
+          age: 30,
+          [domainSymbol]: `preserved`,
+        },
+      }
+
+      Object.defineProperty(obj.user, metadata, {
+        value: `internal`,
+        enumerable: false,
+      })
+
+      const changes = withChangeTracking(obj, (draft) => {
+        draft.user.age = 31
+      })
+
+      const changedUser = changes.user as Record<string | symbol, unknown>
+
+      expect(changedUser.age).toBe(31)
+      expect(changedUser[domainSymbol]).toBe(`preserved`)
+      expect(Object.getOwnPropertySymbols(changedUser)).not.toContain(metadata)
+    })
+
     it(`should track when properties are deleted from objects`, () => {
       const obj: { name: string; age: number; role?: string } = {
         name: `John`,

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -36,6 +36,14 @@ type Issue = {
   userId: string
 }
 
+type DeepNode = {
+  id: string
+  size: {
+    min: number
+    max: number
+  }
+}
+
 const initialPersons: Array<Person> = [
   {
     id: `1`,
@@ -2705,5 +2713,112 @@ describe(`Query Collections`, () => {
 
       expect(rendered.result()).toBeUndefined()
     })
+  })
+
+  it('single-row reflects the current value on remount', async () => {
+    const nodeId = 'node-1'
+    const collection = createCollection(
+      mockSyncCollectionOptions<DeepNode>({
+        id: `remount-single-nested-test`,
+        getKey: (item) => item.id,
+        initialData: [
+          {
+            id: nodeId,
+            size: { min: 1, max: 10 },
+          },
+        ],
+      }),
+    )
+
+    const updateMax = (max: number) => {
+      collection.update(nodeId, (draft) => {
+        draft.size.max = max
+      })
+    }
+
+    const mount = () =>
+      render(() => {
+        const query = useLiveQuery((q) =>
+          q
+            .from({ source: collection })
+            .where(({ source }) => eq(source.id, nodeId))
+            .findOne(),
+        )
+
+        return <span data-testid="value">{query()?.size.max ?? 'pending'}</span>
+      })
+
+    const first = mount()
+
+    await waitFor(() =>
+      expect(first.getByTestId(`value`).textContent).toBe(`10`),
+    )
+
+    updateMax(777)
+
+    await waitFor(() =>
+      expect(first.getByTestId(`value`).textContent).toBe(`777`),
+    )
+
+    first.unmount()
+
+    const second = mount()
+    await waitFor(() =>
+      expect(second.getByTestId(`value`).textContent).toBe(`777`),
+    )
+  })
+
+  it('array reflects the current value on remount', async () => {
+    const nodeId = 'node-1'
+    const collection = createCollection(
+      mockSyncCollectionOptions<DeepNode>({
+        id: `remount-single-nested-test`,
+        getKey: (item) => item.id,
+        initialData: [
+          {
+            id: nodeId,
+            size: { min: 1, max: 10 },
+          },
+        ],
+      }),
+    )
+
+    const updateMax = (max: number) => {
+      collection.update(nodeId, (draft) => {
+        draft.size.max = max
+      })
+    }
+
+    const mount = () =>
+      render(() => {
+        const query = useLiveQuery((q) =>
+          q
+            .from({ source: collection })
+            .where(({ source }) => eq(source.id, nodeId)),
+        )
+
+        return (
+          <span data-testid="value">{query()[0]?.size.max ?? 'pending'}</span>
+        )
+      })
+
+    const first = mount()
+
+    await waitFor(() =>
+      expect(first.getByTestId(`value`).textContent).toBe(`10`),
+    )
+
+    updateMax(777)
+
+    await waitFor(() =>
+      expect(first.getByTestId(`value`).textContent).toBe(`777`),
+    )
+
+    first.unmount()
+
+    const second = mount()
+    await waitFor(() =>
+      expect(second.getByTestId(`value`).textContent).toBe(`777`),
+    )
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Fixed a bug where cloning non enumerable properties causes solid to get stuck in an old state after mounting a query.
Tests have been added that check for the issue, and fail on the current upstream code. 

This can be recreated in real life by using a keyed Show component that mounts a form, updating the data, then remounting the form. The data will show the correct value, but will revert when remounted. The data in the collection will be correct, but the ui will be out of sync.

## ✅ Checklist

- [X] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a shared live query observer API that unifies live-query lifecycle handling across integrations.

* **Bug Fixes**
  * Prevented cloning from capturing non-enumerable symbol metadata that could corrupt live updates.
  * Improved live query update behavior after component unmount/remount, including nested-field scenarios.
  * Corrected live-query lifecycle/notification edge cases (readiness/status transitions and stable snapshot behavior).

* **Tests**
  * Added coverage for symbol cloning edge cases, remounting nested updates, and observer semantics across granular/wholesale modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->