### PR TITLE
docs(query-db-collection): document runtime QueryClient factory pattern

### DIFF
--- a/.changeset/document-runtime-query-client-factory.md
+++ b/.changeset/document-runtime-query-client-factory.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/query-db-collection": patch
+---
+
+Document how to create query collection options from a request-local or route-local QueryClient.

--- a/.changeset/document-runtime-query-client-factory.md
+++ b/.changeset/document-runtime-query-client-factory.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/query-db-collection": patch
+'@tanstack/query-db-collection': patch
 ---
 
 Document how to create query collection options from a request-local or route-local QueryClient.

--- a/.changeset/document-runtime-query-client-factory.md
+++ b/.changeset/document-runtime-query-client-factory.md
@@ -1,5 +1,0 @@
----
-'@tanstack/query-db-collection': patch
----
-
-Document how to create query collection options from a request-local or route-local QueryClient.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -58,7 +58,7 @@ The `queryCollectionOptions` function accepts the following options:
 
 `queryCollectionOptions` needs a `queryClient` when the collection options are created. In SSR, TanStack Start, tests, or multi-tenant apps, that `QueryClient` is often request-local or route-local rather than module-global.
 
-Keep shared collection configuration in a factory function that accepts the runtime `QueryClient`, then call that factory wherever the scoped client is available:
+Keep shared collection configuration in a factory function that accepts the runtime `QueryClient`:
 
 ```typescript
 import { QueryClient } from "@tanstack/query-core"
@@ -82,9 +82,35 @@ export function todoCollectionOptions(queryClient: QueryClient) {
   })
 }
 
-const queryClient = getRequestQueryClient()
-const todosCollection = createCollection(todoCollectionOptions(queryClient))
+function createTodosCollection(queryClient: QueryClient) {
+  return createCollection(todoCollectionOptions(queryClient))
+}
 ```
+
+Create the collection once for each scoped `QueryClient` and parameter set, then reuse that `Collection` instance. Creating multiple collections with the same `QueryClient` and `queryKey` gives each collection its own materialized state, lifecycle, subscriptions, and optimistic mutations.
+
+In request-scoped environments, store the collection in request or router context. For client-side scopes, memoize by `QueryClient`:
+
+```typescript
+type TodosCollection = ReturnType<typeof createTodosCollection>
+
+const collectionsByClient = new WeakMap<QueryClient, TodosCollection>()
+
+export function getTodosCollection(
+  queryClient: QueryClient,
+): TodosCollection {
+  let collection = collectionsByClient.get(queryClient)
+
+  if (!collection) {
+    collection = createTodosCollection(queryClient)
+    collectionsByClient.set(queryClient, collection)
+  }
+
+  return collection
+}
+```
+
+Avoid calling `createCollection(todoCollectionOptions(queryClient))` independently during render or in each consumer. Share the stable collection instance for the lifetime of that `QueryClient` scope.
 
 The same pattern works for scoped or parameterized collections. Pass route params, a tenant ID, or filters into the factory alongside the `QueryClient`:
 
