### PR TITLE
feat(query-db-collection): support runtime QueryClient binding

### DIFF
--- a/.changeset/runtime-query-binding.md
+++ b/.changeset/runtime-query-binding.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/query-db-collection": patch
+'@tanstack/query-db-collection': patch
 ---
 
 Add `defineQueryCollectionOptions` for defining query collections without a `QueryClient` and binding a runtime client later.

--- a/.changeset/runtime-query-binding.md
+++ b/.changeset/runtime-query-binding.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/query-db-collection": patch
+---
+
+Add `defineQueryCollectionOptions` for defining query collections without a `QueryClient` and binding a runtime client later.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -43,6 +43,31 @@ const todosCollection = createCollection(
 )
 ```
 
+## Runtime QueryClient Binding
+
+For SSR or request-scoped environments, define the collection options without a `QueryClient`, then bind the request-local client where you create the collection:
+
+```typescript
+import { QueryClient } from "@tanstack/query-core"
+import { createCollection } from "@tanstack/db"
+import { defineQueryCollectionOptions } from "@tanstack/query-db-collection"
+
+const todosDefinition = defineQueryCollectionOptions({
+  queryKey: ["todos"],
+  queryFn: async () => {
+    const response = await fetch("/api/todos")
+    return response.json()
+  },
+  getKey: (item) => item.id,
+})
+
+export function createTodosCollection(queryClient: QueryClient) {
+  return createCollection(todosDefinition.bind({ queryClient }))
+}
+```
+
+Each call to `bind` uses only the `QueryClient` you pass. The direct `queryCollectionOptions({ queryClient, ... })` API remains supported.
+
 ## Configuration Options
 
 The `queryCollectionOptions` function accepts the following options:

--- a/packages/query-db-collection/src/index.ts
+++ b/packages/query-db-collection/src/index.ts
@@ -3,7 +3,9 @@
 export type { QueryCollectionMeta } from './global'
 
 export {
+  defineQueryCollectionOptions,
   queryCollectionOptions,
+  type DefinedQueryCollectionOptions,
   type QueryCollectionConfig,
   type QueryCollectionUtils,
   type SyncOperation,

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -414,7 +414,12 @@ export function defineQueryCollectionOptions<
     InferSchemaOutput<T>,
     TKey,
     T,
-    QueryCollectionUtils<InferSchemaOutput<T>, TKey, InferSchemaInput<T>, TError>
+    QueryCollectionUtils<
+      InferSchemaOutput<T>,
+      TKey,
+      InferSchemaInput<T>,
+      TError
+    >
   > & {
     schema: T
     utils: QueryCollectionUtils<
@@ -480,7 +485,12 @@ export function defineQueryCollectionOptions<
     InferSchemaOutput<T>,
     TKey,
     T,
-    QueryCollectionUtils<InferSchemaOutput<T>, TKey, InferSchemaInput<T>, TError>
+    QueryCollectionUtils<
+      InferSchemaOutput<T>,
+      TKey,
+      InferSchemaInput<T>,
+      TError
+    >
   > & {
     schema: T
     utils: QueryCollectionUtils<

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -375,9 +375,19 @@ type QueryCollectionConfigWithoutClient<
   TSchema extends StandardSchemaV1 = never,
   TQueryData = Awaited<ReturnType<TQueryFn>>,
 > = Omit<
-  QueryCollectionConfig<T, TQueryFn, TError, TQueryKey, TKey, TSchema, TQueryData>,
+  QueryCollectionConfig<
+    T,
+    TQueryFn,
+    TError,
+    TQueryKey,
+    TKey,
+    TSchema,
+    TQueryData
+  >,
   `queryClient`
->
+> & {
+  queryClient?: never
+}
 
 export function defineQueryCollectionOptions<
   T extends StandardSchemaV1,

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -359,6 +359,174 @@ function getLoadSubsetOptionsForMeta(
   return serializableOptions
 }
 
+export interface DefinedQueryCollectionOptions<TConfig, TResult> {
+  bind: (runtime: { queryClient: QueryClient }) => TResult
+  config: TConfig
+}
+
+type QueryCollectionConfigWithoutClient<
+  T extends object = object,
+  TQueryFn extends (context: QueryFunctionContext<any>) => any = (
+    context: QueryFunctionContext<any>,
+  ) => any,
+  TError = unknown,
+  TQueryKey extends QueryKey = QueryKey,
+  TKey extends string | number = string | number,
+  TSchema extends StandardSchemaV1 = never,
+  TQueryData = Awaited<ReturnType<TQueryFn>>,
+> = Omit<
+  QueryCollectionConfig<T, TQueryFn, TError, TQueryKey, TKey, TSchema, TQueryData>,
+  `queryClient`
+>
+
+export function defineQueryCollectionOptions<
+  T extends StandardSchemaV1,
+  TQueryFn extends (context: QueryFunctionContext<any>) => any,
+  TError = unknown,
+  TQueryKey extends QueryKey = QueryKey,
+  TKey extends string | number = string | number,
+  TQueryData = Awaited<ReturnType<TQueryFn>>,
+>(
+  config: QueryCollectionConfigWithoutClient<
+    InferSchemaOutput<T>,
+    TQueryFn,
+    TError,
+    TQueryKey,
+    TKey,
+    T
+  > & {
+    schema: T
+    select: (data: TQueryData) => Array<InferSchemaInput<T>>
+  },
+): DefinedQueryCollectionOptions<
+  typeof config,
+  CollectionConfig<
+    InferSchemaOutput<T>,
+    TKey,
+    T,
+    QueryCollectionUtils<InferSchemaOutput<T>, TKey, InferSchemaInput<T>, TError>
+  > & {
+    schema: T
+    utils: QueryCollectionUtils<
+      InferSchemaOutput<T>,
+      TKey,
+      InferSchemaInput<T>,
+      TError
+    >
+  }
+>
+
+export function defineQueryCollectionOptions<
+  T extends object,
+  TQueryFn extends (context: QueryFunctionContext<any>) => any = (
+    context: QueryFunctionContext<any>,
+  ) => any,
+  TError = unknown,
+  TQueryKey extends QueryKey = QueryKey,
+  TKey extends string | number = string | number,
+  TQueryData = Awaited<ReturnType<TQueryFn>>,
+>(
+  config: QueryCollectionConfigWithoutClient<
+    T,
+    TQueryFn,
+    TError,
+    TQueryKey,
+    TKey,
+    never,
+    TQueryData
+  > & {
+    schema?: never
+    select: (data: TQueryData) => Array<T>
+  },
+): DefinedQueryCollectionOptions<
+  typeof config,
+  CollectionConfig<T, TKey, never, QueryCollectionUtils<T, TKey, T, TError>> & {
+    schema?: never
+    utils: QueryCollectionUtils<T, TKey, T, TError>
+  }
+>
+
+export function defineQueryCollectionOptions<
+  T extends StandardSchemaV1,
+  TError = unknown,
+  TQueryKey extends QueryKey = QueryKey,
+  TKey extends string | number = string | number,
+>(
+  config: QueryCollectionConfigWithoutClient<
+    InferSchemaOutput<T>,
+    (
+      context: QueryFunctionContext<any>,
+    ) => Array<InferSchemaOutput<T>> | Promise<Array<InferSchemaOutput<T>>>,
+    TError,
+    TQueryKey,
+    TKey,
+    T
+  > & {
+    schema: T
+  },
+): DefinedQueryCollectionOptions<
+  typeof config,
+  CollectionConfig<
+    InferSchemaOutput<T>,
+    TKey,
+    T,
+    QueryCollectionUtils<InferSchemaOutput<T>, TKey, InferSchemaInput<T>, TError>
+  > & {
+    schema: T
+    utils: QueryCollectionUtils<
+      InferSchemaOutput<T>,
+      TKey,
+      InferSchemaInput<T>,
+      TError
+    >
+  }
+>
+
+export function defineQueryCollectionOptions<
+  T extends object,
+  TError = unknown,
+  TQueryKey extends QueryKey = QueryKey,
+  TKey extends string | number = string | number,
+>(
+  config: QueryCollectionConfigWithoutClient<
+    T,
+    (context: QueryFunctionContext<any>) => Array<T> | Promise<Array<T>>,
+    TError,
+    TQueryKey,
+    TKey
+  > & { schema?: never },
+): DefinedQueryCollectionOptions<
+  typeof config,
+  CollectionConfig<T, TKey, never, QueryCollectionUtils<T, TKey, T, TError>> & {
+    schema?: never
+    utils: QueryCollectionUtils<T, TKey, T, TError>
+  }
+>
+
+export function defineQueryCollectionOptions(
+  config: QueryCollectionConfigWithoutClient<
+    Record<string, unknown>,
+    (context: QueryFunctionContext<any>) => any
+  >,
+): DefinedQueryCollectionOptions<
+  typeof config,
+  CollectionConfig<
+    Record<string, unknown>,
+    string | number,
+    never,
+    QueryCollectionUtils
+  > & { utils: QueryCollectionUtils }
+> {
+  return {
+    config,
+    bind: ({ queryClient }) =>
+      queryCollectionOptions({
+        ...config,
+        queryClient,
+      }),
+  }
+}
+
 /**
  * Creates query collection options for use with a standard Collection.
  * This integrates TanStack Query with TanStack DB for automatic synchronization.

--- a/packages/query-db-collection/tests/query.test-d.ts
+++ b/packages/query-db-collection/tests/query.test-d.ts
@@ -10,7 +10,10 @@ import {
 } from '@tanstack/db'
 import { QueryClient } from '@tanstack/query-core'
 import { z } from 'zod'
-import { defineQueryCollectionOptions, queryCollectionOptions } from '../src/query'
+import {
+  defineQueryCollectionOptions,
+  queryCollectionOptions,
+} from '../src/query'
 import type {
   DataTag,
   QueryFunctionContext,

--- a/packages/query-db-collection/tests/query.test-d.ts
+++ b/packages/query-db-collection/tests/query.test-d.ts
@@ -45,6 +45,24 @@ describe(`Query collection type resolution tests`, () => {
     expectTypeOf(options.getKey).parameters.toEqualTypeOf<[ExplicitType]>()
   })
 
+  it(`should not accept QueryClient in runtime-bound definitions`, () => {
+    defineQueryCollectionOptions<ExplicitType>({
+      id: `defined-test-without-client`,
+      queryKey: [`defined-test-without-client`],
+      queryFn: () => Promise.resolve([]),
+      getKey: (item) => item.id,
+    })
+
+    defineQueryCollectionOptions<ExplicitType>({
+      id: `defined-test-with-client`,
+      // @ts-expect-error - queryClient is supplied by definition.bind()
+      queryClient,
+      queryKey: [`defined-test-with-client`],
+      queryFn: () => Promise.resolve([]),
+      getKey: (item) => item.id,
+    })
+  })
+
   it(`should prioritize explicit type in QueryCollectionConfig`, () => {
     const options = queryCollectionOptions<ExplicitType>({
       id: `test`,

--- a/packages/query-db-collection/tests/query.test-d.ts
+++ b/packages/query-db-collection/tests/query.test-d.ts
@@ -10,7 +10,7 @@ import {
 } from '@tanstack/db'
 import { QueryClient } from '@tanstack/query-core'
 import { z } from 'zod'
-import { queryCollectionOptions } from '../src/query'
+import { defineQueryCollectionOptions, queryCollectionOptions } from '../src/query'
 import type {
   DataTag,
   QueryFunctionContext,
@@ -31,6 +31,19 @@ describe(`Query collection type resolution tests`, () => {
 
   // Create a mock QueryClient for tests
   const queryClient = new QueryClient()
+
+  it(`should preserve explicit types when definition is bound`, () => {
+    const definition = defineQueryCollectionOptions<ExplicitType>({
+      id: `defined-test`,
+      queryKey: [`defined-test`],
+      queryFn: () => Promise.resolve([]),
+      getKey: (item) => item.id,
+    })
+
+    const options = definition.bind({ queryClient })
+
+    expectTypeOf(options.getKey).parameters.toEqualTypeOf<[ExplicitType]>()
+  })
 
   it(`should prioritize explicit type in QueryCollectionConfig`, () => {
     const options = queryCollectionOptions<ExplicitType>({

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -14,7 +14,10 @@ import {
   stripVirtualProps,
 } from '../../db/tests/utils'
 import { persistedCollectionOptions } from '../../db-sqlite-persistence-core/src'
-import { defineQueryCollectionOptions, queryCollectionOptions } from '../src/query'
+import {
+  defineQueryCollectionOptions,
+  queryCollectionOptions,
+} from '../src/query'
 import type { QueryFunctionContext } from '@tanstack/query-core'
 import type {
   Collection,
@@ -227,7 +230,10 @@ describe(`QueryCollection`, () => {
     createCollection(definition.bind({ queryClient: firstClient }))
     createCollection(definition.bind({ queryClient: secondClient }))
 
-    firstClient.setQueryData([`isolatedItems`], [{ id: `first`, name: `First` }])
+    firstClient.setQueryData(
+      [`isolatedItems`],
+      [{ id: `first`, name: `First` }],
+    )
 
     expect(firstClient.getQueryData([`isolatedItems`])).toEqual([
       { id: `first`, name: `First` },

--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -14,7 +14,7 @@ import {
   stripVirtualProps,
 } from '../../db/tests/utils'
 import { persistedCollectionOptions } from '../../db-sqlite-persistence-core/src'
-import { queryCollectionOptions } from '../src/query'
+import { defineQueryCollectionOptions, queryCollectionOptions } from '../src/query'
 import type { QueryFunctionContext } from '@tanstack/query-core'
 import type {
   Collection,
@@ -183,6 +183,59 @@ describe(`QueryCollection`, () => {
   afterEach(() => {
     // Ensure all queries are properly cleaned up after each test
     queryClient.clear()
+  })
+
+  it(`should define options without QueryClient and bind at runtime`, async () => {
+    const initialItems: Array<TestItem> = [{ id: `1`, name: `Item 1` }]
+    const queryFn = vi.fn().mockResolvedValue(initialItems)
+
+    const definition = defineQueryCollectionOptions<TestItem>({
+      id: `defined-test`,
+      queryKey: [`definedItems`],
+      queryFn,
+      getKey,
+      startSync: true,
+    })
+
+    const collection = createCollection(definition.bind({ queryClient }))
+
+    await vi.waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(1)
+      expect(collection.size).toBe(initialItems.length)
+    })
+
+    expect(stripVirtualProps(collection.get(`1`))).toEqual(initialItems[0])
+  })
+
+  it(`should isolate bindings to the provided QueryClient`, async () => {
+    const firstClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const secondClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const queryFn = vi.fn().mockResolvedValue([{ id: `1`, name: `Item 1` }])
+
+    const definition = defineQueryCollectionOptions<TestItem>({
+      id: `isolated-test`,
+      queryKey: [`isolatedItems`],
+      queryFn,
+      getKey,
+      startSync: false,
+    })
+
+    createCollection(definition.bind({ queryClient: firstClient }))
+    createCollection(definition.bind({ queryClient: secondClient }))
+
+    firstClient.setQueryData([`isolatedItems`], [{ id: `first`, name: `First` }])
+
+    expect(firstClient.getQueryData([`isolatedItems`])).toEqual([
+      { id: `first`, name: `First` },
+    ])
+    expect(secondClient.getQueryData([`isolatedItems`])).toBeUndefined()
+
+    firstClient.clear()
+    secondClient.clear()
   })
 
   it(`should initialize and fetch initial data`, async () => {


### PR DESCRIPTION
Adds `defineQueryCollectionOptions` so query collection definitions can be created without a `QueryClient` and bound later with a request-local/runtime client. This keeps the existing `queryCollectionOptions({ queryClient, ... })` API working while supporting SSR/TanStack Start-style per-request clients.

## Approach

- Introduce `defineQueryCollectionOptions(config)` as an additive helper for unbound query collection definitions.
- Return a small definition object with `bind({ queryClient })`, which delegates to the existing `queryCollectionOptions({ ...config, queryClient })` lifecycle path.
- Type the definition config so `queryClient` is rejected at definition time and must be supplied during binding.
- Export the new helper and document request-local usage in the query collection docs.

## Key invariants

- No global `QueryClient` is introduced.
- Existing direct `queryCollectionOptions({ queryClient, ... })` usage remains supported.
- A bound collection uses the runtime `QueryClient` passed to `.bind(...)`.
- Query option inference for `queryFn`, `getKey`, and schema usage is preserved.

## Non-goals

- This does not rewrite query collection lifecycle internals.
- This does not add a process-wide or implicit default `QueryClient`.
- This does not change existing direct-binding behavior.

## Trade-offs

The new helper is intentionally a thin wrapper over `queryCollectionOptions` rather than a separate runtime path. That keeps the API small and avoids duplicating query lifecycle behavior, while still separating definition-time configuration from runtime `QueryClient` binding.

## Verification

```bash
pnpm --filter @tanstack/db-ivm build
pnpm --filter @tanstack/electric-db-collection build
pnpm --filter @tanstack/db build
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts -t "bind|QueryClient|beforeLoad|runtime"
pnpm --filter @tanstack/query-db-collection test -- query.test-d.ts query.test.ts
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts
```

## Files changed

- `packages/query-db-collection/src/query.ts` — adds the runtime binding helper and types.
- `packages/query-db-collection/src/index.ts` — exports the new helper/types.
- `packages/query-db-collection/tests/query.test.ts` — covers runtime binding and separate `QueryClient` instances.
- `packages/query-db-collection/tests/query.test-d.ts` — covers inference and rejects `queryClient` at definition time.
- `docs/collections/query-collection.md` — documents request-local/runtime binding usage.
- `.changeset/runtime-query-binding.md` — records the package patch change.

---

Related RFC: https://github.com/TanStack/db/issues/1643

Addresses #436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `defineQueryCollectionOptions` for defining query collections without an immediately available `QueryClient`.
  - Bind a request-specific client later when creating the collection, supporting SSR and request-scoped usage.
  - Preserved type inference across schemas, query functions, and selection mappings.
  - Runtime bindings remain isolated, preventing query data from leaking between clients.
- **Documentation**
  - Added guidance and examples for runtime `QueryClient` binding.
- **Tests**
  - Added coverage for runtime binding, type safety, initial synchronization, and client isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
