### PR TITLE
fix(db): avoid full row origin snapshots

### DIFF
--- a/.changeset/quiet-row-origins.md
+++ b/.changeset/quiet-row-origins.md
@@ -2,4 +2,4 @@
 '@tanstack/db': patch
 ---
 
-Avoid full row origin snapshots during incremental collection updates.
+Avoid full row origin snapshots during incremental collection updates and make bulk mutation merging linear.

--- a/.changeset/quiet-row-origins.md
+++ b/.changeset/quiet-row-origins.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Avoid full row origin snapshots during incremental collection updates.

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -226,6 +226,21 @@ export class CollectionStateManager<
     })
   }
 
+  private snapshotRowOriginsForKeys(
+    keys: Iterable<TKey>,
+  ): Map<TKey, VirtualOrigin> {
+    const rowOrigins = new Map<TKey, VirtualOrigin>()
+
+    for (const key of keys) {
+      const origin = this.rowOrigins.get(key)
+      if (origin !== undefined) {
+        rowOrigins.set(key, origin)
+      }
+    }
+
+    return rowOrigins
+  }
+
   private enrichWithVirtualPropsSnapshot(
     row: TOutput,
     virtualProps: VirtualRowProps<TKey>,
@@ -476,7 +491,7 @@ export class CollectionStateManager<
 
     const previousState = new Map(this.optimisticUpserts)
     const previousDeletes = new Set(this.optimisticDeletes)
-    const previousRowOrigins = new Map(this.rowOrigins)
+    const previousRowOrigins = this.rowOrigins
 
     // Update pending optimistic state for completed/failed transactions
     for (const transaction of this.transactions.values()) {
@@ -857,10 +872,6 @@ export class CollectionStateManager<
       // Set flag to prevent redundant optimistic state recalculations
       this.isCommittingSyncTransactions = true
 
-      const previousRowOrigins = new Map(this.rowOrigins)
-      const previousOptimisticUpserts = new Map(this.optimisticUpserts)
-      const previousOptimisticDeletes = new Set(this.optimisticDeletes)
-
       // Get the optimistic snapshot from the truncate transaction (captured when truncate() was called)
       const truncateOptimisticSnapshot = hasTruncateSync
         ? committedSyncedTransactions.find((t) => t.truncate)
@@ -879,6 +890,18 @@ export class CollectionStateManager<
           changedKeys.add(key)
         }
       }
+
+      const virtualSnapshotKeys = new Set(changedKeys)
+      for (const key of this.pendingOptimisticDirectUpserts) {
+        virtualSnapshotKeys.add(key)
+      }
+      for (const key of this.pendingOptimisticDirectDeletes) {
+        virtualSnapshotKeys.add(key)
+      }
+      const previousRowOrigins =
+        this.snapshotRowOriginsForKeys(virtualSnapshotKeys)
+      const previousOptimisticUpserts = new Map(this.optimisticUpserts)
+      const previousOptimisticDeletes = new Set(this.optimisticDeletes)
 
       // Use pre-captured state if available (from optimistic scenarios),
       // otherwise capture current state (for pure sync scenarios)

--- a/packages/db/src/transactions.ts
+++ b/packages/db/src/transactions.ts
@@ -334,26 +334,38 @@ class Transaction<T extends object = Record<string, unknown>> {
    * @param mutations - Array of new mutations to apply
    */
   applyMutations(mutations: Array<PendingMutation<any>>): void {
-    for (const newMutation of mutations) {
-      const existingIndex = this.mutations.findIndex(
-        (m) => m.globalKey === newMutation.globalKey,
-      )
+    // Merge via a globalKey-keyed map rather than a findIndex scan per
+    // mutation, which is O(n²) for bulk operations (e.g. inserting many rows
+    // in one call). Map preserves insertion order, matching the previous
+    // replace-in-place / remove / append semantics.
+    const merged = new Map<string, PendingMutation<any>>()
+    for (const mutation of this.mutations) {
+      merged.set(mutation.globalKey, mutation)
+    }
 
-      if (existingIndex >= 0) {
-        const existingMutation = this.mutations[existingIndex]!
+    for (const newMutation of mutations) {
+      const existingMutation = merged.get(newMutation.globalKey)
+
+      if (existingMutation) {
         const mergeResult = mergePendingMutations(existingMutation, newMutation)
 
         if (mergeResult === null) {
           // Remove the mutation (e.g., delete after insert cancels both)
-          this.mutations.splice(existingIndex, 1)
+          merged.delete(newMutation.globalKey)
         } else {
           // Replace with merged mutation
-          this.mutations[existingIndex] = mergeResult
+          merged.set(newMutation.globalKey, mergeResult)
         }
       } else {
         // Insert new mutation
-        this.mutations.push(newMutation)
+        merged.set(newMutation.globalKey, newMutation)
       }
+    }
+
+    // Rebuild in place to preserve the array's identity for external holders
+    this.mutations.length = 0
+    for (const mutation of merged.values()) {
+      this.mutations.push(mutation)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two collection/transaction performance hot paths:

- Avoids source-sized `rowOrigins` snapshots during incremental collection updates.
- Makes `Transaction.applyMutations` merge bulk mutations in O(n) instead of O(n²).

## Root Cause

Single-row incremental writes were cloning the full `rowOrigins` map before propagating changes. Since `rowOrigins` grows with the source collection, normal incremental writes paid O(source collection size) work before the query graph could process the actual changed keys.

Kevin also identified a separate bulk mutation issue: `Transaction.applyMutations` used `findIndex` for every incoming mutation, making large bulk operations quadratic.

## Changes

- Reuse the existing `rowOrigins` map during optimistic recompute, where confirmed origins are not mutated.
- Snapshot row origins only for keys affected by a synced commit, plus pending direct optimistic keys that may be cleaned up by sync confirmation.
- Merge transaction mutations through a `globalKey`-keyed `Map`, then rebuild the public mutations array in place to preserve identity.
- Keep the PR branch free of tracing or benchmark instrumentation.

## Validation

- `pnpm --dir packages/db exec tsc --noEmit`
- `pnpm --dir packages/db exec vitest --run tests/transactions.test.ts tests/collection-subscribe-changes.test.ts tests/collection-change-events.test.ts tests/collection-truncate.test.ts`
