### PR TITLE
ci: benchmark PRs against main with the incremental update suite

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,95 @@
+name: Benchmark
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'packages/db/**'
+      - 'packages/db-ivm/**'
+      - 'scripts/bench/**'
+      - '.github/workflows/benchmark.yml'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Incremental Update Benchmark
+    # Skip draft PRs; the benchmark runs once a PR is marked ready for review
+    # (and on subsequent pushes to it).
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Tools
+        uses: tanstack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3
+      - name: Run benchmark on PR
+        run: |
+          pnpm --filter @tanstack/db-ivm build
+          pnpm exec tsx scripts/bench/incremental-update.ts \
+            --iterations=100 --warmup=20 \
+            --outFile="$RUNNER_TEMP/candidate.json"
+      - name: Run benchmark on base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+          BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "Benchmarking base commit $BASE_SHA"
+          git checkout --force "$BASE_SHA"
+          # Run the exact same benchmark code on both sides
+          git checkout "$HEAD_SHA" -- scripts/bench
+          pnpm install --frozen-lockfile
+          pnpm --filter @tanstack/db-ivm build
+          pnpm exec tsx scripts/bench/incremental-update.ts \
+            --iterations=100 --warmup=20 \
+            --outFile="$RUNNER_TEMP/base.json"
+      - name: Compare results
+        run: |
+          pnpm exec tsx scripts/bench/compare-incremental-update.ts \
+            --base="$RUNNER_TEMP/base.json" \
+            --candidate="$RUNNER_TEMP/candidate.json" \
+            --outFile="$RUNNER_TEMP/comparison.md"
+          cat "$RUNNER_TEMP/comparison.md" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: benchmark-reports
+          path: |
+            ${{ runner.temp }}/base.json
+            ${{ runner.temp }}/candidate.json
+            ${{ runner.temp }}/comparison.md
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        # PRs from forks get a read-only token; the job summary and artifacts
+        # still carry the results.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          MARKER='<!-- incremental-update-benchmark -->'
+          BODY_FILE="$RUNNER_TEMP/comment.md"
+          { echo "$MARKER"; cat "$RUNNER_TEMP/comparison.md"; } > "$BODY_FILE"
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -n1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" -F body=@"$BODY_FILE" > /dev/null
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@"$BODY_FILE" > /dev/null
+          fi

--- a/scripts/bench/compare-incremental-update.ts
+++ b/scripts/bench/compare-incremental-update.ts
@@ -242,6 +242,48 @@ function formatMarkdown(
   )
   lines.push(``)
 
