### PR TITLE
fix(angular-db): config-object input to injectLiveQuery now syncs

### DIFF
--- a/.changeset/angular-config-object-startsync.md
+++ b/.changeset/angular-config-object-startsync.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/angular-db': patch
+---
+
+fix(angular-db): a `{ query }` config-object passed to `injectLiveQuery` now syncs
+
+The config-object branch called `createLiveQueryCollection(opts)` without defaulting `startSync`, unlike the query-function and reactive-options branches (which force `startSync: true`), so a bare `{ query }` never started syncing and produced no data. It now defaults `startSync: true` and `gcTime: 0` while still honoring any explicit values in the config.

--- a/packages/angular-db/src/index.ts
+++ b/packages/angular-db/src/index.ts
@@ -194,9 +194,11 @@ export function injectLiveQuery(opts: any) {
       })
     }
 
-    // Handle LiveQueryCollectionConfig objects
+    // Handle LiveQueryCollectionConfig objects. Default startSync/gcTime to
+    // match the query-fn and reactive-options paths, but let an explicit value
+    // in the config win — otherwise a bare `{ query }` never syncs.
     if (opts && typeof opts === `object` && typeof opts.query === `function`) {
-      return createLiveQueryCollection(opts)
+      return createLiveQueryCollection({ startSync: true, gcTime: 0, ...opts })
     }
 
     throw new Error(`Invalid options provided to injectLiveQuery`)

--- a/packages/angular-db/tests/conformance.test.ts
+++ b/packages/angular-db/tests/conformance.test.ts
@@ -214,13 +214,7 @@ const angularDriver: LiveQueryDriver = {
   mountCollection,
   mountConfig,
   mountDisabled,
-  // Divergence the suite surfaced: angular-db's plain `{ query }` config-object
-  // path calls createLiveQueryCollection(opts) as-is, without injecting
-  // startSync:true the way the query-fn path does — so a bare `{ query }` never
-  // syncs and returns empty. React/Vue/Svelte/Solid all auto-start a config
-  // object; Angular requires an explicit `startSync: true` (its own config test
-  // passes it). Recorded until angular-db aligns.
-  knownGaps: [`config-object-input`],
+  knownGaps: [],
   features: { serverSnapshot: false, suspense: false },
 }
 


### PR DESCRIPTION
Follow-up #2 of 3 to the conformance suite (#1636), fixing a `knownGap` it surfaced.

**Base:** stacked on `test/live-query-conformance-suite` (#1636). Re-target to `main` once #1636 lands.

## The issue

`injectLiveQuery({ query: (q) => ... })` — the config-object input form — returned **empty data**: the collection never started syncing.

## Root cause

`injectLiveQuery` has three creation paths. The query-fn and reactive-options paths both force `startSync: true` (and `gcTime: 0`):

```ts
return createLiveQueryCollection({ query: opts, startSync: true, gcTime: 0 })
```

…but the config-object path passed `opts` through untouched:

```ts
return createLiveQueryCollection(opts)   // no startSync default → never syncs
```

So a bare `{ query }` was created not-syncing and stayed empty. React/Vue/Svelte/Solid all auto-start a config object; only Angular required the caller to pass `startSync: true` explicitly (which is why angular-db's own config test passes it).

## Fix

Default `startSync: true` and `gcTime: 0` in the config-object path, while letting explicit values in the config win:

```ts
return createLiveQueryCollection({ startSync: true, gcTime: 0, ...opts })
```

## Verification

Clears the `config-object-input` `knownGap` in the angular-db conformance driver — now passes as a normal test. Full angular-db suite green. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed live queries created with a plain `{ query }` config so they start syncing automatically and return data as expected.
  * Kept any explicitly provided settings intact while applying safer defaults for sync behavior and data cleanup.
* **Tests**
  * Updated conformance coverage to reflect the improved config-object behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->