### PR TITLE
refactor(query-db-collection): extract query ownership helpers

### DIFF
--- a/.changeset/extract-query-ownership-helpers.md
+++ b/.changeset/extract-query-ownership-helpers.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-db-collection': patch
+---
+
+Extract internal query row ownership helpers to make lifecycle cleanup paths easier to reason about while preserving existing behavior.

--- a/packages/query-db-collection/src/query.ts
+++ b/packages/query-db-collection/src/query.ts
@@ -697,28 +697,58 @@ export function queryCollectionOptions(
   // 3. Decrements refcount and GCs rows where count reaches 0
   const queryRefCounts = new Map<string, number>()
 
-  // Helper function to add a row to the internal state
-  const addRow = (rowKey: string | number, hashedQueryKey: string) => {
-    const rowToQueriesSet = rowToQueries.get(rowKey) || new Set()
-    rowToQueriesSet.add(hashedQueryKey)
-    rowToQueries.set(rowKey, rowToQueriesSet)
+  const addRowOwner = (rowKey: string | number, hashedQueryKey: string) => {
+    const owners = rowToQueries.get(rowKey) || new Set<string>()
+    owners.add(hashedQueryKey)
+    rowToQueries.set(rowKey, owners)
 
-    const queryToRowsSet = queryToRows.get(hashedQueryKey) || new Set()
-    queryToRowsSet.add(rowKey)
-    queryToRows.set(hashedQueryKey, queryToRowsSet)
+    const ownedRows =
+      queryToRows.get(hashedQueryKey) || new Set<string | number>()
+    ownedRows.add(rowKey)
+    queryToRows.set(hashedQueryKey, ownedRows)
   }
 
-  // Helper function to remove a row from the internal state
-  const removeRow = (rowKey: string | number, hashedQuerKey: string) => {
-    const rowToQueriesSet = rowToQueries.get(rowKey) || new Set()
-    rowToQueriesSet.delete(hashedQuerKey)
-    rowToQueries.set(rowKey, rowToQueriesSet)
+  const addRowOwners = (rowKey: string | number, owners: Set<string>) => {
+    rowToQueries.set(rowKey, new Set(owners))
+    owners.forEach((owner) => {
+      const ownedRows = queryToRows.get(owner) || new Set<string | number>()
+      ownedRows.add(rowKey)
+      queryToRows.set(owner, ownedRows)
+    })
+  }
 
-    const queryToRowsSet = queryToRows.get(hashedQuerKey) || new Set()
-    queryToRowsSet.delete(rowKey)
-    queryToRows.set(hashedQuerKey, queryToRowsSet)
+  const removeRowOwner = (rowKey: string | number, hashedQueryKey: string) => {
+    const owners = rowToQueries.get(rowKey) || new Set<string>()
+    owners.delete(hashedQueryKey)
+    rowToQueries.set(rowKey, owners)
 
-    return rowToQueriesSet.size === 0
+    const ownedRows =
+      queryToRows.get(hashedQueryKey) || new Set<string | number>()
+    ownedRows.delete(rowKey)
+    queryToRows.set(hashedQueryKey, ownedRows)
+
+    return owners.size === 0
+  }
+
+  const removeQueryOwnership = (hashedQueryKey: string) => {
+    const nextOwnersByRow = new Map<string | number, Set<string>>()
+
+    const rowKeys =
+      queryToRows.get(hashedQueryKey) ?? new Set<string | number>()
+
+    rowKeys.forEach((rowKey) => {
+      const owners = rowToQueries.get(rowKey)
+
+      if (!owners) {
+        return
+      }
+
+      const nextOwners = new Set(owners)
+      nextOwners.delete(hashedQueryKey)
+      nextOwnersByRow.set(rowKey, nextOwners)
+    })
+
+    return nextOwnersByRow
   }
 
   const internalSync: SyncConfig<any>[`sync`] = (params) => {
@@ -853,12 +883,7 @@ export function queryCollectionOptions(
           continue
         }
 
-        rowToQueries.set(rowKey, new Set(owners))
-        owners.forEach((owner) => {
-          const queryToRowsSet = queryToRows.get(owner) || new Set()
-          queryToRowsSet.add(rowKey)
-          queryToRows.set(owner, queryToRowsSet)
-        })
+        addRowOwners(rowKey, owners)
 
         if (owners.has(hashedQueryKey)) {
           ownedRows.add(rowKey)
@@ -944,12 +969,7 @@ export function queryCollectionOptions(
           return
         }
 
-        rowToQueries.set(row.key, new Set(ownerSet))
-        ownerSet.forEach((owner) => {
-          const queryToRowsSet = queryToRows.get(owner) || new Set()
-          queryToRowsSet.add(row.key)
-          queryToRows.set(owner, queryToRowsSet)
-        })
+        addRowOwners(row.key, ownerSet)
 
         if (ownerSet.has(hashedQueryKey)) {
           baseline.set(row.key, {
@@ -975,7 +995,7 @@ export function queryCollectionOptions(
       baseline.forEach(({ value: oldItem, owners }, rowKey) => {
         owners.delete(hashedQueryKey)
         setPersistedOwners(rowKey, owners)
-        const needToRemove = removeRow(rowKey, hashedQueryKey)
+        const needToRemove = removeRowOwner(rowKey, hashedQueryKey)
         if (needToRemove) {
           rowsToDelete.push(oldItem)
         }
@@ -1321,7 +1341,7 @@ export function queryCollectionOptions(
           const owners = getPersistedOwners(key)
           owners.delete(hashedQueryKey)
           setPersistedOwners(key, owners)
-          const needToRemove = removeRow(key, hashedQueryKey)
+          const needToRemove = removeRowOwner(key, hashedQueryKey)
           if (needToRemove) {
             write({ type: `delete`, value: oldItem })
           }
@@ -1336,7 +1356,7 @@ export function queryCollectionOptions(
           owners.add(hashedQueryKey)
           setPersistedOwners(key, owners)
         }
-        addRow(key, hashedQueryKey)
+        addRowOwner(key, hashedQueryKey)
         if (!currentSyncedItems.has(key)) {
           write({ type: `insert`, value: newItem })
         }
@@ -1506,21 +1526,10 @@ export function queryCollectionOptions(
       cancelPersistedRetentionExpiry(hashedQueryKey)
       retainedQueriesPendingRevalidation.delete(hashedQueryKey)
 
-      const rowKeys = queryToRows.get(hashedQueryKey) ?? new Set()
-      const nextOwnersByRow = new Map<string | number, Set<string>>()
+      const nextOwnersByRow = removeQueryOwnership(hashedQueryKey)
       const rowsToDelete: Array<any> = []
 
-      rowKeys.forEach((rowKey) => {
-        const queries = rowToQueries.get(rowKey)
-
-        if (!queries) {
-          return
-        }
-
-        const nextOwners = new Set(queries)
-        nextOwners.delete(hashedQueryKey)
-        nextOwnersByRow.set(rowKey, nextOwners)
-
+      nextOwnersByRow.forEach((nextOwners, rowKey) => {
         if (nextOwners.size === 0 && collection.has(rowKey)) {
           rowsToDelete.push(collection.get(rowKey))
         }


### PR DESCRIPTION
Extracts the internal row/query ownership bookkeeping in `@tanstack/query-db-collection` into small private helpers. There is no intended public API or user-visible behavior change; this is lifecycle groundwork for future cancellation/lease-manager work.

## Related

- RFC: https://github.com/TanStack/db/issues/1643

## Approach

This keeps the existing maps and lifecycle flow intact while centralizing the direct mutations of query ownership state:

- `addRowOwner` updates `rowToQueries` and `queryToRows` for one query/row relationship.
- `addRowOwners` hydrates ownership for persisted rows with multiple owners.
- `removeRowOwner` removes one query/row relationship while preserving existing empty-set behavior.
- `removeQueryOwnership` computes the remaining owners for all rows associated with a query during cleanup.

The extraction is intentionally local to `query.ts` and does not change observer refcounting, invalidation handling, or persisted retention semantics.

## Key invariants

- `rowToQueries` and `queryToRows` remain inverse ownership indexes.
- Shared rows stay materialized while at least one query still owns them.
- Cleanup removes only rows whose owner set becomes empty.
- Existing invalidation and remount behavior remains unchanged.
- Persisted retention metadata continues to be updated by the existing call sites.

## Non-goals

- No public API changes.
- No observer lifecycle rewrite.
- No new cancellation or lease state machine yet.
- No behavior-adjacent cleanup of empty ownership sets; that can be handled separately with focused characterization tests.

## Trade-offs

A full lease manager would make lifecycle ownership more explicit, but would be higher risk. This PR takes a smaller step: it reduces duplicated map mutation code and creates clearer seams for future work while preserving current behavior.

## Verification

```bash
pnpm --filter @tanstack/db-ivm build
pnpm --filter @tanstack/electric-db-collection build
pnpm --filter @tanstack/db build
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts -t "lifecycle|GC|invalidation|on-demand|late|cleanup"
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts
pnpm --filter @tanstack/query-db-collection build
pnpm --filter @tanstack/query-db-collection test -- --runInBand
```

## Files changed

- `packages/query-db-collection/src/query.ts` — extracts private row/query ownership helpers and routes existing ownership call sites through them.
- `.changeset/extract-query-ownership-helpers.md` — patch changeset for the internal refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal cleanup and ownership tracking for persisted query data.
  * Preserved existing behavior while making row removal and metadata updates more reliable during query reconciliation and lifecycle cleanup.

* **Release**
  * Patch release prepared for `@tanstack/query-db-collection`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