@@ -102,7 +128,9 @@ export function projectTodosCollectionOptions(
 }
 ```
 
-This keeps SSR and request-scoped code from sharing a global `QueryClient`.
+For parameterized collections, memoize by both the scoped `QueryClient` and the parameter tuple. If a long-lived scope can create unbounded parameter sets, add eviction or dispose collections when they are no longer needed.
+
+This keeps SSR and request-scoped code from sharing a global `QueryClient` while keeping each collection instance stable within its scope.
 
 ### Query Options
 

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -54,6 +54,56 @@ The `queryCollectionOptions` function accepts the following options:
 - `queryClient`: TanStack Query client instance
 - `getKey`: Function to extract the unique key from an item
 
+### Creating Collection Options from a Runtime QueryClient
+
+`queryCollectionOptions` needs a `queryClient` when the collection options are created. In SSR, TanStack Start, tests, or multi-tenant apps, that `QueryClient` is often request-local or route-local rather than module-global.
+
+Keep shared collection configuration in a factory function that accepts the runtime `QueryClient`, then call that factory wherever the scoped client is available:
+
+```typescript
+import { QueryClient } from "@tanstack/query-core"
+import { createCollection } from "@tanstack/db"
+import { queryCollectionOptions } from "@tanstack/query-db-collection"
+
+interface Todo {
+  id: string
+  title: string
+}
+
+export function todoCollectionOptions(queryClient: QueryClient) {
+  return queryCollectionOptions<Todo>({
+    queryKey: ["todos"],
+    queryFn: async () => {
+      const response = await fetch("/api/todos")
+      return response.json() as Promise<Array<Todo>>
+    },
+    queryClient,
+    getKey: (todo) => todo.id,
+  })
+}
+
+const queryClient = getRequestQueryClient()
+const todosCollection = createCollection(todoCollectionOptions(queryClient))
+```
+
+The same pattern works for scoped or parameterized collections. Pass route params, a tenant ID, or filters into the factory alongside the `QueryClient`:
+
+```typescript
+export function projectTodosCollectionOptions(
+  queryClient: QueryClient,
+  projectId: string,
+) {
+  return queryCollectionOptions<Todo>({
+    queryKey: ["projects", projectId, "todos"],
+    queryFn: () => fetchProjectTodos(projectId),
+    queryClient,
+    getKey: (todo) => todo.id,
+  })
+}
+```
+
+This keeps SSR and request-scoped code from sharing a global `QueryClient`.
+
 ### Query Options
 
 Query Collections use TanStack Query internally, but `queryCollectionOptions` is not a full `QueryObserverOptions` pass-through. It exposes only the Query options supported by the collection adapter. Fields that affect row materialization, collection identity, and synchronization are handled by the adapter itself.


### PR DESCRIPTION
## Summary

Document the recommended factory pattern for using `@tanstack/query-db-collection` with runtime-scoped `QueryClient` instances. This shows users in SSR, TanStack Start, test, and multi-tenant environments how to avoid sharing a module-global `QueryClient`.

## Approach

- Add a new Query Collection docs section for creating collection options from a runtime `QueryClient`.
- Show a plain TypeScript factory that accepts the scoped `QueryClient` and returns `queryCollectionOptions(...)`.
- Include a parameterized collection example for route params, tenant IDs, or filters.
- Add a patch changeset for `@tanstack/query-db-collection` because the docs are package-specific.

## Key Invariants

- `queryCollectionOptions` still receives `queryClient` when collection options are created.
- Request-local or route-local environments do not need to use a module-global `QueryClient`.
- This is docs-only and does not introduce a new public API.

## Non-goals

- No runtime binding API is added.
- No framework-specific TanStack Start APIs are documented beyond the general request-local pattern.
- No production code changes are included.

## Trade-offs

The docs recommend a plain factory function rather than adding API sugar. This keeps the guidance usable today while leaving room for a future API only if repeated examples show that boilerplate or type inference becomes a problem.

## Verification

```bash
pnpm prettier --write docs/collections/query-collection.md
pnpm exec tsx scripts/verify-links.ts
git diff --check
```

Also attempted:

```bash
pnpm test:docs
pnpm test
```

`pnpm test:docs` failed because the package script runs `node scripts/verify-links.ts`, and Node rejected the `.ts` entrypoint with `ERR_UNKNOWN_FILE_EXTENSION`. Running the same script with `tsx` passed.

`pnpm test` failed in `packages/offline-transactions` because Vite could not resolve the `@tanstack/db` package entry. This appears unrelated to this docs-only change.

## Files changed

- `docs/collections/query-collection.md`: Adds runtime `QueryClient` factory guidance and examples.
- `.changeset/document-runtime-query-client-factory.md`: Adds a patch changeset for `@tanstack/query-db-collection` docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating collection options using a request- or route-scoped QueryClient instead of a module-global singleton.
  * Included factory-pattern examples (including `QueryClient` parameterization) and advice for memoizing collections per scoped client and parameter set for stable behavior in SSR/tests/multi-tenant apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->