### PR TITLE
Fix/live query record drop on subset unmount

### DIFF
--- a/.changeset/evil-maps-shine.md
+++ b/.changeset/evil-maps-shine.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-db-collection': minor
+---
+
+fix: move setPersistedOwners after write to prevent row deletion when sibling live query GCs

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -1318,14 +1318,19 @@ export function queryCollectionOptions(
       })
 
       newItemsMap.forEach((newItem, key) => {
+        addRow(key, hashedQueryKey)
+        const existingItem = currentSyncedItems.get(key)
+        if (!existingItem) {
+          write({ type: `insert`, value: newItem })
+        } else if (!previouslyOwnedRows.has(key)) {
+          write({ type: `update`, value: newItem })
+        }
+        // Read owners AFTER write: insert clears pending metadata, so reading here
+        // ensures we see the post-insert baseline and correctly re-apply ownership.
         const owners = getPersistedOwners(key)
         if (!owners.has(hashedQueryKey)) {
           owners.add(hashedQueryKey)
           setPersistedOwners(key, owners)
-        }
-        addRow(key, hashedQueryKey)
-        if (!currentSyncedItems.has(key)) {
-          write({ type: `insert`, value: newItem })
         }
       })
 

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -2604,4 +2604,47 @@ describe(`Query Collections`, () => {
       )
     })
   })
+
+  describe(`unmounting narrow live query does not drop record from broad live query`, () => {
+    it(`should retain item in broad useLiveQuery when narrow eq-filter useLiveQuery unmounts`, async () => {
+      const collection = createCollection(
+        mockSyncCollectionOptions<Person>({
+          id: `test-unmount-sibling`,
+          getKey: (p: Person) => p.id,
+          initialData: initialPersons,
+        }),
+      )
+
+      // List view: all items
+      const listResult = renderHook(() =>
+        useLiveQuery((q) => q.from({ p: collection })),
+      )
+
+      // Wait for list to load
+      await waitFor(() => {
+        expect(listResult.result.current.data).toHaveLength(3)
+      })
+
+      // Detail view: single item with eq filter
+      const detailResult = renderHook(() =>
+        useLiveQuery((q) =>
+          q.from({ p: collection }).where(({ p }) => eq(p.id, `1`)),
+        ),
+      )
+
+      await waitFor(() => {
+        expect(detailResult.result.current.data).toHaveLength(1)
+      })
+
+      // Unmount the detail view
+      detailResult.unmount()
+
+      // Wait a tick for GC to fire (gcTime: 1ms)
+      await new Promise((r) => setTimeout(r, 10))
+
+      // List should still have all 3 items
+      expect(listResult.result.current.data).toHaveLength(3)
+      expect(listResult.result.current.state.get(`1`)).toBeDefined()
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

When a row was first inserted by subset query A, `write({ type: 'insert' })` cleared the row's pending metadata. `setPersistedOwners` was called *before* `write`, so the ownership it set was immediately overwritten by the insert's metadata-delete.

When a later live query called `getHydratedOwnedRowsForQueryBaseline`, it read the stale persisted state and overwrote the in-memory `rowToQueries` map, dropping query A's hash from the owner set. When that query was GC'd, it found zero remaining owners and deleted the row — removing it from unrelated list views.

## ✅ Checklist

- [ x ] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


## Notes

Currently facing the below issue with react-db and I believe the below re-ordering of lines fixes it for myself but need to understand the impact elsewhere or if there is a better place to add this fix.

- Live query A contains a list of rows
- Live query B contains a subset of those rows with a different where clause
- When Live Query B unmounts then the rows are removed from the collection completely even with Live Query A still mounted and requires those rows., 

Any new live queries seem to take ownership of existing rows when mounting. Meaning that when the new live query unmounts it causes that record to be removed from the collection even if other useLiveQueries still should have that row existing.

I am unsure if this is a similar impact across the other vue/svelte db packages I am currently only using react-db so any advise if this change would negatively impact other areas would be helpful. 

One thing noticed - my team have observed that the row will re-appear in the correct live query if we force a re-render during local development


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected record syncing to ensure existing rows receive the appropriate update behavior rather than being skipped.
  - Fixed ownership tracking to re-apply ownership after writes, improving consistency and preventing unintended row deletion during sibling live query garbage collection.
- **Tests**
  - Added coverage confirming that unmounting a narrowly filtered `useLiveQuery` does not remove records from another still-mounted, unfiltered list `useLiveQuery`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->