+  const byQuery = new Map<string, Array<Comparison>>()
+  for (const comparison of allComparisons) {
+    const group = byQuery.get(comparison.query) ?? []
+    group.push(comparison)
+    byQuery.set(comparison.query, group)
+  }
+
+  lines.push(`| Query | Δ median (geomean) | Best case | Worst case | Flags |`)
+  lines.push(`| --- | ---: | ---: | ---: | :-- |`)
+  for (const [query, group] of byQuery) {
+    const ratios = group
+      .map((comparison) => comparison.medianRatio)
+      .filter((value) => Number.isFinite(value))
+    const best = Math.min(...ratios)
+    const worst = Math.max(...ratios)
+    const redCount = group.filter((comparison) =>
+      isRegression(comparison, threshold),
+    ).length
+    const greenCount = group.filter((comparison) =>
+      isImprovement(comparison, threshold),
+    ).length
+    const flags =
+      [
+        redCount > 0 ? `${redCount} 🔴` : ``,
+        greenCount > 0 ? `${greenCount} 🟢` : ``,
+      ]
+        .filter(Boolean)
+        .join(` `) || `—`
+    lines.push(
+      `| ${query} | ${formatDelta(geomeanRatio(group))} | ${formatDelta(
+        best,
+      )} | ${formatDelta(worst)} | ${flags} |`,
+    )
+  }
+  lines.push(``)
+  lines.push(
+    `Each row aggregates the ${allComparisons.length / byQuery.size || 0} ` +
+      `scale/index/write-mode configurations of that query; per-configuration ` +
+      `tables below.`,
+  )
+  lines.push(``)
+
   const groups = new Map<string, Array<Comparison>>()
   for (const comparison of allComparisons) {
     const groupKey = `${formatScale(comparison.scale)} | source indexes: ${

--- a/scripts/bench/compare-incremental-update.ts
+++ b/scripts/bench/compare-incremental-update.ts
@@ -184,6 +184,23 @@ function marker(comparison: Comparison, threshold: number): string {
   return ``
 }
 
+// Individual rows are noisy at sub-ms timings, but a consistent shift across
+// many rows is a real change even when no single row clears the per-row
+// significance bar — the geometric mean of the ratios captures that.
+function geomeanRatio(group: Array<Comparison>): number {
+  const finite = group
+    .map((comparison) => comparison.medianRatio)
+    .filter((value) => Number.isFinite(value) && value > 0)
+  if (finite.length === 0) return 1
+  return Math.exp(
+    finite.reduce((sum, value) => sum + Math.log(value), 0) / finite.length,
+  )
+}
+
+function formatRatio(value: number): string {
+  return `${value.toFixed(2)}×`
+}
+
 function formatMarkdown(
   baseReport: Report,
   candidateReport: Report,
@@ -218,6 +235,12 @@ function formatMarkdown(
     )
   }
   lines.push(``)
+  lines.push(
+    `Overall median write time vs base: **${formatRatio(
+      geomeanRatio(allComparisons),
+    )}** (geometric mean of per-case ratios; lower is faster).`,
+  )
+  lines.push(``)
 
   const groups = new Map<string, Array<Comparison>>()
   for (const comparison of allComparisons) {
@@ -234,8 +257,12 @@ function formatMarkdown(
     const changed = group.filter(
       (comparison) => marker(comparison, threshold) !== ``,
     ).length
-    const summarySuffix = changed > 0 ? ` — ${changed} change(s)` : ``
-    lines.push(`<summary><b>${groupKey}</b>${summarySuffix}</summary>`)
+    const changedSuffix = changed > 0 ? `, ${changed} change(s)` : ``
+    lines.push(
+      `<summary><b>${groupKey}</b> — geomean ${formatRatio(
+        geomeanRatio(group),
+      )}${changedSuffix}</summary>`,
+    )
     lines.push(``)
     lines.push(
       `| Query | Base median | PR median | Δ median | Base p95 | PR p95 | Δ p95 | |`,

--- a/scripts/bench/compare-incremental-update.ts
+++ b/scripts/bench/compare-incremental-update.ts
@@ -1,0 +1,344 @@
+/**
+ * Compares two JSON reports produced by `scripts/bench/incremental-update.ts`
+ * and prints a markdown summary of the differences.
+ *
+ * Usage:
+ *   tsx scripts/bench/compare-incremental-update.ts \
+ *     --base=.tmp/perf/base.json \
+ *     --candidate=.tmp/perf/candidate.json \
+ *     [--outFile=.tmp/perf/comparison.md] \
+ *     [--threshold=0.20] \
+ *     [--failOnRegression=false]
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+
+type Summary = {
+  iterations: number
+  medianMs: number
+  p75Ms: number
+  p95Ms: number
+  minMs: number
+  maxMs: number
+  stddevMs: number
+}
+
+type FixtureScale = {
+  label: string
+  issueCount: number
+  userCount: number
+  commentCount: number
+}
+
+type RunResult = {
+  query: string
+  scenario: string
+  scale: FixtureScale
+  sourceIndexMode: string
+  mutationMode: string
+  coldHydrateMs: number
+  writeSummary: Summary
+}
+
+type Report = {
+  metadata: {
+    node: string
+    platform: string
+    cpu: string
+    gitSha: string
+    iterations: number
+    warmup: number
+  }
+  results: Array<RunResult>
+}
+
+type Comparison = {
+  key: string
+  query: string
+  scenario: string
+  scale: FixtureScale
+  sourceIndexMode: string
+  mutationMode: string
+  base: RunResult
+  candidate: RunResult
+  medianRatio: number
+  p95Ratio: number
+}
+
+// Relative change below which a result is considered noise, and an absolute
+// floor so sub-hundredth-of-a-ms jitter never counts as a change.
+const defaultThreshold = 0.2
+const absoluteFloorMs = 0.05
+
+const args = parseArgs(process.argv.slice(2))
+
+const base = readReport(args.base)
+const candidate = readReport(args.candidate)
+
+const comparisons = compareReports(base, candidate)
+const markdown = formatMarkdown(base, candidate, comparisons, args.threshold)
+
+if (args.outFile) {
+  writeFileSync(args.outFile, markdown)
+}
+console.log(markdown)
+
+const regressions = comparisons.filter((comparison) =>
+  isRegression(comparison, args.threshold),
+)
+if (args.failOnRegression && regressions.length > 0) {
+  console.error(`\n${regressions.length} benchmark regression(s) found`)
+  process.exit(1)
+}
+
+function readReport(path: string): Report {
+  return JSON.parse(readFileSync(path, `utf8`)) as Report
+}
+
+function resultKey(result: RunResult): string {
+  return [
+    result.query,
+    result.scenario,
+    result.scale.label,
+    result.scale.issueCount,
+    result.scale.userCount,
+    result.scale.commentCount,
+    result.sourceIndexMode,
+    result.mutationMode,
+  ].join(`|`)
+}
+
+function compareReports(
+  baseReport: Report,
+  candidateReport: Report,
+): Array<Comparison> {
+  const baseByKey = new Map(
+    baseReport.results.map((result) => [resultKey(result), result]),
+  )
+
+  const matched: Array<Comparison> = []
+  for (const result of candidateReport.results) {
+    const key = resultKey(result)
+    const baseResult = baseByKey.get(key)
+    if (!baseResult) continue
+
+    matched.push({
+      key,
+      query: result.query,
+      scenario: result.scenario,
+      scale: result.scale,
+      sourceIndexMode: result.sourceIndexMode,
+      mutationMode: result.mutationMode,
+      base: baseResult,
+      candidate: result,
+      medianRatio: ratio(
+        baseResult.writeSummary.medianMs,
+        result.writeSummary.medianMs,
+      ),
+      p95Ratio: ratio(baseResult.writeSummary.p95Ms, result.writeSummary.p95Ms),
+    })
+  }
+
+  return matched
+}
+
+function ratio(baseMs: number, candidateMs: number): number {
+  if (baseMs <= 0) return candidateMs <= 0 ? 1 : Number.POSITIVE_INFINITY
+  return candidateMs / baseMs
+}
+
+function isSignificant(
+  baseMs: number,
+  candidateMs: number,
+  threshold: number,
+): boolean {
+  const relativeChange = Math.abs(ratio(baseMs, candidateMs) - 1)
+  const absoluteChange = Math.abs(candidateMs - baseMs)
+  return relativeChange > threshold && absoluteChange > absoluteFloorMs
+}
+
+function isRegression(comparison: Comparison, threshold: number): boolean {
+  return (
+    comparison.medianRatio > 1 &&
+    isSignificant(
+      comparison.base.writeSummary.medianMs,
+      comparison.candidate.writeSummary.medianMs,
+      threshold,
+    )
+  )
+}
+
+function isImprovement(comparison: Comparison, threshold: number): boolean {
+  return (
+    comparison.medianRatio < 1 &&
+    isSignificant(
+      comparison.base.writeSummary.medianMs,
+      comparison.candidate.writeSummary.medianMs,
+      threshold,
+    )
+  )
+}
+
+function marker(comparison: Comparison, threshold: number): string {
+  if (isRegression(comparison, threshold)) return `🔴`
+  if (isImprovement(comparison, threshold)) return `🟢`
+  return ``
+}
+
+function formatMarkdown(
+  baseReport: Report,
+  candidateReport: Report,
+  allComparisons: Array<Comparison>,
+  threshold: number,
+): string {
+  const lines: Array<string> = []
+  const regressed = allComparisons.filter((comparison) =>
+    isRegression(comparison, threshold),
+  )
+  const improved = allComparisons.filter((comparison) =>
+    isImprovement(comparison, threshold),
+  )
+
+  lines.push(`## Incremental update benchmark`)
+  lines.push(``)
+  lines.push(
+    `Comparing \`${candidateReport.metadata.gitSha}\` (this PR) against \`${baseReport.metadata.gitSha}\` (base). ` +
+      `Times are per-write medians over ${candidateReport.metadata.iterations} iterations ` +
+      `(${candidateReport.metadata.warmup} warmup writes).`,
+  )
+  lines.push(``)
+
+  if (regressed.length === 0 && improved.length === 0) {
+    lines.push(
+      `**No significant changes** (threshold: ±${Math.round(threshold * 100)}% and >${absoluteFloorMs}ms).`,
+    )
+  } else {
+    lines.push(
+      `**${regressed.length} regression(s), ${improved.length} improvement(s)** ` +
+        `(threshold: ±${Math.round(threshold * 100)}% and >${absoluteFloorMs}ms).`,
+    )
+  }
+  lines.push(``)
+
+  const groups = new Map<string, Array<Comparison>>()
+  for (const comparison of allComparisons) {
+    const groupKey = `${formatScale(comparison.scale)} | source indexes: ${
+      comparison.sourceIndexMode
+    } | ${comparison.mutationMode} writes`
+    const group = groups.get(groupKey) ?? []
+    group.push(comparison)
+    groups.set(groupKey, group)
+  }
+
+  for (const [groupKey, group] of groups) {
+    lines.push(`<details>`)
+    const changed = group.filter(
+      (comparison) => marker(comparison, threshold) !== ``,
+    ).length
+    const summarySuffix = changed > 0 ? ` — ${changed} change(s)` : ``
+    lines.push(`<summary><b>${groupKey}</b>${summarySuffix}</summary>`)
+    lines.push(``)
+    lines.push(
+      `| Query | Base median | PR median | Δ median | Base p95 | PR p95 | Δ p95 | |`,
+    )
+    lines.push(`| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |`)
+    for (const comparison of group) {
+      lines.push(
+        `| ${comparison.query} | ${formatMs(
+          comparison.base.writeSummary.medianMs,
+        )} | ${formatMs(comparison.candidate.writeSummary.medianMs)} | ${formatDelta(
+          comparison.medianRatio,
+        )} | ${formatMs(comparison.base.writeSummary.p95Ms)} | ${formatMs(
+          comparison.candidate.writeSummary.p95Ms,
+        )} | ${formatDelta(comparison.p95Ratio)} | ${marker(
+          comparison,
+          threshold,
+        )} |`,
+      )
+    }
+    lines.push(``)
+    lines.push(`</details>`)
+    lines.push(``)
+  }
+
+  lines.push(
+    `<sub>Runner: node ${candidate.metadata.node}, ${candidate.metadata.platform}, ${candidate.metadata.cpu}. ` +
+      `Timings on shared CI runners are noisy; treat small deltas as indicative only.</sub>`,
+  )
+
+  return lines.join(`\n`)
+}
+
+function formatScale(scale: FixtureScale): string {
+  if (
+    scale.issueCount === scale.userCount &&
+    scale.userCount === scale.commentCount
+  ) {
+    return `${scale.issueCount.toLocaleString(`en-US`)} rows/collection`
+  }
+  return `issues:${scale.issueCount} users:${scale.userCount} comments:${scale.commentCount}`
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(3)}ms`
+}
+
+function formatDelta(value: number): string {
+  if (!Number.isFinite(value)) return `n/a`
+  const percent = (value - 1) * 100
+  const sign = percent > 0 ? `+` : ``
+  return `${sign}${percent.toFixed(1)}%`
+}
+
+function parseArgs(argv: Array<string>): {
+  base: string
+  candidate: string
+  outFile?: string
+  threshold: number
+  failOnRegression: boolean
+} {
+  let basePath: string | undefined
+  let candidatePath: string | undefined
+  let outFile: string | undefined
+  let threshold = defaultThreshold
+  let failOnRegression = false
+
+  for (const arg of argv) {
+    const [name, value] = arg.replace(/^--/, ``).split(`=`)
+    if (!name || value === undefined) continue
+
+    switch (name) {
+      case `base`:
+        basePath = value
+        break
+      case `candidate`:
+        candidatePath = value
+        break
+      case `outFile`:
+        outFile = value
+        break
+      case `threshold`: {
+        const parsed = Number(value)
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          throw new Error(`--threshold must be a positive number`)
+        }
+        threshold = parsed
+        break
+      }
+      case `failOnRegression`:
+        failOnRegression = value === `true`
+        break
+    }
+  }
+
+  if (!basePath || !candidatePath) {
+    throw new Error(`--base and --candidate report paths are required`)
+  }
+
+  return {
+    base: basePath,
+    candidate: candidatePath,
+    outFile,
+    threshold,
+    failOnRegression,
+  }
+}

--- a/scripts/bench/incremental-update.ts
+++ b/scripts/bench/incremental-update.ts
@@ -1,0 +1,1004 @@
+import { execSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { cpus, platform, release } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  BTreeIndex,
+  count,
+  createCollection,
+  createLiveQueryCollection,
+  createTransaction,
+  eq,
+  materialize,
+} from '../../packages/db/src/index.js'
+import type {
+  ChangeMessageOrDeleteKeyMessage,
+  Collection,
+  SyncConfig,
+} from '../../packages/db/src/index.js'
+
+type Issue = {
+  id: number
+  status: `open` | `closed`
+  authorId: number
+  createdAt: number
+  title: string
+  body: string
+  updateTick: number
+}
+
+type User = {
+  id: number
+  name: string
+  reputation: number
+}
+
+type Comment = {
+  id: number
+  issueId: number
+  authorId: number
+  createdAt: number
+  body: string
+  updateTick: number
+}
+
+type ManualSyncUtils<T extends object, TKey extends string | number> = {
+  begin: Parameters<SyncConfig<T, TKey>[`sync`]>[0][`begin`]
+  write: (message: ChangeMessageOrDeleteKeyMessage<T, TKey>) => void
+  commit: Parameters<SyncConfig<T, TKey>[`sync`]>[0][`commit`]
+}
+
+type ManualCollection<
+  T extends object,
+  TKey extends string | number,
+> = Collection<T, TKey, ManualSyncUtils<T, TKey>, never, T>
+
+type BenchmarkCollection = Collection<Record<string, unknown>, string | number>
+
+type Fixture = {
+  seed: number
+  issues: ManualCollection<Issue, number>
+  users: ManualCollection<User, number>
+  comments: ManualCollection<Comment, number>
+  issueById: Map<number, Issue>
+  userById: Map<number, User>
+  commentById: Map<number, Comment>
+  visibleIssueId: number
+  selectedIssueId: number
+  nextCommentId: number
+}
+
+type BenchmarkOptions = {
+  seed: number
+  levels: Array<number>
+  sourceIndexModes: Array<SourceIndexMode>
+  mutationModes: Array<MutationMode>
+  issueCount?: number
+  userCount?: number
+  commentCount?: number
+  warmup: number
+  iterations: number
+  outDir: string
+  outFile?: string
+}
+
+type FixtureScale = {
+  label: string
+  issueCount: number
+  userCount: number
+  commentCount: number
+}
+
+type BenchmarkRunOptions = {
+  seed: number
+  scale: FixtureScale
+  issueCount: number
+  userCount: number
+  commentCount: number
+  sourceIndexMode: SourceIndexMode
+  warmup: number
+  iterations: number
+}
+
+type Summary = {
+  iterations: number
+  medianMs: number
+  p75Ms: number
+  p95Ms: number
+  minMs: number
+  maxMs: number
+  stddevMs: number
+}
+
+type RunResult = {
+  query: string
+  scenario: string
+  scale: FixtureScale
+  sourceIndexMode: SourceIndexMode
+  mutationMode: MutationMode
+  coldHydrateMs: number
+  writeSummary: Summary
+}
+
+type MutationMode = `synced` | `optimistic`
+type SourceIndexMode = `none` | `manual` | `auto`
+
+type WriteCleanup = () => void | Promise<void>
+
+type WriteResult = void | { cleanup: WriteCleanup }
+
+type QueryCase = {
+  name: string
+  scenario: string
+  createQuery: (fixture: Fixture) => BenchmarkCollection
+  write: (
+    fixture: Fixture,
+    iteration: number,
+    mutationMode: MutationMode,
+  ) => WriteResult
+}
+
+const defaultOptions: BenchmarkOptions = {
+  seed: 42,
+  levels: [100, 1_000, 10_000],
+  sourceIndexModes: [`none`, `manual`],
+  mutationModes: [`synced`, `optimistic`],
+  warmup: 10,
+  iterations: 50,
+  outDir: `.tmp/perf`,
+}
+
+const defaultCustomScale: FixtureScale = {
+  label: `custom`,
+  issueCount: 10_000,
+  userCount: 1_000,
+  commentCount: 40_000,
+}
+
+const options = parseArgs(process.argv.slice(2), defaultOptions)
+
+const queryCases: Array<QueryCase> = [
+  {
+    name: `list: newest 50 open`,
+    scenario: `visible issue update`,
+    createQuery: ({ issues }) =>
+      createLiveQueryCollection((q) =>
+        q
+          .from({ issue: issues })
+          .where(({ issue }) => eq(issue.status, `open`))
+          .orderBy(({ issue }) => issue.createdAt, `desc`)
+          .limit(50)
+          .select(({ issue }) => ({
+            id: issue.id,
+            title: issue.title,
+            createdAt: issue.createdAt,
+          })),
+      ) as unknown as BenchmarkCollection,
+    write: updateVisibleIssue,
+  },
+  {
+    name: `list + author`,
+    scenario: `visible author update`,
+    createQuery: ({ issues, users }) =>
+      createLiveQueryCollection((q) =>
+        q
+          .from({ issue: issues })
+          .where(({ issue }) => eq(issue.status, `open`))
+          .join({ author: users }, ({ issue, author }) =>
+            eq(issue.authorId, author.id),
+          )
+          .orderBy(({ issue }) => issue.createdAt, `desc`)
+          .limit(50)
+          .select(({ issue, author }) => ({
+            id: issue.id,
+            title: issue.title,
+            createdAt: issue.createdAt,
+            authorName: author.name,
+          })),
+      ) as unknown as BenchmarkCollection,
+    write: updateVisibleAuthor,
+  },
+  {
+    name: `list + comment count`,
+    scenario: `visible issue comment insert`,
+    createQuery: ({ issues, comments }) =>
+      createLiveQueryCollection((q) =>
+        q
+          .from({ issue: issues })
+          .where(({ issue }) => eq(issue.status, `open`))
+          .orderBy(({ issue }) => issue.createdAt, `desc`)
+          .limit(50)
+          .select(({ issue }) => ({
+            id: issue.id,
+            title: issue.title,
+            commentCount: materialize(
+              q
+                .from({ comment: comments })
+                .where(({ comment }) => eq(comment.issueId, issue.id))
+                .select(({ comment }) => count(comment.id))
+                .findOne(),
+            ),
+          })),
+      ) as unknown as BenchmarkCollection,
+    write: insertVisibleComment,
+  },
+  {
+    name: `list + 3 recent comments`,
+    scenario: `visible issue comment insert`,
+    createQuery: ({ issues, comments }) =>
+      createLiveQueryCollection((q) =>
+        q
+          .from({ issue: issues })
+          .where(({ issue }) => eq(issue.status, `open`))
+          .orderBy(({ issue }) => issue.createdAt, `desc`)
+          .limit(50)
+          .select(({ issue }) => ({
+            id: issue.id,
+            title: issue.title,
+            recentComments: q
+              .from({ comment: comments })
+              .where(({ comment }) => eq(comment.issueId, issue.id))
+              .orderBy(({ comment }) => comment.createdAt, `desc`)
+              .limit(3)
+              .select(({ comment }) => ({
+                id: comment.id,
+                body: comment.body,
+                createdAt: comment.createdAt,
+              })),
+          })),
+      ) as unknown as BenchmarkCollection,
+    write: insertVisibleComment,
+  },
+  {
+    name: `issue detail + comments`,
+    scenario: `selected issue comment insert`,
+    createQuery: ({ issues, comments, selectedIssueId }) =>
+      createLiveQueryCollection((q) =>
+        q
+          .from({ issue: issues })
+          .where(({ issue }) => eq(issue.id, selectedIssueId))
+          .select(({ issue }) => ({
+            id: issue.id,
+            title: issue.title,
+            comments: q
+              .from({ comment: comments })
+              .where(({ comment }) => eq(comment.issueId, issue.id))
+              .orderBy(({ comment }) => comment.createdAt, `desc`)
+              .select(({ comment }) => ({
+                id: comment.id,
+                body: comment.body,
+                createdAt: comment.createdAt,
+              })),
+          })),
+      ) as unknown as BenchmarkCollection,
+    write: insertSelectedIssueComment,
+  },
+]
+
+const scales = resolveScales(options)
+const results: Array<RunResult> = []
+for (const scale of scales) {
+  for (const sourceIndexMode of options.sourceIndexModes) {
+    const runOptions = createRunOptions(options, scale, sourceIndexMode)
+    for (const mutationMode of options.mutationModes) {
+      for (const queryCase of queryCases) {
+        results.push(await runCase(queryCase, mutationMode, runOptions))
+      }
+    }
+  }
+}
+
+const report = {
+  metadata: runtimeMetadata(options, scales),
+  results,
+}
+
+const outputPath =
+  options.outFile ??
+  join(options.outDir, `incremental-update-${Date.now()}.json`)
+mkdirSync(dirname(outputPath), { recursive: true })
+writeFileSync(outputPath, JSON.stringify(report, null, 2))
+
+console.log(formatTextReport(report, outputPath))
+
+async function runCase(
+  queryCase: QueryCase,
+  mutationMode: MutationMode,
+  options: BenchmarkRunOptions,
+): Promise<RunResult> {
+  const fixture = createFixture(options)
+  const query = queryCase.createQuery(fixture)
+
+  const coldStart = performance.now()
+  await query.preload()
+  await flushMicrotasks()
+  const coldHydrateMs = performance.now() - coldStart
+
+  for (let i = 0; i < options.warmup; i++) {
+    const writeResult = queryCase.write(fixture, i, mutationMode)
+    await flushMicrotasks()
+    await cleanupWrite(writeResult)
+  }
+
+  const samples: Array<number> = []
+  for (let i = 0; i < options.iterations; i++) {
+    const start = performance.now()
+    const writeResult = queryCase.write(
+      fixture,
+      options.warmup + i,
+      mutationMode,
+    )
+    await flushMicrotasks()
+    samples.push(performance.now() - start)
+    await cleanupWrite(writeResult)
+  }
+
+  await cleanupFixture(fixture, query)
+
+  return {
+    query: queryCase.name,
+    scenario: queryCase.scenario,
+    scale: options.scale,
+    sourceIndexMode: options.sourceIndexMode,
+    mutationMode,
+    coldHydrateMs,
+    writeSummary: summarize(samples),
+  }
+}
+
+function createManualCollection<T extends object, TKey extends string | number>(
+  id: string,
+  initialData: Array<T>,
+  getKey: (item: T) => TKey,
+  sourceIndexMode: SourceIndexMode,
+): ManualCollection<T, TKey> {
+  let begin: Parameters<SyncConfig<T, TKey>[`sync`]>[0][`begin`] | undefined
+  let write: Parameters<SyncConfig<T, TKey>[`sync`]>[0][`write`] | undefined
+  let commit: Parameters<SyncConfig<T, TKey>[`sync`]>[0][`commit`] | undefined
+
+  const utils: ManualSyncUtils<T, TKey> = {
+    begin: (syncOptions) => begin!(syncOptions),
+    write: (message) => write!(message),
+    commit: () => commit!(),
+  }
+
+  return createCollection<T, TKey, ManualSyncUtils<T, TKey>>({
+    id,
+    getKey,
+    utils,
+    startSync: true,
+    autoIndex: sourceIndexMode === `auto` ? `eager` : `off`,
+    defaultIndexType: BTreeIndex,
+    sync: {
+      rowUpdateMode: `full`,
+      sync: (methods) => {
+        begin = methods.begin
+        write = methods.write
+        commit = methods.commit
+
+        begin()
+        for (const value of initialData) {
+          write({
+            type: `insert`,
+            value,
+          })
+        }
+        commit()
+        methods.markReady()
+
+        return () => {
+          begin = undefined
+          write = undefined
+          commit = undefined
+        }
+      },
+    },
+  })
+}
+
+function createFixture(options: BenchmarkRunOptions): Fixture {
+  const random = seededRandom(options.seed)
+  const usersData: Array<User> = []
+  for (let id = 1; id <= options.userCount; id++) {
+    usersData.push({
+      id,
+      name: `User ${id}`,
+      reputation: Math.floor(random() * 10_000),
+    })
+  }
+
+  const issuesData: Array<Issue> = []
+  for (let id = 1; id <= options.issueCount; id++) {
+    issuesData.push({
+      id,
+      status: id % 3 === 0 ? `closed` : `open`,
+      authorId: 1 + (id % options.userCount),
+      createdAt: id,
+      title: `Issue ${id}`,
+      body: `Body ${id}`,
+      updateTick: 0,
+    })
+  }
+
+  const visibleIssueId = findNewestOpenIssueId(issuesData)
+  const selectedIssueId = visibleIssueId
+  const commentsData: Array<Comment> = []
+  for (let id = 1; id <= options.commentCount; id++) {
+    const hotIssueId =
+      id % 5 === 0
+        ? 1 + Math.floor(random() * Math.min(options.issueCount, 50))
+        : 1 + Math.floor(random() * options.issueCount)
+    commentsData.push({
+      id,
+      issueId: hotIssueId,
+      authorId: 1 + (id % options.userCount),
+      createdAt: id,
+      body: `Comment ${id}`,
+      updateTick: 0,
+    })
+  }
+
+  const fixture = {
+    seed: options.seed,
+    issues: createManualCollection(
+      `bench-issues`,
+      issuesData,
+      (issue) => issue.id,
+      options.sourceIndexMode,
+    ),
+    users: createManualCollection(
+      `bench-users`,
+      usersData,
+      (user) => user.id,
+      options.sourceIndexMode,
+    ),
+    comments: createManualCollection(
+      `bench-comments`,
+      commentsData,
+      (comment) => comment.id,
+      options.sourceIndexMode,
+    ),
+    issueById: new Map(issuesData.map((issue) => [issue.id, issue])),
+    userById: new Map(usersData.map((user) => [user.id, user])),
+    commentById: new Map(commentsData.map((comment) => [comment.id, comment])),
+    visibleIssueId,
+    selectedIssueId,
+    nextCommentId: options.commentCount + 1,
+  }
+
+  applySourceIndexes(fixture, options.sourceIndexMode)
+
+  return fixture
+}
+
+function applySourceIndexes(
+  fixture: Fixture,
+  sourceIndexMode: SourceIndexMode,
+): void {
+  if (sourceIndexMode !== `manual`) return
+
+  fixture.issues.createIndex((issue) => issue.id)
+  fixture.issues.createIndex((issue) => issue.status)
+  fixture.issues.createIndex((issue) => issue.authorId)
+  fixture.issues.createIndex((issue) => issue.createdAt)
+  fixture.users.createIndex((user) => user.id)
+  fixture.comments.createIndex((comment) => comment.issueId)
+  fixture.comments.createIndex((comment) => comment.createdAt)
+}
+
+function updateVisibleIssue(
+  fixture: Fixture,
+  iteration: number,
+  mutationMode: MutationMode,
+): WriteResult {
+  const issue = fixture.issueById.get(fixture.visibleIssueId)!
+  const next = {
+    ...issue,
+    title: `Issue ${issue.id} tick ${iteration}`,
+    updateTick: iteration,
+  }
+  fixture.issueById.set(issue.id, next)
+
+  if (mutationMode === `synced`) {
+    writeSync(fixture.issues, {
+      type: `update`,
+      value: next,
+    })
+    return
+  }
+
+  const transaction = writeOptimistic(() => {
+    fixture.issues.update(issue.id, (draft) => {
+      draft.title = next.title
+      draft.updateTick = next.updateTick
+    })
+  })
+
+  return {
+    cleanup: () => {
+      transaction.rollback()
+      fixture.issueById.set(issue.id, issue)
+    },
+  }
+}
+
+function updateVisibleAuthor(
+  fixture: Fixture,
+  iteration: number,
+  mutationMode: MutationMode,
+): WriteResult {
+  const issue = fixture.issueById.get(fixture.visibleIssueId)!
+  const user = fixture.userById.get(issue.authorId)!
+  const next = {
+    ...user,
+    name: `User ${user.id} tick ${iteration}`,
+    reputation: user.reputation + 1,
+  }
+  fixture.userById.set(user.id, next)
+
+  if (mutationMode === `synced`) {
+    writeSync(fixture.users, {
+      type: `update`,
+      value: next,
+    })
+    return
+  }
+
+  const transaction = writeOptimistic(() => {
+    fixture.users.update(user.id, (draft) => {
+      draft.name = next.name
+      draft.reputation = next.reputation
+    })
+  })
+
+  return {
+    cleanup: () => {
+      transaction.rollback()
+      fixture.userById.set(user.id, user)
+    },
+  }
+}
+
+function insertVisibleComment(
+  fixture: Fixture,
+  iteration: number,
+  mutationMode: MutationMode,
+): WriteResult {
+  return insertCommentForIssue(
+    fixture,
+    fixture.visibleIssueId,
+    iteration,
+    mutationMode,
+  )
+}
+
+function insertSelectedIssueComment(
+  fixture: Fixture,
+  iteration: number,
+  mutationMode: MutationMode,
+): WriteResult {
+  return insertCommentForIssue(
+    fixture,
+    fixture.selectedIssueId,
+    iteration,
+    mutationMode,
+  )
+}
+
+function insertCommentForIssue(
+  fixture: Fixture,
+  issueId: number,
+  iteration: number,
+  mutationMode: MutationMode,
+): WriteResult {
+  const comment: Comment = {
+    id: fixture.nextCommentId++,
+    issueId,
+    authorId: 1 + (iteration % fixture.userById.size),
+    createdAt: 1_000_000_000 + iteration,
+    body: `Inserted comment ${iteration}`,
+    updateTick: iteration,
+  }
+  fixture.commentById.set(comment.id, comment)
+
+  if (mutationMode === `synced`) {
+    writeSync(fixture.comments, {
+      type: `insert`,
+      value: comment,
+    })
+    return
+  }
+
+  const transaction = writeOptimistic(() => {
+    fixture.comments.insert(comment)
+  })
+
+  return {
+    cleanup: () => {
+      transaction.rollback()
+      fixture.commentById.delete(comment.id)
+    },
+  }
+}
+
+function writeSync<T extends object, TKey extends string | number>(
+  collection: ManualCollection<T, TKey>,
+  message: ChangeMessageOrDeleteKeyMessage<T, TKey>,
+): void {
+  collection.utils.begin({ immediate: true })
+  collection.utils.write(message)
+  collection.utils.commit()
+}
+
+function writeOptimistic(write: () => void) {
+  const transaction = createTransaction({
+    autoCommit: false,
+    mutationFn: async () => {},
+  })
+  transaction.isPersisted.promise.catch(() => undefined)
+  transaction.mutate(write)
+  return transaction
+}
+
+async function cleanupWrite(writeResult: WriteResult): Promise<void> {
+  if (!writeResult) return
+  await writeResult.cleanup()
+  await flushMicrotasks()
+}
+
+async function cleanupFixture(
+  fixture: Fixture,
+  query: BenchmarkCollection,
+): Promise<void> {
+  await Promise.all([
+    query.cleanup(),
+    fixture.issues.cleanup(),
+    fixture.users.cleanup(),
+    fixture.comments.cleanup(),
+  ])
+}
+
+function summarize(samples: Array<number>): Summary {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const total = sorted.reduce((sum, value) => sum + value, 0)
+  const mean = total / sorted.length
+  const variance =
+    sorted.reduce((sum, value) => sum + (value - mean) ** 2, 0) / sorted.length
+  return {
+    iterations: sorted.length,
+    medianMs: percentile(sorted, 0.5),
+    p75Ms: percentile(sorted, 0.75),
+    p95Ms: percentile(sorted, 0.95),
+    minMs: sorted[0] ?? 0,
+    maxMs: sorted[sorted.length - 1] ?? 0,
+    stddevMs: Math.sqrt(variance),
+  }
+}
+
+function percentile(sorted: Array<number>, p: number): number {
+  if (sorted.length === 0) return 0
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * p) - 1)
+  return sorted[index]!
+}
+
+function runtimeMetadata(
+  options: BenchmarkOptions,
+  scales: Array<FixtureScale>,
+) {
+  return {
+    seed: options.seed,
+    levels: options.levels,
+    scales,
+    sourceIndexModes: options.sourceIndexModes,
+    mutationModes: options.mutationModes,
+    warmup: options.warmup,
+    iterations: options.iterations,
+    node: process.version,
+    platform: `${platform()} ${release()}`,
+    cpu: cpus()[0]?.model ?? `unknown`,
+    gitSha: gitSha(),
+    gcAvailable: typeof global.gc === `function`,
+  }
+}
+
+function formatTextReport(
+  report: {
+    metadata: ReturnType<typeof runtimeMetadata>
+    results: Array<RunResult>
+  },
+  outputPath: string,
+): string {
+  const lines: Array<string> = []
+  lines.push(`Incremental update benchmark`)
+  lines.push(`seed=${report.metadata.seed}`)
+  lines.push(`scales=${report.metadata.scales.map(formatScale).join(`; `)}`)
+  lines.push(`sourceIndexModes=${report.metadata.sourceIndexModes.join(`,`)}`)
+  lines.push(`mutationModes=${report.metadata.mutationModes.join(`,`)}`)
+  lines.push(
+    `runtime=node ${report.metadata.node} ${report.metadata.platform} ${report.metadata.cpu}`,
+  )
+  lines.push(`git=${report.metadata.gitSha}`)
+  lines.push(`json=${outputPath}`)
+  lines.push(``)
+
+  for (const scale of uniqueScales(report.results)) {
+    lines.push(`scale=${formatScale(scale)}`)
+    for (const sourceIndexMode of report.metadata.sourceIndexModes) {
+      lines.push(`sourceIndexMode=${sourceIndexMode}`)
+      for (const mutationMode of report.metadata.mutationModes) {
+        lines.push(`mutationMode=${mutationMode}`)
+        for (const result of report.results.filter(
+          (item) =>
+            scaleKey(item.scale) === scaleKey(scale) &&
+            item.sourceIndexMode === sourceIndexMode &&
+            item.mutationMode === mutationMode,
+        )) {
+          lines.push(`${result.query} | ${result.scenario}`)
+          lines.push(
+            `  cold=${formatMs(result.coldHydrateMs)} median=${formatMs(
+              result.writeSummary.medianMs,
+            )} p95=${formatMs(result.writeSummary.p95Ms)} min=${formatMs(
+              result.writeSummary.minMs,
+            )} max=${formatMs(result.writeSummary.maxMs)} stddev=${formatMs(
+              result.writeSummary.stddevMs,
+            )}`,
+          )
+        }
+        lines.push(``)
+      }
+    }
+  }
+
+  return lines.join(`\n`)
+}
+
+function resolveScales(options: BenchmarkOptions): Array<FixtureScale> {
+  const hasCustomScale =
+    options.issueCount !== undefined ||
+    options.userCount !== undefined ||
+    options.commentCount !== undefined
+
+  if (hasCustomScale) {
+    return [
+      {
+        label: `custom`,
+        issueCount: options.issueCount ?? defaultCustomScale.issueCount,
+        userCount: options.userCount ?? defaultCustomScale.userCount,
+        commentCount: options.commentCount ?? defaultCustomScale.commentCount,
+      },
+    ]
+  }
+
+  return options.levels.map((level) => ({
+    label: String(level),
+    issueCount: level,
+    userCount: level,
+    commentCount: level,
+  }))
+}
+
+function createRunOptions(
+  options: BenchmarkOptions,
+  scale: FixtureScale,
+  sourceIndexMode: SourceIndexMode,
+): BenchmarkRunOptions {
+  return {
+    seed: options.seed,
+    scale,
+    issueCount: scale.issueCount,
+    userCount: scale.userCount,
+    commentCount: scale.commentCount,
+    sourceIndexMode,
+    warmup: options.warmup,
+    iterations: options.iterations,
+  }
+}
+
+function uniqueScales(results: Array<RunResult>): Array<FixtureScale> {
+  const scales = new Map<string, FixtureScale>()
+  for (const result of results) {
+    scales.set(scaleKey(result.scale), result.scale)
+  }
+  return [...scales.values()]
+}
+
+function scaleKey(scale: FixtureScale): string {
+  return `${scale.label}:${scale.issueCount}:${scale.userCount}:${scale.commentCount}`
+}
+
+function formatScale(scale: FixtureScale): string {
+  if (
+    scale.issueCount === scale.userCount &&
+    scale.userCount === scale.commentCount
+  ) {
+    return `${formatInteger(scale.issueCount)} rows/collection`
+  }
+
+  return `issues:${formatInteger(scale.issueCount)} users:${formatInteger(
+    scale.userCount,
+  )} comments:${formatInteger(scale.commentCount)}`
+}
+
+function formatMs(value: number): string {
+  return `${formatNumber(value)}ms`
+}
+
+function formatNumber(value: number): string {
+  return value.toFixed(3)
+}
+
+function formatInteger(value: number): string {
+  return value.toLocaleString(`en-US`)
+}
+
+function parseArgs(
+  args: Array<string>,
+  defaults: BenchmarkOptions,
+): BenchmarkOptions {
+  const parsed = {
+    ...defaults,
+    levels: [...defaults.levels],
+    sourceIndexModes: [...defaults.sourceIndexModes],
+    mutationModes: [...defaults.mutationModes],
+  }
+
+  for (const arg of args) {
+    const [name, value] = arg.replace(/^--/, ``).split(`=`)
+    if (!name || value === undefined) continue
+
+    switch (name) {
+      case `seed`:
+        parsed.seed = parseNonNegativeInteger(value, name)
+        break
+      case `levels`:
+        parsed.levels = parseLevels(value)
+        break
+      case `sourceIndexes`:
+      case `sourceIndexModes`:
+        parsed.sourceIndexModes = parseSourceIndexModes(value)
+        break
+      case `mutationModes`:
+        parsed.mutationModes = parseMutationModes(value)
+        break
+      case `issues`:
+        parsed.issueCount = parsePositiveCount(value, name)
+        break
+      case `users`:
+        parsed.userCount = parsePositiveCount(value, name)
+        break
+      case `comments`:
+        parsed.commentCount = parsePositiveCount(value, name)
+        break
+      case `warmup`:
+        parsed.warmup = parseNonNegativeInteger(value, name)
+        break
+      case `iterations`:
+        parsed.iterations = parsePositiveInteger(value, name)
+        break
+      case `outDir`:
+        parsed.outDir = value
+        break
+      case `outFile`:
+        parsed.outFile = value
+        break
+    }
+  }
+
+  return parsed
+}
+
+function parseLevels(value: string): Array<number> {
+  const levels = value
+    .split(`,`)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => parsePositiveCount(part, `levels`))
+
+  if (levels.length === 0) {
+    throw new Error(`--levels must contain at least one positive integer`)
+  }
+
+  return levels
+}
+
+function parseMutationModes(value: string): Array<MutationMode> {
+  const modes = value
+    .split(`,`)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+
+  if (modes.length === 0) {
+    throw new Error(`--mutationModes must contain at least one mode`)
+  }
+
+  for (const mode of modes) {
+    if (mode !== `synced` && mode !== `optimistic`) {
+      throw new Error(`--mutationModes must contain synced and/or optimistic`)
+    }
+  }
+
+  return modes
+}
+
+function parseSourceIndexModes(value: string): Array<SourceIndexMode> {
+  const modes = value
+    .split(`,`)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+
+  if (modes.length === 0) {
+    throw new Error(`--sourceIndexes must contain at least one mode`)
+  }
+
+  for (const mode of modes) {
+    if (mode !== `none` && mode !== `manual` && mode !== `auto`) {
+      throw new Error(`--sourceIndexes must contain none, manual, and/or auto`)
+    }
+  }
+
+  return modes
+}
+
+function parsePositiveCount(value: string, name: string): number {
+  const normalized = value.trim().toLowerCase()
+  const parsed = normalized.endsWith(`k`)
+    ? Number(normalized.slice(0, -1)) * 1_000
+    : Number(normalized)
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`--${name} must be a positive integer or k-suffixed count`)
+  }
+  return parsed
+}
+
+function parsePositiveInteger(value: string, name: string): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`--${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+function parseNonNegativeInteger(value: string, name: string): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`--${name} must be a non-negative integer`)
+  }
+  return parsed
+}
+
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    return ((state >>> 0) % 1_000_000) / 1_000_000
+  }
+}
+
+function findNewestOpenIssueId(issues: Array<Issue>): number {
+  for (let index = issues.length - 1; index >= 0; index--) {
+    const issue = issues[index]!
+    if (issue.status === `open`) {
+      return issue.id
+    }
+  }
+  throw new Error(`Fixture must contain at least one open issue`)
+}
+
+function gitSha(): string {
+  try {
+    return execSync(`git rev-parse --short HEAD`, {
+      encoding: `utf8`,
+      stdio: [`ignore`, `pipe`, `ignore`],
+    }).trim()
+  } catch {
+    return `unknown`
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}


### PR DESCRIPTION
## Summary

Extracts the incremental update benchmark from #1648 into a standalone suite and adds a CI workflow that automatically measures the performance impact of PRs against `main`.

### What's included

- **`scripts/bench/incremental-update.ts`** — the benchmark from #1648, with the opt-in perf-tracing removed (those trace hooks only exist on that branch's instrumented code paths, so the extracted benchmark relies purely on its own wall-clock timing and runs against any revision). It measures per-write latency (median/p75/p95/min/max/stddev) plus cold hydrate time for five live-query shapes — filtered+ordered list, join, aggregate subquery, nested includes, detail view — across fixture scales (100/1k/10k rows), source index modes (none/manual), and mutation modes (synced/optimistic).
- **`scripts/bench/compare-incremental-update.ts`** — compares two benchmark reports and emits a markdown summary: per-case deltas with significance flags (default: >20% relative **and** >0.05ms absolute, so sub-ms jitter isn't flagged), plus geometric-mean ratios overall and per group to surface consistent shifts that are individually below the noise floor.
- **`.github/workflows/benchmark.yml`** — runs on non-draft PRs that touch `packages/db`, `packages/db-ivm`, or the benchmark itself (and on `workflow_dispatch`). It benchmarks the PR merge commit and its merge-base with `main` back-to-back on the same runner using the same benchmark code for both sides, then publishes the comparison as a job summary, uploads the raw reports as artifacts, and posts/updates a sticky PR comment (skipped gracefully for fork PRs, whose token is read-only — the job summary always has the results).

### Trigger choice

Draft PRs are skipped, so the benchmark starts when a PR is opened/marked ready for review and re-runs on pushes to it (with concurrency cancellation). Easy to tighten later (e.g. label-gated or on approval only) by changing the `on:`/`if:` conditions.

### Validation

- Benchmark runs green against current `main` (the suite is decoupled from #1648's code changes).
- Compared two same-code runs: overall geomean 1.01×, no significant changes flagged — the noise floor holds.
- Compared #1648's branch against `main` with this tooling: overall geomean 0.86× with consistent per-group improvements at the 10k scale (down to 0.5× medians), demonstrating that real perf changes are clearly visible in the report. (It also flagged a >3× median regression for the `issue detail + comments` case with optimistic writes at 10k scale on that branch — worth a look over there.)
- Full local run takes ~12s (M2); the CI config uses 100 iterations + 20 warmup writes per case, so the whole job should stay in the low minutes.
- Workflow passes zizmor with no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Benchmark workflow that runs on pull requests and manual dispatch, generating baseline vs. candidate benchmark outputs and summaries.
  * Introduced an incremental update benchmark runner with configurable scenarios, warmups, iterations, and detailed runtime metrics.
  * Added a comparison tool that produces a Markdown report with regression/improvement detection and rich per-case breakdowns.
* **Bug Fixes**
  * Improved handling for draft and forked pull requests when skipping runs and updating PR comments.
* **Documentation**
  * Benchmark results are now posted to PR comments and included in job summaries for easier review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->