### PR TITLE
Solid renderer rework - huge performance gains

### DIFF
--- a/.changeset/small-doors-raise.md
+++ b/.changeset/small-doors-raise.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-db': minor
+---
+
+Rework to the solid js renderer that increases performance up to 4x

--- a/packages/solid-db/src/useLiveQuery.ts
+++ b/packages/solid-db/src/useLiveQuery.ts
@@ -1,3 +1,10 @@
+import { ReactiveMap } from '@solid-primitives/map'
+import {
+  BaseQueryBuilder,
+  createLiveQueryCollection,
+  createLiveQueryObserver,
+  isCollection,
+} from '@tanstack/db'
 import {
   batch,
   createEffect,
@@ -6,14 +13,6 @@ import {
   createSignal,
   onCleanup,
 } from 'solid-js'
-import { ReactiveMap } from '@solid-primitives/map'
-import {
-  BaseQueryBuilder,
-  createLiveQueryCollection,
-  createLiveQueryObserver,
-  isCollection,
-  isSingleResultCollection,
-} from '@tanstack/db'
 import { createStore, reconcile } from 'solid-js/store'
 import type { Accessor } from 'solid-js'
 import type {
@@ -28,7 +27,15 @@ import type {
   NonSingleResult,
   QueryBuilder,
   SingleResult,
+  WithVirtualProps,
 } from '@tanstack/db'
+
+const RECONCILE_KEY = { key: `$key` } as const
+
+const RECONCILE_DEEP = { merge: true } as const
+
+type AnyCollection = Collection<any, any, any>
+type AnyChange = ChangeMessage<any, string | number>
 
 /**
  * Create a live query using a query function
@@ -334,6 +341,44 @@ export function useLiveQuery(
     name: `TanstackDBData`,
   })
 
+  const rowIndex = new Map<string | number, number>()
+  const syncRows: Array<any> = []
+
+  // The collection currently reflected by `data`.
+  let syncedCollection: AnyCollection | null = null
+
+  // `.state` is maintained lazily and can lag behind `data` until accessed.
+  let stateSyncedCollection: AnyCollection | null = null
+  let stateAccessed = false
+
+  // The row currently exposed by findOne-style queries.
+  let singleRowKey: string | number | undefined
+
+  // Read the collection config once at call sites that need single-row behavior.
+  const isSingleResult = (currentCollection: AnyCollection) => {
+    const config = currentCollection.config
+    return 'singleResult' in config && config.singleResult === true
+  }
+
+  // Patch an existing store row instead of replacing the array. This keeps
+  // Solid's per-field subscriptions alive for rows that did not change.
+  const patchStoreRow = (index: number, row: WithVirtualProps<any>) => {
+    if (index >= data.length) return false
+
+    setData(index, reconcile(row, RECONCILE_DEEP))
+    return true
+  }
+
+  // Public `.state` is lazy. Most consumers only use the accessor result, so we
+  // avoid maintaining a second reactive map until `.state` is actually read.
+  const syncStateFromCollection = (currentCollection: AnyCollection) => {
+    state.clear()
+    for (const value of currentCollection.values()) {
+      state.set(value.$key, value)
+    }
+    stateSyncedCollection = currentCollection
+  }
+
   // Track collection status reactively
   const [status, setStatus] = createSignal(
     collection() ? collection()!.status : (`disabled` as const),
@@ -342,13 +387,145 @@ export function useLiveQuery(
     },
   )
 
-  // Helper to sync data array from collection in correct order
+  // Sync the ordered result array from the collection, reusing scratch storage.
   const syncDataFromCollection = (
-    currentCollection: Collection<any, any, any>,
+    currentCollection: AnyCollection,
+    stateTarget = stateAccessed ? state : undefined,
   ) => {
-    setData((prev) =>
-      reconcile(Array.from(currentCollection.values()))(prev).filter(Boolean),
-    )
+    syncedCollection = currentCollection
+
+    // Unsorted result collections keep stable positions by key; sorted queries
+    // may move rows, so they always resync instead of using rowIndex patches.
+    const shouldTrackIndex = currentCollection.config.compare === undefined
+    if (shouldTrackIndex) rowIndex.clear()
+
+    stateTarget?.clear()
+
+    if (isSingleResult(currentCollection)) {
+      const value = currentCollection.values().next().value
+      if (!value) {
+        singleRowKey = undefined
+        syncRows.length = 0
+        if (stateTarget) stateSyncedCollection = currentCollection
+        setData(reconcile(syncRows, RECONCILE_KEY))
+        return
+      }
+
+      const row = value
+      singleRowKey = row.$key
+      if (stateTarget) {
+        stateTarget.set(row.$key, row)
+        stateSyncedCollection = currentCollection
+      }
+      syncRows[0] = row
+      syncRows.length = 1
+      setData(reconcile(syncRows, RECONCILE_KEY))
+      return
+    }
+
+    syncRows.length = 0
+
+    let index = 0
+    for (const value of currentCollection.values()) {
+      const row = value
+      syncRows[index] = row
+      if (shouldTrackIndex) rowIndex.set(row.$key, index)
+      if (stateTarget) stateTarget.set(row.$key, row)
+      index++
+    }
+    syncRows.length = index
+    if (stateTarget) stateSyncedCollection = currentCollection
+
+    setData(reconcile(syncRows, RECONCILE_KEY))
+  }
+
+  const syncDataOnlyFromCollection = (currentCollection: AnyCollection) => {
+    // Used after `.state` has already been incrementally updated while `data`
+    // still needs an authoritative rebuild for ordering/membership.
+    syncDataFromCollection(currentCollection, undefined)
+  }
+
+  // Fast path for update-only batches. Inserts/deletes or sorted queries can
+  // change membership/order, so those fall back to a collection resync.
+  const patchArrayChanges = (
+    currentCollection: AnyCollection,
+    changes: Array<AnyChange>,
+  ) => {
+    let needsResync = false
+
+    for (const change of changes) {
+      if (change.type !== `update`) {
+        // Inserts/deletes can change membership; update `.state` while we are
+        // here, then rebuild `data` once after the loop.
+        needsResync = true
+        if (stateAccessed) {
+          if (change.type === `delete`) {
+            state.delete(change.key)
+          } else {
+            state.set(change.key, change.value)
+          }
+        }
+        continue
+      }
+
+      const row = change.value
+
+      if (stateAccessed) state.set(change.key, row)
+
+      // Once a batch needs a resync, avoid doing wasted row-level patches for
+      // later updates in the same batch.
+      if (needsResync) continue
+
+      const index = rowIndex.get(change.key)
+      if (index === undefined || !patchStoreRow(index, row)) {
+        needsResync = true
+      }
+    }
+
+    if (needsResync) {
+      syncDataOnlyFromCollection(currentCollection)
+    }
+
+    return !needsResync
+  }
+
+  const patchSingleResultChanges = (
+    currentCollection: AnyCollection,
+    changes: Array<AnyChange>,
+  ) => {
+    let needsResync = false
+
+    for (const change of changes) {
+      if (change.type !== `update`) {
+        // Non-update changes can replace/remove the single result; update the
+        // lazy state map now and rebuild `data` after this pass.
+        needsResync = true
+        if (stateAccessed) {
+          if (change.type === `delete`) {
+            state.delete(change.key)
+          } else {
+            state.set(change.key, change.value)
+          }
+        }
+        continue
+      }
+
+      // Updates for non-matching rows do not affect the exposed single result.
+      if (change.key !== singleRowKey) continue
+
+      const row = change.value
+      if (stateAccessed) state.set(change.key, row)
+
+      // If the batch already needs a resync, defer the visible update to the
+      // final rebuild so ordering/membership stays authoritative.
+      if (!needsResync) setData(0, reconcile(row))
+    }
+
+    if (needsResync) {
+      syncDataOnlyFromCollection(currentCollection)
+    }
+
+    return !needsResync
   }
 
   // Generation guard for the resource's async continuations: Solid discards a
@@ -358,12 +535,9 @@ export function useLiveQuery(
   let resourceGeneration = 0
 
   const [getDataResource] = createResource(
-    () => ({ currentCollection: collection() }),
-    async ({ currentCollection }) => {
+    collection,
+    async (currentCollection) => {
       const generation = ++resourceGeneration
-      if (!currentCollection) {
-        return []
-      }
       setStatus(currentCollection.status)
       try {
         await currentCollection.toArrayWhenReady()
@@ -374,15 +548,10 @@ export function useLiveQuery(
       if (generation !== resourceGeneration) {
         return data
       }
-      // Initialize state with current collection data
-      batch(() => {
-        state.clear()
-        for (const [key, value] of currentCollection.entries()) {
-          state.set(key, value)
-        }
+      if (syncedCollection !== currentCollection) {
         syncDataFromCollection(currentCollection)
-        setStatus(currentCollection.status)
-      })
+      }
+      setStatus(currentCollection.status)
       return data
     },
     {
@@ -396,36 +565,42 @@ export function useLiveQuery(
     const currentCollection = collection()
     if (!currentCollection) {
       setStatus(`disabled` as const)
-      state.clear()
-      setData([])
+      syncedCollection = null
+      stateSyncedCollection = null
+      singleRowKey = undefined
+      rowIndex.clear()
+      if (stateAccessed) state.clear()
+      syncRows.length = 0
+      setData(reconcile(syncRows, RECONCILE_KEY))
       return
     }
-
-    // The shared observer owns subscription, the ready-race, and status; Solid
-    // materializes into its keyed ReactiveMap (granular) + reconciled store.
+    const singleResult = isSingleResult(currentCollection)
+    const canPatchUpdates = currentCollection.config.compare === undefined
+    // The shared observer owns the subscription, the ready-race, and status;
+    // Solid materializes the delivered deltas into the keyed store, patching
+    // rows granularly when membership and order cannot change.
     const observer = createLiveQueryObserver(currentCollection)
-    // Clear any keys carried over from a previous collection before the new
-    // observer re-seeds via `includeInitialState` (which only inserts current
-    // rows, never deletes stale ones). Without this, switching collections
-    // leaves the dropped keys in `state` until the async resource reconciles.
-    state.clear()
     const unsubscribe = observer.subscribe(
       (changes: Array<ChangeMessage<any>> | undefined) => {
         batch(() => {
-          if (changes) {
-            for (const change of changes) {
-              switch (change.type) {
-                case `insert`:
-                case `update`:
-                  state.set(change.key, change.value)
-                  break
-                case `delete`:
-                  state.delete(change.key)
-                  break
-              }
+          if (syncedCollection !== currentCollection) {
+            // The observer replays the initial state on attach, which can win
+            // the race against the resource. Do one authoritative sync instead
+            // of patching stale row indices from the previous collection.
+            syncDataFromCollection(currentCollection)
+          } else if (changes !== undefined && canPatchUpdates) {
+            if (singleResult) {
+              patchSingleResultChanges(currentCollection, changes)
+            } else {
+              patchArrayChanges(currentCollection, changes)
             }
+          } else {
+            // Synthetic status notifies carry no change set, and sorted
+            // queries can reorder rows on any delta; both need a full resync.
+            syncDataFromCollection(currentCollection)
           }
-          syncDataFromCollection(currentCollection)
+
+          // Update status ref on every change
           setStatus(observer.getSnapshot().status)
         })
       },
@@ -440,12 +615,10 @@ export function useLiveQuery(
   // We have to remove getters from the resource function so we wrap it
   function getData() {
     const currentCollection = collection()
-    if (currentCollection) {
-      if (isSingleResultCollection(currentCollection)) {
-        // Force resource tracking so Suspense works
-        getDataResource()
-        return data[0]
-      }
+    if (currentCollection && isSingleResult(currentCollection)) {
+      // Force resource tracking so Suspense works before the collection is ready.
+      if (status() !== `ready`) getDataResource()
+      return data[0]
     }
     return getDataResource()
   }
@@ -468,6 +641,16 @@ export function useLiveQuery(
     },
     state: {
       get() {
+        stateAccessed = true
+        const currentCollection = collection()
+        if (!currentCollection) {
+          if (stateSyncedCollection !== null) {
+            state.clear()
+            stateSyncedCollection = null
+          }
+        } else if (stateSyncedCollection !== currentCollection) {
+          syncStateFromCollection(currentCollection)
+        }
         return state
       },
     },

--- a/packages/solid-db/src/useLiveQuery.ts
+++ b/packages/solid-db/src/useLiveQuery.ts
@@ -516,9 +516,7 @@ export function useLiveQuery(
       const row = change.value
       if (stateAccessed) state.set(change.key, row)
 
-      // If the batch already needs a resync, defer the visible update to the
-      // final rebuild so ordering/membership stays authoritative.
-      if (!needsResync) setData(0, reconcile(row))
+      if (!needsResync) setData(0, reconcile(row, RECONCILE_DEEP))
     }
 
     if (needsResync) {

--- a/packages/solid-db/tests/useLiveQuery.test.tsx
+++ b/packages/solid-db/tests/useLiveQuery.test.tsx
@@ -1095,9 +1095,9 @@ describe(`Query Collections`, () => {
             // Don't call begin/commit immediately
           },
         },
-        onInsert: async () => {},
-        onUpdate: async () => {},
-        onDelete: async () => {},
+        onInsert: async () => { },
+        onUpdate: async () => { },
+        onDelete: async () => { },
       })
 
       const rendered = renderHook(() => {
@@ -1193,9 +1193,9 @@ describe(`Query Collections`, () => {
             // Don't sync immediately
           },
         },
-        onInsert: async () => {},
-        onUpdate: async () => {},
-        onDelete: async () => {},
+        onInsert: async () => { },
+        onUpdate: async () => { },
+        onDelete: async () => { },
       })
 
       const rendered = renderHook(() => {
@@ -1318,9 +1318,9 @@ describe(`Query Collections`, () => {
             // Don't sync immediately
           },
         },
-        onInsert: async () => {},
-        onUpdate: async () => {},
-        onDelete: async () => {},
+        onInsert: async () => { },
+        onUpdate: async () => { },
+        onDelete: async () => { },
       })
 
       const issueCollection = createCollection<Issue>({
@@ -1335,9 +1335,9 @@ describe(`Query Collections`, () => {
             // Don't sync immediately
           },
         },
-        onInsert: async () => {},
-        onUpdate: async () => {},
-        onDelete: async () => {},
+        onInsert: async () => { },
+        onUpdate: async () => { },
+        onDelete: async () => { },
       })
 
       const { result } = renderHook(() => {
@@ -1417,9 +1417,9 @@ describe(`Query Collections`, () => {
               // Don't sync immediately
             },
           },
-          onInsert: async () => {},
-          onUpdate: async () => {},
-          onDelete: async () => {},
+          onInsert: async () => { },
+          onUpdate: async () => { },
+          onDelete: async () => { },
         })
 
         const [minAge, setMinAge] = createSignal(30)
@@ -2705,5 +2705,117 @@ describe(`Query Collections`, () => {
 
       expect(rendered.result()).toBeUndefined()
     })
+  })
+
+  it(`should resync first change after collection switch instead of patching stale row indexes`, async () => {
+    const oldSource = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `first-change-old-source`,
+        getKey: (person: Person) => person.id,
+        initialData: [
+          {
+            id: `same`,
+            name: `Old Same`,
+            age: 30,
+            email: `old.same@example.com`,
+            isActive: true,
+            team: `old`,
+          },
+          {
+            id: `old-only`,
+            name: `Old Only`,
+            age: 31,
+            email: `old.only@example.com`,
+            isActive: true,
+            team: `old`,
+          },
+        ],
+      }),
+    )
+
+    const newSource = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `first-change-new-source`,
+        getKey: (person: Person) => person.id,
+        initialData: [
+          {
+            id: `new-only`,
+            name: `New Only`,
+            age: 40,
+            email: `new.only@example.com`,
+            isActive: true,
+            team: `new`,
+          },
+          {
+            id: `same`,
+            name: `New Same`,
+            age: 41,
+            email: `new.same@example.com`,
+            isActive: true,
+            team: `new`,
+          },
+        ],
+      }),
+    )
+
+    const oldLiveQuery = createLiveQueryCollection({
+      query: (q) =>
+        q.from({ persons: oldSource }).select(({ persons }) => ({
+          id: persons.id,
+          name: persons.name,
+        })),
+      startSync: true,
+    })
+
+    const newLiveQuery = createLiveQueryCollection({
+      query: (q) =>
+        q.from({ persons: newSource }).select(({ persons }) => ({
+          id: persons.id,
+          name: persons.name,
+        })),
+      startSync: true,
+    })
+
+    let resolveNewLiveQuery: (() => void) | undefined
+    const originalToArrayWhenReady = newLiveQuery.toArrayWhenReady.bind(
+      newLiveQuery,
+    )
+    newLiveQuery.toArrayWhenReady = async () => {
+      await new Promise<void>((resolve) => {
+        resolveNewLiveQuery = resolve
+      })
+      return originalToArrayWhenReady()
+    }
+
+    const [activeCollection, setActiveCollection] = createSignal(oldLiveQuery)
+
+    const rendered = renderHook(() => {
+      return useLiveQuery(activeCollection)
+    })
+
+    await waitFor(() => {
+      expect(new Set(rendered.result().map((person) => person.id))).toEqual(
+        new Set([`same`, `old-only`]),
+      )
+      expect(rendered.result()).toHaveLength(2)
+    })
+
+    setActiveCollection(newLiveQuery)
+
+    newSource.update(`same`, (draft) => {
+      draft.name = `New Same Updated`
+    })
+
+    await waitFor(() => {
+      expect(new Set(rendered.result().map((person) => person.id))).toEqual(
+        new Set([`new-only`, `same`]),
+      )
+      expect(rendered.result()).toHaveLength(2)
+      expect(rendered.result().find((person) => person.id === `same`)).toMatchObject({
+        name: `New Same Updated`,
+      })
+    })
+
+    resolveNewLiveQuery!()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Changes how the solid-js renderer updates data to be much more performant in all cases.
This PR manages to keep the API interface exactly the same, while improving change updates + mounting performance.

Currently whenever any data changes, the entire store is reset. This is reliable to keep the data consistent, but for huge collections that only have one field change it is a bit excessive. The changes handle different cases in a few different ways with a huge focus on performance and memory improvements.
 - It keeps avoids cloning any data in the solid renderer, it will only reference the data already in the solid store
   - It also handles the double data set on mount that was happening with the old renderer
 - Uses `$key` for reconcile
 - It handles singleResult queries much more cleanly
 - If the changes are only just updates that will not change the data order, it will update the rows in place
 - It avoids creating new objects and arrays at all costs, reusing temp arrays so that memory only needs to grow once
 - It lazily mounts state if it is accessed. State is rarely used in reality and can probably be removed, but in the interest of compatibility I just made it faster

All this adds together to a much more reliable and performant library that keeps the promised performance by default of both solid-js and tanstack-db.

I have also extensively tested this in a real world app, and no problems where witnessed.

### Benchmarks

When writing this PR I wrote extensive benchmarks that compared this version with the version currently in main. Here are the results.

#### _JSDOM Benchmarks_

#### Initial All-Row Mount

| Case        | Current |   Main | Result       |
| ----------- | ------: | -----: | ------------ |
| 10 rows     |  0.08ms | 0.12ms | 1.42× faster |
| 1,000 rows  |  4.77ms | 7.97ms | 1.67× faster |
| 10,000 rows |  48.2ms | 86.2ms | 1.79× faster |

#### Single-Row Update in All-Row Query

| Case        | Current |    Main | Result       |
| ----------- | ------: | ------: | ------------ |
| 10 rows     |  1.71ms |  1.75ms | 1.03× faster |
| 1,000 rows  |  7.37ms |  12.4ms | 1.69× faster |
| 10,000 rows |  57.3ms | 123.3ms | 2.15× faster |

#### 10% Row Batch Update in All-Row Query

| Case        | Current |    Main | Result       |
| ----------- | ------: | ------: | ------------ |
| 10 rows     |  1.71ms |  1.74ms | 1.02× faster |
| 1,000 rows  |  17.5ms |  21.9ms | 1.26× faster |
| 10,000 rows | 200.8ms | 276.0ms | 1.37× faster |

#### Non-Matching Update in Single-Row Query

| Case        | Current |   Main | Result       |
| ----------- | ------: | -----: | ------------ |
| 10 rows     |  0.61ms | 0.60ms | 1.00× slower |
| 1,000 rows  |  0.66ms | 0.66ms | 1.00× faster |
| 10,000 rows |  1.73ms | 1.76ms | 1.02× faster |

#### Remount After Update

| Case        | Current |    Main | Result       |
| ----------- | ------: | ------: | ------------ |
| 10 rows     |  2.41ms |  2.49ms | 1.03× faster |
| 1,000 rows  |  12.4ms |  20.8ms | 1.68× faster |
| 10,000 rows | 110.6ms | 210.6ms | 1.90× faster |

#### Sorted Query Moves One Row

| Case        | Current |    Main | Result       |
| ----------- | ------: | ------: | ------------ |
| 10 rows     |  0.12ms |  0.15ms | 1.20× faster |
| 1,000 rows  |  7.28ms |  10.7ms | 1.47× faster |
| 10,000 rows | 152.8ms | 194.4ms | 1.27× faster |

#### Single-Row Query Update

| Case        | Current |   Main | Result       |
| ----------- | ------: | -----: | ------------ |
| 10 rows     |  1.88ms | 1.81ms | 1.04× slower |
| 1,000 rows  |  2.01ms | 1.86ms | 1.08× slower |
| 10,000 rows |  2.76ms | 2.71ms | 1.02× slower |

#### Library-Unfavourable Repeated Update Commits

| Case                                                               |  Current |     Main | Result       |
| ------------------------------------------------------------------ | -------: | -------: | ------------ |
| 10k rows, 200 single-row update commits                            | 1594.3ms | 7728.8ms | 4.85× faster |
| 1k rows, indexed single-row query, 100 matching update commits     |   26.3ms |   30.3ms | 1.15× faster |
| 1k rows, indexed single-row query, 100 non-matching update commits |   14.5ms |   14.4ms | 1.01× slower |

#### Large Change Sets

| Case                                            | Current |   Main | Result       |
| ----------------------------------------------- | ------: | -----: | ------------ |
| 1k rows, 100% row batch update in all-row query |  62.4ms | 68.1ms | 1.09× faster |

#### Deep Row Cloning

| Case                                                 | Current |   Main | Result       |
| ---------------------------------------------------- | ------: | -----: | ------------ |
| 1k deep rows, single-row update in all-row query     |  11.2ms | 25.3ms | 2.26× faster |
| 1k deep rows, 3-level nested update in all-row query |  11.2ms | 25.2ms | 2.26× faster |

### _Real browser benchmarks_

### Initial Table Render

#### Chrome

| Case                            | Current |   Main | Result       |
| ------------------------------- | ------: | -----: | ------------ |
| 100 rows initial table render   |  8.35ms | 8.33ms | 1.00× slower |
| 1,000 rows initial table render |  28.7ms | 31.1ms | 1.09× faster |

#### Firefox

| Case                            | Current |   Main | Result       |
| ------------------------------- | ------: | -----: | ------------ |
| 100 rows initial table render   |  8.33ms | 8.33ms | 1.00× faster |
| 1,000 rows initial table render |  38.9ms | 42.7ms | 1.10× faster |

#### Safari

| Case                            | Current |   Main | Result       |
| ------------------------------- | ------: | -----: | ------------ |
| 100 rows initial table render   |  16.7ms | 16.7ms | 1.00× faster |
| 1,000 rows initial table render |  32.1ms | 33.3ms | 1.04× faster |

### Single-Row Update Commits

#### Chrome

| Case                                           | Current |    Main | Result       |
| ---------------------------------------------- | ------: | ------: | ------------ |
| 1,000 rows table, 25 single-row update commits |  53.5ms | 120.7ms | 2.26× faster |

#### Firefox

| Case                                           | Current |    Main | Result       |
| ---------------------------------------------- | ------: | ------: | ------------ |
| 1,000 rows table, 25 single-row update commits |  55.4ms | 126.4ms | 2.28× faster |

#### Safari

| Case                                           | Current |   Main | Result       |
| ---------------------------------------------- | ------: | -----: | ------------ |
| 1,000 rows table, 25 single-row update commits |  51.8ms | 88.6ms | 1.71× faster |

### Batch Update

#### Chrome

| Case                                   | Current |   Main | Result       |
| -------------------------------------- | ------: | -----: | ------------ |
| 1,000 rows table, 100-row batch update |  40.8ms | 45.7ms | 1.12× faster |

#### Firefox

| Case                                   | Current |   Main | Result       |
| -------------------------------------- | ------: | -----: | ------------ |
| 1,000 rows table, 100-row batch update |  53.8ms | 54.8ms | 1.02× faster |

#### Safari

| Case                                   | Current |   Main | Result       |
| -------------------------------------- | ------: | -----: | ------------ |
| 1,000 rows table, 100-row batch update |  43.2ms | 46.2ms | 1.07× faster |

### Sorted Reorder

#### Chrome

| Case                                             | Current |   Main | Result       |
| ------------------------------------------------ | ------: | -----: | ------------ |
| 1,000 rows sorted table, update reorders one row |  33.3ms | 34.1ms | 1.02× faster |

#### Firefox

| Case                                             | Current |   Main | Result       |
| ------------------------------------------------ | ------: | -----: | ------------ |
| 1,000 rows sorted table, update reorders one row |  46.5ms | 54.8ms | 1.18× faster |

#### Safari

| Case                                             | Current |   Main | Result       |
| ------------------------------------------------ | ------: | -----: | ------------ |
| 1,000 rows sorted table, update reorders one row |  47.5ms | 47.0ms | 1.01× slower |

### Query Filter Changes

#### Chrome

| Case                                               | Current |   Main | Result       |
| -------------------------------------------------- | ------: | -----: | ------------ |
| 1,000 rows table, query filter changes after mount |  17.1ms | 18.7ms | 1.10× faster |

#### Firefox

| Case                                               | Current |   Main | Result       |
| -------------------------------------------------- | ------: | -----: | ------------ |
| 1,000 rows table, query filter changes after mount |  23.2ms | 34.1ms | 1.47× faster |

#### Safari

| Case                                               | Current |   Main | Result       |
| -------------------------------------------------- | ------: | -----: | ------------ |
| 1,000 rows table, query filter changes after mount |  33.3ms | 33.3ms | 1.00× faster |

### Deep Nested Update Commits

#### Chrome

| Case                                                 | Current |    Main | Result       |
| ---------------------------------------------------- | ------: | ------: | ------------ |
| 1,000 deep rows table, 25 deep nested update commits |  52.4ms | 219.8ms | 4.20× faster |

#### Firefox

| Case                                                 | Current |    Main | Result       |
| ---------------------------------------------------- | ------: | ------: | ------------ |
| 1,000 deep rows table, 25 deep nested update commits |  77.2ms | 217.8ms | 2.82× faster |

#### Safari

| Case                                                 | Current |    Main | Result       |
| ---------------------------------------------------- | ------: | ------: | ------------ |
| 1,000 deep rows table, 25 deep nested update commits |  55.3ms | 166.1ms | 3.00× faster |

> I am happy to provide the benchmark code if wanted, its just a tad noisy and adds playwright as a dependency which could slow down other runners. Can clean it up and add some actions that show benchmarks in comparison with main when creating PRs possibly

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared live-query observer layer in the core package and updated framework adapters (including Angular and Solid) to use it for consistent lifecycle and snapshot behavior.
* **Performance**
  * Improved live-query result synchronization in Solid for faster updates and more efficient state/data reconciliation.
* **Bug Fixes**
  * Fixed live-query resync issues when switching or recompiling queries, preventing stale keys/rows from persisting and improving status/snapshot update handling.
* **Tests**
  * Added regression and conformance coverage for observer snapshot/delivery semantics and state consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->