### PR TITLE
fix(db-sqlite-persistence-core): rows marked with metadata prior to insert get reset causing stale data

### DIFF
--- a/.changeset/small-tables-listen.md
+++ b/.changeset/small-tables-listen.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db-sqlite-persistence-core': patch
+---
+
+Fixed bug where internal metadata would get reset on insert causing stale items to remain

--- a/packages/db-sqlite-persistence-core/src/persisted.ts
+++ b/packages/db-sqlite-persistence-core/src/persisted.ts
@@ -2290,9 +2290,21 @@ function createWrappedSyncConfig<
             message.type === `insert` &&
             normalization.operation.metadata === undefined
           ) {
-            openTransaction.rowMetadataWrites.set(normalization.operation.key, {
-              type: `delete`,
-            })
+            // Reset stale metadata for a fresh insert, but don't clobber an
+            // explicit metadata write already queued for this key in the same
+            // transaction (e.g. query reconcile stamps owners, then inserts).
+            if (
+              !openTransaction.rowMetadataWrites.has(
+                normalization.operation.key,
+              )
+            ) {
+              openTransaction.rowMetadataWrites.set(
+                normalization.operation.key,
+                {
+                  type: `delete`,
+                },
+              )
+            }
           } else if (normalization.operation.metadata !== undefined) {
             openTransaction.rowMetadataWrites.set(normalization.operation.key, {
               type: `set`,

--- a/packages/db-sqlite-persistence-core/tests/persisted.test.ts
+++ b/packages/db-sqlite-persistence-core/tests/persisted.test.ts
@@ -816,6 +816,78 @@ describe(`persistedCollectionOptions`, () => {
     )
   })
 
+  it(`preserves row metadata set before a metadata-less insert in the same sync transaction`, async () => {
+    const adapter = createRecordingAdapter()
+    const ownership = { queryCollection: { owners: [`gc:q1`] } }
+    const sync: SyncConfig<Todo, string> = {
+      sync: ({ begin, write, commit, markReady, metadata }) => {
+        begin()
+        metadata?.row.set(`remote-1`, ownership)
+        write({
+          type: `insert`,
+          value: {
+            id: `remote-1`,
+            title: `From remote`,
+          },
+        })
+        commit()
+        markReady()
+      },
+    }
+
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present`,
+        getKey: (item: Todo) => item.id,
+        sync,
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    await collection.stateWhenReady()
+    await flushAsyncWork()
+
+    expect(adapter.rowMetadata.get(`remote-1`)).toEqual(ownership)
+    expect(collection._state.syncedMetadata.get(`remote-1`)).toEqual(ownership)
+  })
+
+  it(`resets stale row metadata for a metadata-less insert with no queued metadata`, async () => {
+    const adapter = createRecordingAdapter()
+    adapter.rowMetadata.set(`remote-1`, { stale: true })
+    const sync: SyncConfig<Todo, string> = {
+      sync: ({ begin, write, commit, markReady }) => {
+        begin()
+        write({
+          type: `insert`,
+          value: {
+            id: `remote-1`,
+            title: `From remote`,
+          },
+        })
+        commit()
+        markReady()
+      },
+    }
+
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present`,
+        getKey: (item: Todo) => item.id,
+        sync,
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    await collection.stateWhenReady()
+    await flushAsyncWork()
+
+    expect(adapter.rowMetadata.has(`remote-1`)).toBe(false)
+  })
+
   it(`uses a stable generated collection id in sync-present mode when id is omitted`, async () => {
     const adapter = createRecordingAdapter()
     const options = persistedCollectionOptions<Todo, string>({


### PR DESCRIPTION
## 🎯 Changes

Fixes https://github.com/TanStack/db/issues/1618 - rows in the same transaction marked with metadata get their metadata reset on insert, causing bugs like stale data when used with `queryCollectionOptions`

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stale item metadata could remain after inserts, causing outdated items to persist.
  * Preserved existing row metadata when an insert occurs in the same transaction as an explicit metadata update.
  * Cleared leftover metadata only when no newer metadata update was already queued, improving sync accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->