### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing
+
+## Questions
+
+If you have questions about implementation details, help, or support, please use our dedicated community forum at [GitHub Discussions](https://github.com/TanStack/db/discussions). **PLEASE NOTE:** If you choose to open an issue for your question instead, your issue may be closed and redirected to the forum.
+
+## Reporting issues
+
+If you have found what you think is a bug, please [file an issue](https://github.com/TanStack/db/issues/new/choose). **PLEASE NOTE:** Issues that are identified as implementation questions or non-issues may be closed and redirected to [GitHub Discussions](https://github.com/TanStack/db/discussions).
+
+## Suggesting new features
+
+If you are here to suggest a feature, first create an issue if it does not already exist. From there, we can discuss use cases for the feature and how it could be implemented.
+
+## Development
+
+If you have been assigned to fix an issue or develop a new feature, please follow these steps to get started:
+
+- Fork this repository.
+- Install dependencies.
+
+  ```bash
+  pnpm install
+  ```
+
+  - We use [pnpm](https://pnpm.io/) for package management. Please use the version mentioned in `package.json`.
+
+    ```bash
+    corepack enable && corepack prepare
+    ```
+
+  - We use [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions. Please use the version mentioned in `.nvmrc`.
+
+    ```bash
+    nvm use
+    ```
+
+- Build all packages.
+
+  ```bash
+  pnpm build
+  ```
+
+- Run tests.
+
+  ```bash
+  pnpm test
+  ```
+
+- Run linting.
+
+  ```bash
+  pnpm lint
+  ```
+
+- Implement your changes and tests in the relevant package or example.
+- Document your changes in the appropriate doc page.
+- Git stage your required changes and commit them.
+- Submit a PR for review.
+
+### Editing the docs locally and previewing changes
+
+The documentation for all TanStack projects is hosted on [tanstack.com](https://tanstack.com), which is a TanStack Start application (https://github.com/TanStack/tanstack.com). You need to run this app locally to preview your changes in the `TanStack/db` docs.
+
+> [!NOTE]
+> The website fetches doc pages from GitHub in production, and searches for them at `../db/docs` in development. Your local clone of `TanStack/db` needs to be in the same directory as the local clone of `TanStack/tanstack.com`.
+
+You can follow these steps to set up the docs for local development:
+
+1. Make a new directory called `tanstack`.
+
+```sh
+mkdir tanstack
+```
+
+2. Enter that directory and clone the [`TanStack/db`](https://github.com/TanStack/db) and [`TanStack/tanstack.com`](https://github.com/TanStack/tanstack.com) repos.
+
+```sh
+cd tanstack
+git clone git@github.com:TanStack/db.git
+# We probably don't need all the branches and commit history
+# from the `tanstack.com` repo, so let's just create a shallow
+# clone of the latest version of the `main` branch.
+# Read more about shallow clones here:
+# https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/#user-content-shallow-clones
+git clone git@github.com:TanStack/tanstack.com.git --depth=1 --single-branch --branch=main
+```
+
+> [!NOTE]
+> Your `tanstack` directory should look like this:
+>
+> ```
+> tanstack/
+>    |
+>    +-- db/ (<-- this directory cannot be called anything else!)
+>    |
+>    +-- tanstack.com/
+> ```
+
+3. Enter the `tanstack/tanstack.com` directory, install the dependencies, and run the app in dev mode.
+
+```sh
+cd tanstack.com
+pnpm i
+# The app will run on http://localhost:3000 by default
+pnpm dev
+```
+
+4. Visit http://localhost:3000/db/latest/docs/overview in the browser and see the changes you make in `tanstack/db/docs` there.
+
+> [!WARNING]
+> You will need to update `docs/config.json` if you add a new documentation page.
+
+### Running examples
+
+- Make sure you've installed dependencies in the repo's root directory.
+
+  ```bash
+  pnpm install
+  ```
+
+- If you want to run an example against your local changes, run the relevant package build/watch command from the repo root if needed. Otherwise, examples may run against the latest published TanStack DB release.
+
+- Run the example from the selected example directory.
+
+  ```bash
+  pnpm dev
+  ```
+
+#### Note on standalone execution
+
+If you want to run an example without installing dependencies for the whole repo, follow the instructions from the example's README.md file. It will then run against the latest TanStack DB release.
+
+## Changesets
+
+This repo uses [Changesets](https://github.com/changesets/changesets) to automate releases. If your PR should release a new package version (patch, minor, or major), please run `pnpm changeset` and commit the generated file. If your PR affects docs, examples, styles, etc., you probably don't need to generate a changeset.
+
+## Pull requests
+
+Maintainers merge pull requests by squashing all commits and editing the commit message if necessary using the GitHub user interface.
+
+Use an appropriate commit type. Be especially careful with breaking changes.
+
+## Releases
+
+For each new commit added to `main`, a GitHub Workflow is triggered which runs the [Changesets Action](https://github.com/changesets/action). This generates a preview PR showing the impact of all changesets. When this PR is merged, the package will be published to npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you have been assigned to fix an issue or develop a new feature, please follo
   - We use [pnpm](https://pnpm.io/) for package management. Please use the version mentioned in `package.json`.
 
     ```bash
-    corepack enable && corepack prepare
+    corepack enable && corepack prepare pnpm@11.1.0 --activate
     ```
 
   - We use [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions. Please use the version mentioned in `.nvmrc`.
@@ -89,7 +89,7 @@ git clone git@github.com:TanStack/tanstack.com.git --depth=1 --single-branch --b
 > [!NOTE]
 > Your `tanstack` directory should look like this:
 >
-> ```
+> ```text
 > tanstack/
 >    |
 >    +-- db/ (<-- this directory cannot be called anything else!)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,23 +17,23 @@ If you are here to suggest a feature, first create an issue if it does not alrea
 If you have been assigned to fix an issue or develop a new feature, please follow these steps to get started:
 
 - Fork this repository.
+- Use the Node.js version mentioned in `.nvmrc`.
+
+  ```bash
+  nvm use
+  ```
+
+- Enable [Corepack](https://nodejs.org/api/corepack.html) so the [pnpm](https://pnpm.io/) version mentioned in `package.json` is used.
+
+  ```bash
+  corepack enable
+  ```
+
 - Install dependencies.
 
   ```bash
   pnpm install
   ```
-
-  - We use [pnpm](https://pnpm.io/) for package management. Please use the version mentioned in `package.json`.
-
-    ```bash
-    corepack enable && corepack prepare pnpm@11.1.0 --activate
-    ```
-
-  - We use [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions. Please use the version mentioned in `.nvmrc`.
-
-    ```bash
-    nvm use
-    ```
 
 - Build all packages.
 


### PR DESCRIPTION
Adds a root `CONTRIBUTING.md` for TanStack DB, following the common structure used across other TanStack repos and adapting it to this repo's commands and docs layout. Contributors now have a clear entry point for questions, issues, local setup, docs previewing, examples, changesets, and PR/release expectations.

## Approach

This PR pulls in the standard TanStack contributing-doc shape rather than inventing a new one:

- community flow for questions, issues, and feature suggestions
- local development setup with `pnpm`, `corepack`, and `.nvmrc`
- repo-level build/test/lint commands from `package.json`
- tanstack.com docs preview instructions adjusted for `TanStack/db` and `../db/docs`
- examples guidance, changeset expectations, PR merge notes, and release process

The README already links to `CONTRIBUTING.md`, so adding this file makes that existing contributor path resolve to useful setup instructions.

## Key Invariants

- Links point at the TanStack DB repo, discussions, and issue chooser.
- Commands match the root scripts currently exposed by this repo: `pnpm build`, `pnpm test`, and `pnpm lint`.
- Docs preview instructions use the expected sibling checkout name, `db`, so tanstack.com can find `../db/docs` during local development.
- Release guidance reflects this repo's Changesets-based workflow.

## Non-goals

- This does not add new contributor policy beyond the patterns already used in other TanStack projects.
- This does not change package code, docs routing, examples, CI, or release automation.
- This does not add a changeset because the change is documentation-only and does not affect published package behavior.

## Trade-offs

The guide is adapted from the shared TanStack convention instead of copied verbatim from a single repo. That keeps the familiar contributor flow while avoiding inaccurate project-specific details like another repo's package manager version, docs URL, or build/test tooling.

## Verification

```bash
pnpm prettier --check CONTRIBUTING.md
```

Not run, because this is a docs-only change and the edited file is Markdown contributor guidance:

```bash
pnpm test
```

## Files changed

- `CONTRIBUTING.md` — new contributor guide covering support channels, issue/feature flow, local development setup, docs previewing, examples, changesets, PR expectations, and releases.

---

Preserved from the previous PR body / CodeRabbit summary:

- Added a new contributing guide with clear steps for asking questions, reporting issues, suggesting features, and submitting pull requests.
- Documented the local development workflow, including setup, build, test, lint, and previewing docs.
- Included guidance for running examples and explained the release and preview process for changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a full contributing guide with clear steps for asking questions, reporting issues, and suggesting features.
  * Documented the local development workflow, including setup plus build, test, lint, and pull request submission steps.
  * Added guidance for editing and previewing documentation locally, running examples/standalone mode, and following the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->