### PR TITLE
test(query-db-collection): cover query invalidation behavior

### DIFF
--- a/.changeset/query-invalidation-matrix.md
+++ b/.changeset/query-invalidation-matrix.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-db-collection': patch
+---
+
+Add coverage for query invalidation behavior across eager and on-demand query collections.

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -1764,7 +1764,9 @@ describe(`QueryCollection`, () => {
 
           await vi.waitFor(() => {
             expect(queryFn).toHaveBeenCalledTimes(1)
-            expect(observedQueryKeys[0]?.length).toBeGreaterThan(queryKey.length)
+            expect(observedQueryKeys[0]?.length).toBeGreaterThan(
+              queryKey.length,
+            )
             expect(stripVirtualProps(collection.get(`1`))).toEqual({
               id: `1`,
               name: `Item 1`,

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -1623,24 +1623,32 @@ describe(`QueryCollection`, () => {
           }),
         )
 
-        await vi.waitFor(() => {
-          expect(queryFn).toHaveBeenCalledTimes(1)
-          expect(stripVirtualProps(collection.get(`1`))).toEqual({
-            id: `1`,
-            name: `Item 1`,
+        try {
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(1)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Item 1`,
+            })
           })
-        })
 
-        items = [{ id: `1`, name: `Updated Item 1` }]
-        await queryClient.invalidateQueries({ queryKey, exact: true })
+          items = [{ id: `1`, name: `Updated Item 1` }]
+          await queryClient.invalidateQueries({ queryKey, exact: true })
 
-        await vi.waitFor(() => {
-          expect(queryFn).toHaveBeenCalledTimes(2)
-          expect(stripVirtualProps(collection.get(`1`))).toEqual({
-            id: `1`,
-            name: `Updated Item 1`,
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(2)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Updated Item 1`,
+            })
           })
-        })
+        } finally {
+          await collection.cleanup()
+        }
+
+        expect(
+          queryClient.getQueryCache().find({ queryKey })?.getObserversCount(),
+        ).toBe(0)
       })
 
       it(`rematerializes an active eager query after prefix invalidation`, async () => {
@@ -1660,24 +1668,28 @@ describe(`QueryCollection`, () => {
           }),
         )
 
-        await vi.waitFor(() => {
-          expect(queryFn).toHaveBeenCalledTimes(1)
-          expect(stripVirtualProps(collection.get(`1`))).toEqual({
-            id: `1`,
-            name: `Item 1`,
+        try {
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(1)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Item 1`,
+            })
           })
-        })
 
-        items = [{ id: `1`, name: `Updated Item 1` }]
-        await queryClient.invalidateQueries({ queryKey: rootQueryKey })
+          items = [{ id: `1`, name: `Updated Item 1` }]
+          await queryClient.invalidateQueries({ queryKey: rootQueryKey })
 
-        await vi.waitFor(() => {
-          expect(queryFn).toHaveBeenCalledTimes(2)
-          expect(stripVirtualProps(collection.get(`1`))).toEqual({
-            id: `1`,
-            name: `Updated Item 1`,
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(2)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Updated Item 1`,
+            })
           })
-        })
+        } finally {
+          await collection.cleanup()
+        }
       })
 
       it(`rematerializes an active on-demand subset after exact invalidation`, async () => {
@@ -1899,25 +1911,29 @@ describe(`QueryCollection`, () => {
           }),
         )
 
-        await vi.waitFor(() => {
-          expect(queryFn).toHaveBeenCalledTimes(1)
+        try {
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(1)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Item 1`,
+            })
+          })
+
+          await queryClient.invalidateQueries({ queryKey, exact: true })
+
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(2)
+            expect(collection.utils.lastError).toBe(refetchError)
+          })
+          expect(collection.size).toBe(1)
           expect(stripVirtualProps(collection.get(`1`))).toEqual({
             id: `1`,
             name: `Item 1`,
           })
-        })
-
-        await queryClient.invalidateQueries({ queryKey, exact: true })
-
-        await vi.waitFor(() => {
-          expect(queryFn).toHaveBeenCalledTimes(2)
-          expect(collection.utils.lastError).toBe(refetchError)
-        })
-        expect(collection.size).toBe(1)
-        expect(stripVirtualProps(collection.get(`1`))).toEqual({
-          id: `1`,
-          name: `Item 1`,
-        })
+        } finally {
+          await collection.cleanup()
+        }
       })
 
       // Retained/persisted invalidation is intentionally not covered here: the

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -1606,6 +1606,399 @@ describe(`QueryCollection`, () => {
       })
     })
 
+    describe(`invalidation behavior`, () => {
+      it(`rematerializes an active eager query after exact invalidation`, async () => {
+        const queryKey = [`invalidation-exact-eager-test`]
+        let items: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+        const queryFn = vi.fn().mockImplementation(() => Promise.resolve(items))
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-exact-eager-test`,
+            queryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            startSync: true,
+          }),
+        )
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(1)
+          expect(stripVirtualProps(collection.get(`1`))).toEqual({
+            id: `1`,
+            name: `Item 1`,
+          })
+        })
+
+        items = [{ id: `1`, name: `Updated Item 1` }]
+        await queryClient.invalidateQueries({ queryKey, exact: true })
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(2)
+          expect(stripVirtualProps(collection.get(`1`))).toEqual({
+            id: `1`,
+            name: `Updated Item 1`,
+          })
+        })
+      })
+
+      it(`rematerializes an active eager query after prefix invalidation`, async () => {
+        const rootQueryKey = [`invalidation-prefix-eager-test`]
+        const queryKey = [...rootQueryKey, `child`]
+        let items: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+        const queryFn = vi.fn().mockImplementation(() => Promise.resolve(items))
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-prefix-eager-test`,
+            queryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            startSync: true,
+          }),
+        )
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(1)
+          expect(stripVirtualProps(collection.get(`1`))).toEqual({
+            id: `1`,
+            name: `Item 1`,
+          })
+        })
+
+        items = [{ id: `1`, name: `Updated Item 1` }]
+        await queryClient.invalidateQueries({ queryKey: rootQueryKey })
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(2)
+          expect(stripVirtualProps(collection.get(`1`))).toEqual({
+            id: `1`,
+            name: `Updated Item 1`,
+          })
+        })
+      })
+
+      it(`rematerializes an active on-demand subset after exact invalidation`, async () => {
+        const queryKey = [`invalidation-exact-on-demand-test`]
+        let items: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+        const queryFn = vi.fn().mockImplementation(() => Promise.resolve(items))
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-exact-on-demand-test`,
+            queryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            syncMode: `on-demand`,
+          }),
+        )
+        const liveQuery = createLiveQueryCollection({
+          query: (q) =>
+            q
+              .from({ item: collection })
+              .select(({ item }) => ({ id: item.id, name: item.name })),
+        })
+
+        try {
+          await liveQuery.preload()
+
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(1)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Item 1`,
+            })
+          })
+
+          items = [{ id: `1`, name: `Updated Item 1` }]
+          await queryClient.invalidateQueries({ queryKey, exact: true })
+
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(2)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Updated Item 1`,
+            })
+          })
+        } finally {
+          await liveQuery.cleanup()
+        }
+      })
+
+      it(`rematerializes an active on-demand subset after root prefix invalidation`, async () => {
+        const queryKey = [`invalidation-prefix-on-demand-test`]
+        let items: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+        const observedQueryKeys: Array<ReadonlyArray<unknown>> = []
+        const queryFn = vi
+          .fn()
+          .mockImplementation(
+            (ctx: QueryFunctionContext<ReadonlyArray<unknown>>) => {
+              observedQueryKeys.push(ctx.queryKey)
+              return Promise.resolve(items)
+            },
+          )
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-prefix-on-demand-test`,
+            queryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            syncMode: `on-demand`,
+          }),
+        )
+        const liveQuery = createLiveQueryCollection({
+          query: (q) =>
+            q
+              .from({ item: collection })
+              .where(({ item }) => eq(item.id, `1`))
+              .select(({ item }) => ({ id: item.id, name: item.name })),
+        })
+
+        try {
+          await liveQuery.preload()
+
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(1)
+            expect(observedQueryKeys[0]?.length).toBeGreaterThan(queryKey.length)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Item 1`,
+            })
+          })
+
+          items = [{ id: `1`, name: `Updated Item 1` }]
+          await queryClient.invalidateQueries({ queryKey })
+
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(2)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Updated Item 1`,
+            })
+          })
+        } finally {
+          await liveQuery.cleanup()
+        }
+      })
+
+      it(`keeps overlapping on-demand subset rows materialized when one subset is invalidated`, async () => {
+        const queryKey = [`invalidation-overlap-on-demand-test`]
+        let firstSubset: Array<TestItem> = [
+          { id: `1`, name: `Item 1` },
+          { id: `2`, name: `Shared Item` },
+        ]
+        const secondSubset: Array<TestItem> = [
+          { id: `2`, name: `Shared Item` },
+          { id: `3`, name: `Item 3` },
+        ]
+        const observedQueryKeys: Array<ReadonlyArray<unknown>> = []
+        const queryFn = vi
+          .fn()
+          .mockImplementation(
+            (ctx: QueryFunctionContext<ReadonlyArray<unknown>>) => {
+              const firstObservedKey = observedQueryKeys[0]
+              observedQueryKeys.push(ctx.queryKey)
+              return Promise.resolve(
+                firstObservedKey === undefined ||
+                  hashKey(ctx.queryKey) === hashKey(firstObservedKey)
+                  ? firstSubset
+                  : secondSubset,
+              )
+            },
+          )
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-overlap-on-demand-test`,
+            queryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            syncMode: `on-demand`,
+          }),
+        )
+        const firstLiveQuery = createLiveQueryCollection({
+          query: (q) =>
+            q
+              .from({ item: collection })
+              .where(({ item }) => inArray(item.id, [`1`, `2`]))
+              .select(({ item }) => ({ id: item.id, name: item.name })),
+        })
+        const secondLiveQuery = createLiveQueryCollection({
+          query: (q) =>
+            q
+              .from({ item: collection })
+              .where(({ item }) => inArray(item.id, [`2`, `3`]))
+              .select(({ item }) => ({ id: item.id, name: item.name })),
+        })
+
+        try {
+          await firstLiveQuery.preload()
+          await secondLiveQuery.preload()
+
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(2)
+            expect(collection.size).toBe(3)
+          })
+
+          firstSubset = [
+            { id: `1`, name: `Updated Item 1` },
+            { id: `2`, name: `Updated Shared Item` },
+          ]
+          await queryClient.invalidateQueries({
+            queryKey: observedQueryKeys[0],
+            exact: true,
+          })
+
+          await vi.waitFor(() => {
+            expect(queryFn).toHaveBeenCalledTimes(3)
+            expect(stripVirtualProps(collection.get(`1`))).toEqual({
+              id: `1`,
+              name: `Updated Item 1`,
+            })
+            expect(stripVirtualProps(collection.get(`2`))).toEqual({
+              id: `2`,
+              name: `Updated Shared Item`,
+            })
+          })
+          expect(stripVirtualProps(collection.get(`3`))).toEqual({
+            id: `3`,
+            name: `Item 3`,
+          })
+        } finally {
+          await firstLiveQuery.cleanup()
+          await secondLiveQuery.cleanup()
+        }
+      })
+
+      it(`retains existing rows when an invalidation refetch fails`, async () => {
+        const queryKey = [`invalidation-failed-refetch-test`]
+        const initialItems: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+        const refetchError = new Error(`refetch failed`)
+        const queryFn = vi
+          .fn()
+          .mockResolvedValueOnce(initialItems)
+          .mockRejectedValueOnce(refetchError)
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-failed-refetch-test`,
+            queryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            startSync: true,
+            retry: false,
+          }),
+        )
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(1)
+          expect(stripVirtualProps(collection.get(`1`))).toEqual({
+            id: `1`,
+            name: `Item 1`,
+          })
+        })
+
+        await queryClient.invalidateQueries({ queryKey, exact: true })
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(2)
+          expect(collection.utils.lastError).toBe(refetchError)
+        })
+        expect(collection.size).toBe(1)
+        expect(stripVirtualProps(collection.get(`1`))).toEqual({
+          id: `1`,
+          name: `Item 1`,
+        })
+      })
+
+      // Retained/persisted invalidation is intentionally not covered here: the
+      // existing unit fixtures do not exercise the full persisted retention path
+      // without introducing broader persistence setup. This PR characterizes active,
+      // inactive, removed, overlapping, and failed-refetch behavior first.
+      it(`does not rematerialize inactive cached query rows after invalidation`, async () => {
+        const retainedQueryClient = new QueryClient({
+          defaultOptions: {
+            queries: {
+              staleTime: 0,
+              gcTime: 60_000,
+              retry: false,
+            },
+          },
+        })
+        const queryKey = [`invalidation-inactive-cached-test`]
+        let items: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+        const queryFn = vi.fn().mockImplementation(() => Promise.resolve(items))
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-inactive-cached-test`,
+            queryClient: retainedQueryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            startSync: true,
+          }),
+        )
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(1)
+          expect(collection.size).toBe(1)
+        })
+
+        await collection.cleanup()
+        expect(collection.status).toBe(`cleaned-up`)
+        expect(
+          retainedQueryClient.getQueryCache().find({ queryKey }),
+        ).toBeDefined()
+
+        items = [{ id: `1`, name: `Updated Item 1` }]
+        await retainedQueryClient.invalidateQueries({ queryKey, exact: true })
+
+        expect(queryFn).toHaveBeenCalledTimes(1)
+        expect(collection.size).toBe(0)
+        retainedQueryClient.clear()
+      })
+
+      it(`does not refetch a removed query after invalidation`, async () => {
+        const queryKey = [`invalidation-removed-query-test`]
+        let items: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+        const queryFn = vi.fn().mockImplementation(() => Promise.resolve(items))
+
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `invalidation-removed-query-test`,
+            queryClient,
+            queryKey,
+            queryFn,
+            getKey,
+            startSync: true,
+          }),
+        )
+
+        await vi.waitFor(() => {
+          expect(queryFn).toHaveBeenCalledTimes(1)
+          expect(collection.size).toBe(1)
+        })
+
+        await collection.cleanup()
+        queryClient.removeQueries({ queryKey, exact: true })
+        expect(queryClient.getQueryCache().find({ queryKey })).toBeUndefined()
+
+        items = [{ id: `1`, name: `Updated Item 1` }]
+        await queryClient.invalidateQueries({ queryKey, exact: true })
+
+        expect(queryFn).toHaveBeenCalledTimes(1)
+        expect(collection.size).toBe(0)
+      })
+    })
+
     it(`should handle concurrent query operations`, async () => {
       const queryKey = [`concurrent-test`]
       const items = [{ id: `1`, name: `Item 1` }]


### PR DESCRIPTION
## 🎯 Changes

Adds a focused invalidation behavior matrix for `@tanstack/query-db-collection`, covering eager and on-demand collections across exact, prefix, overlapping, inactive, removed, and failed-refetch scenarios.

This is test/spec coverage only for the adapter boundary: TanStack Query remains the invalidation authority, while the collection adapter is verified to rematerialize or preserve DB rows appropriately when Query invalidation changes observer state.

## Reviewer Guidance

### Root Cause

Issue #344 and RFC #1643 call out that the adapter sits between TanStack Query's document-cache model and TanStack DB's normalized row store. Without explicit matrix coverage, it is easy to regress where responsibility lives: Query should own invalidation and matching semantics, while the adapter should react correctly to successful or failed observer results.

### Approach

- Add a dedicated `invalidation behavior` suite in `packages/query-db-collection/tests/query.test.ts`.
- Drive all invalidation scenarios through `queryClient.invalidateQueries`.
- Cover eager collections with exact and prefix invalidation.
- Cover active on-demand collections through live queries, including exact invalidation, root-prefix invalidation, and overlapping subsets.
- Characterize lifecycle/error behavior:
  - failed refetches keep existing materialized rows;
  - inactive cached Query entries do not rematerialize DB rows;
  - removed Query entries do not refetch after invalidation.
- Add a changeset for `@tanstack/query-db-collection`.

No runtime adapter code changes were needed.

### Key Invariants

- TanStack Query remains the only invalidation/matching authority.
- The adapter does not add a parallel invalidation API or duplicate Query's matching logic.
- Successful invalidation refetches rematerialize rows.
- Failed invalidation refetches preserve the last successful materialized rows and expose error state.
- DB rows are not recreated merely because an inactive Query cache entry exists.

### Non-goals

- No new public invalidation API.
- No lifecycle or lease-manager refactor.
- No changes to Query matching behavior.
- No broad persistence fixture expansion for retained/persisted invalidation.

### Trade-offs

The tests keep setup mostly explicit rather than extracting shared helpers. That makes each matrix row easier to review as a standalone characterization, at the cost of some repetition.

Retained/persisted invalidation is intentionally noted but not expanded into a broader fixture here; the existing unit coverage focuses this PR on active, inactive, removed, overlapping, and failed-refetch behavior.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

Verification run locally:

```bash
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts -t "invalidation"
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts
```

Both commands pass locally. The test output includes expected stderr from existing error-path tests and the new failed-refetch characterization.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Files changed

- `.changeset/query-invalidation-matrix.md` — adds a patch changeset for the new query collection invalidation coverage.
- `packages/query-db-collection/tests/query.test.ts` — adds the invalidation behavior matrix.

---

Refs #344
Refs #1643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader coverage for query invalidation behavior, including exact and prefix invalidations.
  * Verified eager and on-demand collections refresh correctly, preserve shared rows, and handle failed refetches without losing existing data.
  * Confirmed inactive or removed queries do not trigger unexpected rematerialization.
* **Chores**
  * Added a release note entry for the `@tanstack/query-db-collection` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->