### PR TITLE
fix(svelte-db): disabled useLiveQuery no longer crashes

### DIFF
--- a/.changeset/svelte-disabled-query-fix.md
+++ b/.changeset/svelte-disabled-query-fix.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/svelte-db': patch
+---
+
+fix(svelte-db): a disabled `useLiveQuery` (query callback returning `null`/`undefined`) no longer crashes
+
+The reactive-getter unwrapping (`toValue`) called the query callback and, when it returned `null`/`undefined` to signal a disabled query, passed the unwrapped `null` into `createLiveQueryCollection`, throwing in `getQueryIR`. A `null`/`undefined` resolved value is now treated as a disabled query (returns the `disabled` state) as it is in the other adapters.

--- a/packages/svelte-db/src/useLiveQuery.svelte.ts
+++ b/packages/svelte-db/src/useLiveQuery.svelte.ts
@@ -350,6 +350,13 @@ export function useLiveQuery(
         startSync: true,
       })
     } else {
+      // A reactive getter (or param-driven query fn) can resolve to null/undefined
+      // to mean "disabled". `toValue` above already called it, so guard here —
+      // otherwise `{ ...null }` reaches createLiveQueryCollection and throws.
+      if (unwrappedParam === undefined || unwrappedParam === null) {
+        return null
+      }
+
       return createLiveQueryCollection({
         ...unwrappedParam,
         startSync: true,

--- a/packages/svelte-db/tests/conformance.svelte.test.ts
+++ b/packages/svelte-db/tests/conformance.svelte.test.ts
@@ -210,13 +210,7 @@ const svelteDriver: LiveQueryDriver = {
   mountCollection,
   mountConfig,
   mountDisabled,
-  // Real bug the suite caught: svelte-db's `toValue()` unwrapping (added for the
-  // reactive `() => collection` form) CALLS a disabled query fn like `() => null`
-  // as if it were a getter, unwraps it to null, and falls through to
-  // createLiveQueryCollection({...null}) → crash in getQueryIR. The disabled
-  // short-circuit is unreachable for this case, and svelte-db has no disabled
-  // tests. Both disabled scenarios fail until this is fixed.
-  knownGaps: [`disabled-explicit`, `disabled-transition`],
+  knownGaps: [],
   features: { serverSnapshot: false, suspense: false },
 }
 


### PR DESCRIPTION
Follow-up #1 of 3 to the conformance suite (#1636), fixing a `knownGap` that suite surfaced.

**Base:** stacked on `test/live-query-conformance-suite` (#1636) — it depends on the conformance drivers to clear the gap. Re-target to `main` once #1636 lands.

## The bug

A disabled `useLiveQuery` — the query callback returning `null`/`undefined`, which every other adapter treats as "disabled" — **crashed** in svelte-db:

```
TypeError: Cannot read properties of undefined (reading '_getQuery')
  ❯ getQueryIR .../query/builder/index.ts
  ❯ createLiveQueryCollection .../query/live-query-collection.ts
```

## Root cause

svelte-db added `toValue()` unwrapping to support the reactive `() => collection` input form. But `toValue` *calls any function*, so it also calls the query callback. When that callback returns `null`/`undefined` (disabled), the unwrapped value became `null`, which fell through to `createLiveQueryCollection({ ...null, startSync: true })` → crash in `getQueryIR`. The existing disabled short-circuit sat behind a `typeof === 'function'` check that `null` never reaches.

It went unnoticed because **svelte-db had no disabled-query tests** — exactly the gap the conformance suite flagged.

## Fix

Treat a `null`/`undefined` *unwrapped* value as a disabled query (return the `disabled` state), matching React/Vue/Solid/Angular. One guard in the non-function branch.

## Verification

Clears the `disabled-explicit` and `disabled-transition` `knownGaps` in the svelte-db conformance driver — both now pass as normal tests. Full svelte-db suite green (54), `svelte-check` clean. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useLiveQuery` so queries that resolve to `null` or `undefined` are treated as disabled instead of causing runtime errors.
  * Improved consistency with other adapters by returning a disabled state in these cases.

* **Tests**
  * Updated conformance coverage to reflect that disabled-query scenarios now pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->