### PR TITLE
fix(sqlite-persistence): preserve query owner metadata on insert (closes #1618)

### DIFF
--- a/.changeset/small-tables-listen.md
+++ b/.changeset/small-tables-listen.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db-sqlite-persistence-core': patch
+---
+
+Fixed bug where internal metadata would get reset on insert causing stale items to remain

--- a/packages/db-sqlite-persistence-core/src/persisted.ts
+++ b/packages/db-sqlite-persistence-core/src/persisted.ts
@@ -2290,9 +2290,21 @@ function createWrappedSyncConfig<
             message.type === `insert` &&
             normalization.operation.metadata === undefined
           ) {
-            openTransaction.rowMetadataWrites.set(normalization.operation.key, {
-              type: `delete`,
-            })
+            // Reset stale metadata for a fresh insert, but don't clobber an
+            // explicit metadata write already queued for this key in the same
+            // transaction (e.g. query reconcile stamps owners, then inserts).
+            if (
+              !openTransaction.rowMetadataWrites.has(
+                normalization.operation.key,
+              )
+            ) {
+              openTransaction.rowMetadataWrites.set(
+                normalization.operation.key,
+                {
+                  type: `delete`,
+                },
+              )
+            }
           } else if (normalization.operation.metadata !== undefined) {
             openTransaction.rowMetadataWrites.set(normalization.operation.key, {
               type: `set`,

--- a/packages/db-sqlite-persistence-core/tests/persisted.test.ts
+++ b/packages/db-sqlite-persistence-core/tests/persisted.test.ts
@@ -816,6 +816,78 @@ describe(`persistedCollectionOptions`, () => {
     )
   })
 
+  it(`preserves row metadata set before a metadata-less insert in the same sync transaction`, async () => {
+    const adapter = createRecordingAdapter()
+    const ownership = { queryCollection: { owners: [`gc:q1`] } }
+    const sync: SyncConfig<Todo, string> = {
+      sync: ({ begin, write, commit, markReady, metadata }) => {
+        begin()
+        metadata?.row.set(`remote-1`, ownership)
+        write({
+          type: `insert`,
+          value: {
+            id: `remote-1`,
+            title: `From remote`,
+          },
+        })
+        commit()
+        markReady()
+      },
+    }
+
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present`,
+        getKey: (item: Todo) => item.id,
+        sync,
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    await collection.stateWhenReady()
+    await flushAsyncWork()
+
+    expect(adapter.rowMetadata.get(`remote-1`)).toEqual(ownership)
+    expect(collection._state.syncedMetadata.get(`remote-1`)).toEqual(ownership)
+  })
+
+  it(`resets stale row metadata for a metadata-less insert with no queued metadata`, async () => {
+    const adapter = createRecordingAdapter()
+    adapter.rowMetadata.set(`remote-1`, { stale: true })
+    const sync: SyncConfig<Todo, string> = {
+      sync: ({ begin, write, commit, markReady }) => {
+        begin()
+        write({
+          type: `insert`,
+          value: {
+            id: `remote-1`,
+            title: `From remote`,
+          },
+        })
+        commit()
+        markReady()
+      },
+    }
+
+    const collection = createCollection(
+      persistedCollectionOptions<Todo, string>({
+        id: `sync-present`,
+        getKey: (item: Todo) => item.id,
+        sync,
+        persistence: {
+          adapter,
+        },
+      }),
+    )
+
+    await collection.stateWhenReady()
+    await flushAsyncWork()
+
+    expect(adapter.rowMetadata.has(`remote-1`)).toBe(false)
+  })
+
   it(`uses a stable generated collection id in sync-present mode when id is omitted`, async () => {
     const adapter = createRecordingAdapter()
     const options = persistedCollectionOptions<Todo, string>({

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -5021,13 +5021,20 @@ describe(`QueryCollection`, () => {
         rowMetadata: adapter.rowMetadata,
         collectionMetadata: adapter.collectionMetadata,
       })
+      let releaseSecondFetch!: () => void
+      const secondFetchReleased = new Promise<void>((resolve) => {
+        releaseSecondFetch = resolve
+      })
       const collection2 = createCollection(
         persistedCollectionOptions({
           ...(queryCollectionOptions<CategorisedItem>({
             id: `reload-insert-cleanup`,
             queryClient: secondQueryClient,
             queryKey,
-            queryFn: async () => serverRows,
+            queryFn: async () => {
+              await secondFetchReleased
+              return serverRows
+            },
             getKey: (item: CategorisedItem): string => item.id,
             syncMode: `eager`,
             startSync: true,
@@ -5036,20 +5043,25 @@ describe(`QueryCollection`, () => {
         }) as any,
       )
 
-      await collection2.stateWhenReady()
+      await vi.waitFor(() => {
+        expect(collection2.has(`1`)).toBe(true)
+        expect(adapter2.rows.has(`1`)).toBe(true)
+      })
+
       const liveQuery = createLiveQueryCollection({
         query: (q) => q.from({ item: collection2 }),
       })
+      releaseSecondFetch()
       await liveQuery.preload()
-      await flushPromises()
       // The query responds on launch (after persisted rows have hydrated).
-      await secondQueryClient.invalidateQueries({ queryKey })
       await flushPromises()
       await flushPromises()
 
-      expect(collection2.has(`1`)).toBe(false)
-      expect(adapter2.rows.has(`1`)).toBe(false)
-      expect(liveQuery.size).toBe(0)
+      await vi.waitFor(() => {
+        expect(collection2.has(`1`)).toBe(false)
+        expect(adapter2.rows.has(`1`)).toBe(false)
+        expect(liveQuery.size).toBe(0)
+      })
 
       firstQueryClient.clear()
       secondQueryClient.clear()

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -4960,6 +4960,101 @@ describe(`QueryCollection`, () => {
       ).toBe(false)
     })
 
+    it(`should clean up an inserted row dropped by the query after a reload`, async () => {
+      // A row inserted while the collection is mounted is persisted. After the
+      // app reloads, if the query no longer returns that row, it must be removed
+      // from both the live collection and the persisted store.
+      const queryKey = [`reload-insert-cleanup`]
+      const makeQueryClient = () =>
+        new QueryClient({
+          defaultOptions: {
+            queries: { staleTime: 0, gcTime: 5 * 60 * 1000, retry: false },
+          },
+        })
+
+      // The shared on-device store, surviving across the two sessions.
+      const adapter = createPersistedQueryAdapter<CategorisedItem>({})
+
+      // ---- First session: insert an item that the server then returns ----
+      let serverRows: Array<CategorisedItem> = []
+      const firstQueryClient = makeQueryClient()
+      const collection1 = createCollection(
+        persistedCollectionOptions({
+          ...(queryCollectionOptions<CategorisedItem>({
+            id: `reload-insert-cleanup`,
+            queryClient: firstQueryClient,
+            queryKey,
+            queryFn: async () => serverRows,
+            getKey: (item: CategorisedItem): string => item.id,
+            syncMode: `eager`,
+            startSync: true,
+            onInsert: async ({ transaction }) => {
+              // The mutation reaches the server: the item now appears in the
+              // API response for subsequent fetches.
+              for (const mutation of transaction.mutations) {
+                serverRows = [...serverRows, mutation.modified]
+              }
+            },
+          }) as any),
+          persistence: { adapter },
+        }) as any,
+      )
+
+      await collection1.stateWhenReady()
+      await flushPromises()
+
+      await collection1.insert({ id: `1`, name: `Buy milk`, category: `A` })
+      // The query refetches and sees the now-synced row.
+      await firstQueryClient.invalidateQueries({ queryKey })
+      await flushPromises()
+      await flushPromises()
+
+      expect(adapter.rows.has(`1`)).toBe(true)
+
+      // ---- App closes; the row is removed on the server out of band ----
+      serverRows = []
+
+      // ---- Second session: reload from the persisted store ----
+      const secondQueryClient = makeQueryClient()
+      const adapter2 = createPersistedQueryAdapter<CategorisedItem>({
+        rows: adapter.rows,
+        rowMetadata: adapter.rowMetadata,
+        collectionMetadata: adapter.collectionMetadata,
+      })
+      const collection2 = createCollection(
+        persistedCollectionOptions({
+          ...(queryCollectionOptions<CategorisedItem>({
+            id: `reload-insert-cleanup`,
+            queryClient: secondQueryClient,
+            queryKey,
+            queryFn: async () => serverRows,
+            getKey: (item: CategorisedItem): string => item.id,
+            syncMode: `eager`,
+            startSync: true,
+          }) as any),
+          persistence: { adapter: adapter2 },
+        }) as any,
+      )
+
+      await collection2.stateWhenReady()
+      const liveQuery = createLiveQueryCollection({
+        query: (q) => q.from({ item: collection2 }),
+      })
+      await liveQuery.preload()
+      await flushPromises()
+      // The query responds on launch (after persisted rows have hydrated).
+      await secondQueryClient.invalidateQueries({ queryKey })
+      await flushPromises()
+      await flushPromises()
+
+      expect(collection2.has(`1`)).toBe(false)
+      expect(adapter2.rows.has(`1`)).toBe(false)
+      expect(liveQuery.size).toBe(0)
+
+      firstQueryClient.clear()
+      secondQueryClient.clear()
+    })
+
     it(`should expire retained ttl placeholders while the app stays open`, async () => {
       vi.useFakeTimers()
       try {


### PR DESCRIPTION
Fixes https://github.com/TanStack/db/issues/1618

## Problem

With a SQLite-persisted `queryCollection`, an item inserted while the app is open survives forever after a reload, even once the query stops returning it (the server-side row was deleted). Reported in #1618 (ExpoSQLitePersistence, but it reproduces with any SQLite persistence adapter).

Root cause: in `db-sqlite-persistence-core`, a sync `write` of type `insert` with no per-row metadata unconditionally queues a metadata **reset** (`delete`) for that key. During query reconciliation the query collection stamps the row's `owners` metadata (`metadata.row.set`) and then writes the metadata-less insert in the **same** sync transaction — so the insert's reset clobbers the just-written owners. Without persisted owners, the row is orphaned: on reload it belongs to no query and an empty query result can never reclaim it.

## Approach (red → green)

1. **First commit — regression test only (expected to fail CI).** A behaviour-level test in `query-db-collection` that inserts a row, reloads from the persisted store, and asserts the row is cleaned up once the query no longer returns it.
2. **Second commit — the fix.** Cherry-picked from @tombryden's #1619: only reset metadata on a metadata-less insert when no metadata write is already queued for that key in the transaction, so an explicitly-stamped owner survives while genuinely metadata-less inserts still clear stale metadata.

This PR is a companion to #1619 that adds the missing end-to-end coverage; fix authorship is preserved via cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row metadata handling during inserts so staged metadata within the same transaction is no longer overwritten.
  * Cleared stale row metadata when inserting rows without metadata.
  * Improved persistence behavior so rows dropped by query syncing are removed from live state and persisted storage after reload.

* **Tests**
  * Added tests covering metadata preservation vs. stale-metadata cleanup.
  * Added a regression test for deleted rows after rehydration and live query refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->