### PR TITLE
test(conformance): parametrize how adapters surface query errors

### DIFF
--- a/packages/db/tests/conformance/contract.ts
+++ b/packages/db/tests/conformance/contract.ts
@@ -145,5 +145,12 @@ export interface LiveQueryDriver {
   mountDisabled: () => LiveQueryHandle
   /** Scenario keys this adapter is empirically known NOT to satisfy yet. */
   knownGaps?: ReadonlyArray<string>
+  /**
+   * How the adapter surfaces a query error (see the `error-status` scenario):
+   * - `flag` (default): a readable `isError`/`status === 'error'` on the result.
+   * - `throw`: reading the errored result throws, for a framework error boundary
+   *   to catch (e.g. Solid's `createResource`/`<ErrorBoundary>` model).
+   */
+  errorSurface?: `flag` | `throw`
   features?: { serverSnapshot?: boolean; suspense?: boolean }
 }

--- a/packages/db/tests/conformance/suite.ts
+++ b/packages/db/tests/conformance/suite.ts
@@ -636,14 +636,20 @@ export function runSuite(rawDriver: LiveQueryDriver) {
 
     scenario(
       `error-status`,
-      `a failing source surfaces status=error / isError`,
+      `a failing source surfaces an error (flag or boundary)`,
       async () => {
         const source = driver.makeErrorSource()
         const h = driver.mountCollection(source.collection)
         await h.flush()
 
-        expect(h.current().status).toBe(`error`)
-        expect(h.current().isError).toBe(true)
+        if (driver.errorSurface === `throw`) {
+          // Boundary model: reading the errored result throws (for an error
+          // boundary to catch), rather than exposing a readable flag.
+          expect(() => h.current()).toThrow()
+        } else {
+          expect(h.current().status).toBe(`error`)
+          expect(h.current().isError).toBe(true)
+        }
         h.unmount()
       },
     )

--- a/packages/solid-db/tests/conformance.test.tsx
+++ b/packages/solid-db/tests/conformance.test.tsx
@@ -214,12 +214,12 @@ const solidDriver: LiveQueryDriver = {
   mountCollection,
   mountConfig,
   mountDisabled,
-  // Divergence the suite surfaced: solid-db routes errors through its
-  // createResource/Suspense path, which THROWS (CollectionStateError) for an
-  // <ErrorBoundary> to catch, rather than exposing a readable isError flag like
-  // React/Vue/Svelte. Reading an errored query throws before isError can be
-  // observed, so the plain error-status assertion doesn't hold here.
-  knownGaps: [`error-status`],
+  // solid-db routes errors through its createResource/Suspense path: reading an
+  // errored query throws (CollectionStateError) for an <ErrorBoundary> to catch,
+  // rather than exposing a readable isError flag. That's a framework idiom, not a
+  // gap — the error-status scenario is parametrized to assert it via the boundary.
+  errorSurface: `throw`,
+  knownGaps: [],
   features: { serverSnapshot: false, suspense: true },
 }
 


### PR DESCRIPTION
Follow-up #3 of 3 to the conformance suite (#1636), resolving the Solid `error-status` `knownGap`.

**Base:** stacked on `test/live-query-conformance-suite` (#1636). Re-target to `main` once #1636 lands.

## Not a bug — a legitimate framework difference

Unlike the Svelte (#1637) and Angular (#1638) follow-ups, this one isn't an adapter fix. The suite flagged that **Solid surfaces query errors differently**: it routes them through `createResource`/Suspense, so reading an errored query **throws** `CollectionStateError` (for an `<ErrorBoundary>` to catch) rather than exposing a readable `isError`/`status === 'error'` flag like React/Vue/Svelte/Angular.

That's idiomatic Solid, not something to "fix." So instead of forcing Solid into the flag model, the suite is **parametrized** to assert whichever model an adapter declares.

Confirmed behavior (probe): the errored collection reaches `error` status, mount does not throw, and *reading the result* throws `Collection is in error state`.

## Change

- `contract.ts`: add `driver.errorSurface?: 'flag' | 'throw'` (default `flag`).
- `suite.ts`: the `error-status` scenario now asserts:
  - `flag` → `isError === true` / `status === 'error'` (readable), or
  - `throw` → reading the errored result throws (boundary model).
- `solid-db` driver: declares `errorSurface: 'throw'`, clears its `error-status` `knownGap`.
- React / Vue / Svelte / Angular keep the default `flag` assertions unchanged.

## Verification

All five conformance suites pass 24/24. Solid's `error-status` now passes via the boundary branch; the other four via the flag branch. Test-infra only — no published-package changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how live-query errors are surfaced, so errored results can now either be marked as errors or thrown for error-boundary handling.
  * Updated conformance coverage to verify both error-reporting behaviors, including the throw-based flow used by Solid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->