### PR TITLE
test: cover late query readiness rejection

### DIFF
--- a/packages/query-db-collection/tests/query.test.ts
+++ b/packages/query-db-collection/tests/query.test.ts
@@ -2466,6 +2466,38 @@ describe(`QueryCollection`, () => {
         await collection.cleanup()
       })
 
+      it(`keeps an unloaded preload resolved when its pending request later rejects`, async () => {
+        const deferred = createDeferred<Array<TestItem>>()
+        const collection = createCollection(
+          queryCollectionOptions<TestItem>({
+            id: `late-subset-rejection-test`,
+            queryClient,
+            queryKey: [`late-subset-rejection-test`],
+            queryFn: () => deferred.promise,
+            getKey,
+            syncMode: `on-demand`,
+          }),
+        )
+        const liveQuery = createSubset(collection)
+        const preloadPromise = liveQuery.preload()
+
+        await vi.waitFor(() => expect(queryClient.isFetching()).toBe(1))
+        await liveQuery.cleanup()
+
+        const subsetQuery = queryClient.getQueryCache().findAll({
+          queryKey: [`late-subset-rejection-test`],
+        })[0]
+        expect(subsetQuery?.getObserversCount() ?? 0).toBe(0)
+        await expect(preloadPromise).resolves.toBeUndefined()
+
+        deferred.reject(new Error(`Late query failure`))
+        await vi.waitFor(() => expect(queryClient.isFetching()).toBe(0))
+
+        expect(collection.size).toBe(0)
+        expect(subsetQuery?.getObserversCount() ?? 0).toBe(0)
+        await collection.cleanup()
+      })
+
       it(`preserves an active subset across cache removal and accepts a late notification from its detached observer`, async () => {
         const queryKey = [`cache-removal-late-notification-test`]
         const collection = createCollection(


### PR DESCRIPTION
Adds the missing rejection-path lifecycle coverage for query-driven subset cleanup. This is a test-only regression lock with no user-visible behavior or package API change.

## Reviewer guidance

### Root cause

PR #1673 added bookkeeping for temporary readiness listeners and covered successful late request settlement, but did not directly exercise an in-flight query that rejects after its subset has been unloaded.

### Approach

- Start an on-demand subset preload backed by a deferred query promise.
- Clean up the live query while Query Core is still fetching.
- Assert cleanup resolves the retained preload and releases all observers.
- Reject the deferred request and verify that no row materializes, no observer returns, and no unhandled rejection escapes the test.

### Key invariants

- Live-query cleanup settles the original preload before the underlying request settles.
- An unloaded subset has zero Query Core observers.
- Late rejection cannot rematerialize collection rows or leak an observer.

### Non-goals

- No production lifecycle or ownership behavior changes.
- No changes to `loadSubset`, query ownership maps, or request cancellation semantics.

### Trade-offs

The test mirrors the adjacent late-success lifecycle test instead of introducing new helpers, keeping the regression scenario explicit and localized.

## Verification

```bash
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts -t "keeps an unloaded preload resolved when its pending request later rejects" --typecheck.enabled=false
pnpm --filter @tanstack/query-db-collection test tests/query.test.ts --typecheck.enabled=false
pnpm exec prettier --check packages/query-db-collection/tests/query.test.ts
git diff --check
```

- Focused test: 1 passed, 118 skipped
- Full query test file: 119 passed

## Files changed

- `packages/query-db-collection/tests/query.test.ts`: adds the deferred rejection lifecycle regression test.

---
Follow-up to RFC #1643 and #1673.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query cleanup handling when a pending subset preload request is cancelled.
  * Ensured cancelled preload operations resolve safely without repopulating collections or leaving observers attached.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->