### PR TITLE
docs(query-db-collection): document scoped collection factories

### DIFF
--- a/.changeset/document-scoped-query-factories.md
+++ b/.changeset/document-scoped-query-factories.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-db-collection': patch
+---
+
+Document business-scoped Query Collection factories, including stable memoization and lifecycle guidance, while distinguishing business scope from relational subset loading.

--- a/.changeset/document-scoped-query-factories.md
+++ b/.changeset/document-scoped-query-factories.md
@@ -1,5 +1,0 @@
----
-'@tanstack/query-db-collection': patch
----
-
-Document business-scoped Query Collection factories, including stable memoization and lifecycle guidance, while distinguishing business scope from relational subset loading.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -112,25 +112,79 @@ export function getTodosCollection(
 
 Avoid calling `createCollection(todoCollectionOptions(queryClient))` independently during render or in each consumer. Share the stable collection instance for the lifetime of that `QueryClient` scope.
 
-The same pattern works for scoped or parameterized collections. Pass route params, a tenant ID, or filters into the factory alongside the `QueryClient`:
+This keeps SSR and request-scoped code from sharing a global `QueryClient` while keeping each collection instance stable within its scope.
+
+### Business-Scoped Collection Factories
+
+A tenant, project, account, or route parameter defines a **business scope**: it determines which server resource the collection represents. Put that scope in both the Query key and the query function. This extends the [runtime `QueryClient` factory pattern](#creating-collection-options-from-a-runtime-queryclient) with another explicit factory parameter:
 
 ```typescript
-export function projectTodosCollectionOptions(
+interface Todo {
+  id: string
+  title: string
+  projectId: string
+}
+
+async function fetchProjectTodos(projectId: string): Promise<Array<Todo>> {
+  const response = await fetch(`/api/projects/${projectId}/todos`)
+  return response.json()
+}
+
+export function createProjectTodosCollection(
   queryClient: QueryClient,
   projectId: string,
 ) {
-  return queryCollectionOptions<Todo>({
-    queryKey: ["projects", projectId, "todos"],
-    queryFn: () => fetchProjectTodos(projectId),
-    queryClient,
-    getKey: (todo) => todo.id,
-  })
+  return createCollection(
+    queryCollectionOptions<Todo>({
+      queryKey: ["projects", projectId, "todos"],
+      queryFn: () => fetchProjectTodos(projectId),
+      queryClient,
+      getKey: (todo) => todo.id,
+      staleTime: 30_000,
+    })
+  )
 }
 ```
 
-For parameterized collections, memoize by both the scoped `QueryClient` and the parameter tuple. If a long-lived scope can create unbounded parameter sets, add eviction or dispose collections when they are no longer needed.
+The scope is part of the collection's identity. Memoize by both the `QueryClient` and a stable scope key so consumers of the same project share one collection:
 
-This keeps SSR and request-scoped code from sharing a global `QueryClient` while keeping each collection instance stable within its scope.
+```typescript
+type ProjectTodosCollection = ReturnType<
+  typeof createProjectTodosCollection
+>
+
+const projectCollections = new WeakMap<
+  QueryClient,
+  Map<string, ProjectTodosCollection>
+>()
+
+export function getProjectTodosCollection(
+  queryClient: QueryClient,
+  projectId: string,
+): ProjectTodosCollection {
+  let collectionsByProject = projectCollections.get(queryClient)
+
+  if (!collectionsByProject) {
+    collectionsByProject = new Map()
+    projectCollections.set(queryClient, collectionsByProject)
+  }
+
+  let collection = collectionsByProject.get(projectId)
+
+  if (!collection) {
+    collection = createProjectTodosCollection(queryClient, projectId)
+    collectionsByProject.set(projectId, collection)
+  }
+
+  return collection
+}
+```
+
+For multiple scope values, use a collision-safe stable key (or nested maps) containing every value. Do not call the factory on each render. In a long-lived client, scopes such as user-selected projects may grow without bound; evict entries that are no longer needed and call `await collection.cleanup()` when your application owns their lifecycle. Request-local maps can instead be discarded with the request.
+
+Business scope is separate from a **relational subset** requested by a live query. With `syncMode: "on-demand"`, `LoadSubsetOptions` describes predicates, ordering, limits, and offsets within one business-scoped collection. The collection passes those options to `queryFn` through `ctx.meta.loadSubsetOptions` and uses them to manage subset Query keys. See [QueryFn and Predicate Push-Down](#queryfn-and-predicate-push-down).
+
+Do not create another collection for every `where`, `orderBy`, or `limit`. Reuse the project-scoped collection and let on-demand subset loading represent those relational queries. Create separate collections only when the server resources are genuinely distinct business scopes.
 
 ### Query Options
 

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -116,7 +116,7 @@ This keeps SSR and request-scoped code from sharing a global `QueryClient` while
 
 ### Business-Scoped Collection Factories
 
-A tenant, project, account, or route parameter defines a **business scope**: it determines which server resource the collection represents. Put that scope in both the Query key and the query function. This extends the [runtime `QueryClient` factory pattern](#creating-collection-options-from-a-runtime-queryclient) with another explicit factory parameter:
+A tenant, project, account, or route parameter can define a **business scope**: the server resource that a collection represents. Include the scope in both the Query key and `queryFn`. This extends the [runtime `QueryClient` factory pattern](#creating-collection-options-from-a-runtime-queryclient) with an explicit scope parameter:
 
 ```typescript
 interface Todo {
@@ -140,7 +140,6 @@ export function createProjectTodosCollection(
       queryFn: () => fetchProjectTodos(projectId),
       queryClient,
       getKey: (todo) => todo.id,
-      staleTime: 30_000,
     })
   )
 }
@@ -149,9 +148,7 @@ export function createProjectTodosCollection(
 The scope is part of the collection's identity. Memoize by both the `QueryClient` and a stable scope key so consumers of the same project share one collection:
 
 ```typescript
-type ProjectTodosCollection = ReturnType<
-  typeof createProjectTodosCollection
->
+type ProjectTodosCollection = ReturnType<typeof createProjectTodosCollection>
 
 const projectCollections = new WeakMap<
   QueryClient,
@@ -180,11 +177,11 @@ export function getProjectTodosCollection(
 }
 ```
 
-For multiple scope values, use a collision-safe stable key (or nested maps) containing every value. Do not call the factory on each render. In a long-lived client, scopes such as user-selected projects may grow without bound; evict entries that are no longer needed and call `await collection.cleanup()` when your application owns their lifecycle. Request-local maps can instead be discarded with the request.
+For multiple scope values, use nested maps or a collision-safe stable key that includes every value. Do not call the factory on each render. In a long-lived client, user-selected scopes can make the map grow without bound. Remove unused entries and call `await collection.cleanup()` when your application owns their lifecycle. Request-local maps can be discarded with the request.
 
-Business scope is separate from a **relational subset** requested by a live query. With `syncMode: "on-demand"`, `LoadSubsetOptions` describes predicates, ordering, limits, and offsets within one business-scoped collection. The collection passes those options to `queryFn` through `ctx.meta.loadSubsetOptions` and uses them to manage subset Query keys. See [QueryFn and Predicate Push-Down](#queryfn-and-predicate-push-down).
+A business scope is separate from a **relational subset** requested by a live query. With `syncMode: "on-demand"`, `LoadSubsetOptions` describes predicates, ordering, limits, and offsets within one business-scoped collection. These options reach `queryFn` through `ctx.meta.loadSubsetOptions` and determine the subset Query keys. See [QueryFn and Predicate Push-Down](#queryfn-and-predicate-push-down).
 
-Do not create another collection for every `where`, `orderBy`, or `limit`. Reuse the project-scoped collection and let on-demand subset loading represent those relational queries. Create separate collections only when the server resources are genuinely distinct business scopes.
+Do not create a collection for each `where`, `orderBy`, or `limit`. Reuse the business-scoped collection and let on-demand loading represent those subsets. Create separate collections only for distinct server resources.
 
 ### Query Options
 


### PR DESCRIPTION
## Summary

Document how to create Query Collections for tenant, project, account, and route-level business scopes. The new guidance helps users preserve collection identity and lifecycle correctly without confusing business scope with relational subset loading.

## Approach

- Add a typed project-scoped factory that accepts both a runtime `QueryClient` and a scope parameter.
- Include the scope in the flat top-level `queryKey` and `queryFn`.
- Show stable memoization keyed by both `QueryClient` and scope.
- Explain eviction and `collection.cleanup()` for unbounded, long-lived scope caches.
- Keep relational predicates, ordering, limits, and offsets in `LoadSubsetOptions` rather than creating collections per subset.
- Link back to the existing runtime `QueryClient` and predicate push-down guidance instead of duplicating it.

## Key invariants

- A collection is reused for the same `QueryClient` and business scope.
- Distinct server resources use distinct business-scoped collections.
- Relational subsets do not become collection identity and do not cause collection recreation.
- Examples use the current flat `queryCollectionOptions` API.

## Non-goals

- No runtime or type changes.
- No `.bind(...)` API or nested query configuration.
- No recommendation to recreate collections per render or relational subset.

## Trade-offs

The example uses explicit `WeakMap<QueryClient, Map<scope, Collection>>` memoization. This is more verbose than an implicit binding API, but keeps dependencies and lifecycle ownership visible while requiring no new runtime abstraction.

## Verification

```bash
pnpm prettier docs/collections/query-collection.md --check
pnpm exec tsx scripts/verify-links.ts
git diff origin/main --check
```

All commands pass. The repository's `pnpm test:docs` wrapper cannot directly execute `scripts/verify-links.ts` under the current Node environment, so the same verifier was run through the installed `tsx` runner.

## Files changed

- `docs/collections/query-collection.md` — adds business-scoped factory, memoization, lifecycle, and relational-subset guidance.
- `.changeset/document-scoped-query-factories.md` — records the documentation update for `@tanstack/query-db-collection`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating business-scoped query collections.
  * Clarified how scope identifiers should affect collection queries.
  * Added memoization and lifecycle recommendations for reusing scoped collections.
  * Explained the difference between business-scoped collections and relational subsets.
  * Updated examples to discourage creating separate collections for every filter, sort, or limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->