### PR TITLE
Fix unused vars

### DIFF
--- a/packages/db/tests/query/select.test-d.ts
+++ b/packages/db/tests/query/select.test-d.ts
@@ -215,15 +215,15 @@ describe(`select types`, () => {
 
     const col = createLiveQueryCollection((q) =>
       q.from({ u: spreadUsers }).select(({ u }) => {
-        const { nickname, ...withoutNickname } = u
+        const { nickname: _nickname, ...withoutNickname } = u
         return { trimmed: withoutNickname }
       }),
     )
 
-    const result = col.toArray[0]!
+    const _result = col.toArray[0]!
     // `nickname` was destructured out, so the projected object must
     // not reintroduce the key.
-    type HasNickname = `nickname` extends keyof typeof result.trimmed
+    type HasNickname = `nickname` extends keyof typeof _result.trimmed
       ? true
       : false
     expectTypeOf<HasNickname>().toEqualTypeOf<false>()


### PR DESCRIPTION
Fix CI. Unused vars should use underscore prefix or have an `// eslint-disable-next-line @typescript-eslint/no-unused-vars`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a type-level test to better verify that omitting an optional field through destructuring does not bring that field back into the resulting type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->