### PR TITLE
fix(db): restore query typechecking for generic collection row types

### DIFF
--- a/.changeset/generic-row-type-refs.md
+++ b/.changeset/generic-row-type-refs.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Fix queries failing to typecheck when the collection's row type is a generic type parameter. Refs inside where/join/select callbacks now expose the properties guaranteed by the type parameter's constraint, and subqueries over generic collections can be used as join sources again (regression introduced in 0.6.6).

--- a/packages/db/src/query/builder/types.ts
+++ b/packages/db/src/query/builder/types.ts
@@ -117,7 +117,7 @@ export type SchemaFromSource<T extends Source> = Prettify<{
   [K in keyof T]: T[K] extends CollectionImpl<any, any, any, any, any>
     ? InferCollectionType<T[K]>
     : T[K] extends QueryBuilder<infer TContext>
-      ? GetResult<TContext>
+      ? GetRawResult<TContext>
       : never
 }>
 
@@ -662,8 +662,11 @@ type ValueOfUnion<T, K extends PropertyKey> = T extends unknown
     ? T[K]
     : never
   : never
-type RefForContextValue<T, Nullable extends boolean = false> =
-  IsPlainObject<T> extends true ? Ref<T, Nullable> : RefLeaf<T, Nullable>
+type RefForContextValue<T, Nullable extends boolean = false> = T extends unknown
+  ? IsPlainObject<T> extends true
+    ? Ref<T, Nullable>
+    : RefLeaf<T, Nullable>
+  : never
 type RefsSchemaForContext<TContext extends Context> =
   IsExactlyUndefined<TContext[`refsSchema`]> extends true
     ? TContext[`schema`]

--- a/packages/db/tests/query/generic-collection.test-d.ts
+++ b/packages/db/tests/query/generic-collection.test-d.ts
@@ -1,0 +1,53 @@
+import { describe, test } from 'vitest'
+import { createLiveQueryCollection, eq } from '../../src/query/index.js'
+import type { Collection } from '../../src/collection/index.js'
+
+// Regression tests for https://github.com/TanStack/db/issues/1677
+// Queries over a Collection<T> where T is an unresolved generic type parameter
+// must still expose the properties guaranteed by T's constraint inside
+// where/join/select callbacks. This worked in 0.6.5 and broke in 0.6.6.
+
+describe(`queries over generic collection row types`, () => {
+  test(`where callback can access properties guaranteed by the type constraint`, () => {
+    function findById<T extends { id: string }>(
+      items: Collection<T, string>,
+      id: string,
+    ) {
+      return createLiveQueryCollection((q) =>
+        q.from({ items }).where(({ items: itemsRef }) => eq(itemsRef.id, id)),
+      )
+    }
+
+    void findById
+  })
+
+  test(`select callback can access properties guaranteed by the type constraint`, () => {
+    function selectIds<T extends { id: string }>(items: Collection<T, string>) {
+      return createLiveQueryCollection((q) =>
+        q.from({ items }).select(({ items: itemsRef }) => ({
+          id: itemsRef.id,
+        })),
+      )
+    }
+
+    void selectIds
+  })
+
+  test(`subquery over a generic collection can be used as a join source`, () => {
+    function withDiff<T extends { id: string }>(
+      a: Collection<T, string>,
+      b: Collection<{ id: string }, string>,
+    ) {
+      return createLiveQueryCollection((q) => {
+        const sub = q.from({ a })
+        return q
+          .from({ b })
+          .leftJoin({ sub }, ({ b: bRef, sub: subRef }) =>
+            eq(bRef.id, subRef.id),
+          )
+      })
+    }
+
+    void withDiff
+  })
+})


### PR DESCRIPTION
This restores TypeScript query-builder support for collections whose row type is an unresolved generic parameter. Generic `where`, `select`, and subquery join-source callbacks once again expose fields guaranteed by the generic constraint, fixing the regression introduced in v0.6.6.

## Root cause

The query builder decides whether a callback value should be represented as a property-bearing `Ref` or an opaque `RefLeaf` through a conditional type. For an unresolved generic such as `T extends { id: string }`, the conditional was deferred into a union containing both possibilities. Because `RefLeaf` has no row properties, TypeScript rejected access to fields such as `id` even though the generic constraint guarantees them.

Subquery sources had an additional mapped `Prettify` layer that prevented TypeScript from resolving the generic constraint through the ref conditional.

## Approach

- Make `RefForContextValue` distributive so TypeScript can evaluate the ref shape through the generic constraint.
- Use the unwrapped `GetRawResult` for internal subquery schemas, while retaining `GetResult` for final user-facing result types.
- Add type regressions for direct `where`, direct `select`, and generic subqueries used as join sources.

## Key invariants

- A constraint such as `T extends { id: string }` must expose `id` inside supported query callbacks.
- Concrete result types retain their existing IDE-friendly presentation.
- The internal schema change does not alter runtime query behavior.

## Non-goals

This PR restores the three cases reported in #1677. Broader generic-constraint propagation through nullable joined aliases and both forms of `unionAll` is tracked separately in #1679; resolving those cases safely requires additional type-system work and must preserve existing heterogeneous union and join inference.

## Trade-offs

`GetRawResult` is used only on the internal subquery schema path. Final results continue to use the prettified representation, avoiding a user-facing type-display regression.

## Verification

The new type tests were added first and verified RED against the regressed implementation, then GREEN after the fix.

```bash
pnpm --filter @tanstack/db test
```

## Files changed

- `packages/db/src/query/builder/types.ts` — preserves generic constraints through callback ref and subquery schema construction.
- `packages/db/tests/query/generic-collection.test-d.ts` — covers generic filtering, selection, and subquery join sources.
- `.changeset/generic-row-type-refs.md` — records the patch release impact.

---

Fixes #1677

Follow-up: #1679
