### PR TITLE
fix: use patch bump for adapter helpers

### DIFF
--- a/.changeset/extract-adapter-helpers.md
+++ b/.changeset/extract-adapter-helpers.md
@@ -1,5 +1,5 @@
 ---
-'@tanstack/db': minor
+'@tanstack/db': patch
 '@tanstack/react-db': patch
 '@tanstack/vue-db': patch
 '@tanstack/svelte-db': patch


### PR DESCRIPTION
The adapter helper extraction was accidentally marked as a minor bump for `@tanstack/db`, causing the version-packages PR to propose `0.7.0`.

Change the changeset to a patch bump so the release PR produces `0.6.15`.

Verified with `changeset status`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the release version increment for `@tanstack/db` from minor to patch.
  * No user-facing functionality or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->