### PR TITLE
fix(db): materialize includes into parent rows before commit

### DIFF
--- a/.changeset/heavy-pandas-tell.md
+++ b/.changeset/heavy-pandas-tell.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Materialize includes into parent rows before they commit so emitted change events already carry their included values. The includes flush ran only after the parent live query collection committed, patching stored rows in place without emitting; any consumer that copies rows at emit time — most commonly another live query layered on the collection, the shape framework adapters produce for component-level queries — captured the pre-patch row with its included fields unset. A parent-only update (no child changes) never triggered the follow-up re-emit, so those consumers kept empty includes until an unrelated child change recomputed the row. Fixes #1635.

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -808,6 +808,11 @@ export class CollectionConfigBuilder<
 
       // 1. Flush parent changes
       if (hasParentChanges) {
+        // Materialize the current includes state into the new parent rows
+        // before they commit, so the emitted change events already carry
+        // their included values (the includes flush below patches stored
+        // rows in place without emitting).
+        patchParentChangesFromIncludes(includesState, changesToApply)
         begin()
         changesToApply.forEach(this.applyChanges.bind(this, config))
         commit()
@@ -1236,6 +1241,47 @@ type ChildCollectionEntry = {
 
 function materializesInline(state: IncludesOutputState): boolean {
   return state.materialization !== `collection`
+}
+
+/**
+ * Materializes the current includes state into freshly computed parent rows
+ * before they are committed, so the emitted change events already carry
+ * their included values.
+ *
+ * The post-commit includes flush patches stored parent rows in place without
+ * emitting an event, which consumers that copy rows at emit time (e.g.
+ * another live query layered on this collection) never observe: a
+ * parent-only update would wipe their included fields until an unrelated
+ * child change re-emitted the row.
+ */
+function patchParentChangesFromIncludes(
+  includesState: Array<IncludesOutputState>,
+  parentChanges: Map<unknown, Changes<any>>,
+): void {
+  for (const state of includesState) {
+    if (!materializesInline(state)) continue
+    for (const [, changes] of parentChanges) {
+      if (changes.inserts > 0) {
+        const parentResult = changes.value
+        const routing = parentResult[INCLUDES_ROUTING]?.[state.fieldName]
+        const correlationKey = routing?.correlationKey
+        if (correlationKey != null) {
+          const routingKey = computeRoutingKey(
+            correlationKey,
+            routing?.parentContext ?? null,
+          )
+          setIncludedValue(
+            parentResult,
+            state.resultPath,
+            materializeIncludedValue(
+              state,
+              state.childRegistry.get(routingKey),
+            ),
+          )
+        }
+      }
+    }
+  }
 }
 
 function materializeIncludedValue(

--- a/packages/db/src/query/live/collection-config-builder.ts
+++ b/packages/db/src/query/live/collection-config-builder.ts
@@ -808,10 +808,6 @@ export class CollectionConfigBuilder<
 
       // 1. Flush parent changes
       if (hasParentChanges) {
-        // Materialize the current includes state into the new parent rows
-        // before they commit, so the emitted change events already carry
-        // their included values (the includes flush below patches stored
-        // rows in place without emitting).
         patchParentChangesFromIncludes(includesState, changesToApply)
         begin()
         changesToApply.forEach(this.applyChanges.bind(this, config))
@@ -1244,25 +1240,19 @@ function materializesInline(state: IncludesOutputState): boolean {
 }
 
 /**
- * Materializes the current includes state into freshly computed parent rows
- * before they are committed, so the emitted change events already carry
+ * Materializes the current includes state into freshly computed parent
+ * change values, so the change events emitted on commit already carry
  * their included values.
- *
- * The post-commit includes flush patches stored parent rows in place without
- * emitting an event, which consumers that copy rows at emit time (e.g.
- * another live query layered on this collection) never observe: a
- * parent-only update would wipe their included fields until an unrelated
- * child change re-emitted the row.
  */
-function patchParentChangesFromIncludes(
+function patchParentChangesFromIncludes<TResult extends object>(
   includesState: Array<IncludesOutputState>,
-  parentChanges: Map<unknown, Changes<any>>,
+  parentChanges: Map<unknown, Changes<TResult>>,
 ): void {
   for (const state of includesState) {
     if (!materializesInline(state)) continue
     for (const [, changes] of parentChanges) {
       if (changes.inserts > 0) {
-        const parentResult = changes.value
+        const parentResult = changes.value as Record<string | symbol, any>
         const routing = parentResult[INCLUDES_ROUTING]?.[state.fieldName]
         const correlationKey = routing?.correlationKey
         if (correlationKey != null) {

--- a/packages/db/tests/query/includes.test.ts
+++ b/packages/db/tests/query/includes.test.ts
@@ -730,21 +730,16 @@ describe(`includes subqueries`, () => {
       )
       await collection.preload()
 
-      // A second live query layered on top copies rows at emit time — the
-      // shape framework adapters produce for component-level queries. The
-      // emitted parent row must already carry its materialized includes: a
-      // post-commit in-place patch is invisible to this layer.
       const layered = createLiveQueryCollection((q) =>
         q.from({ row: collection }),
       )
       await layered.preload()
 
-      expect(sortedPlainRows((layered.get(1) as any).issues)).toEqual([
+      expect(sortedPlainRows(layered.get(1)!.issues)).toEqual([
         { id: 10, title: `Bug in Alpha` },
         { id: 11, title: `Feature for Alpha` },
       ])
 
-      // Update only the parent row; no child rows change.
       projects.utils.begin()
       projects.utils.write({
         type: `update`,
@@ -752,11 +747,11 @@ describe(`includes subqueries`, () => {
       })
       projects.utils.commit()
 
-      await new Promise((resolve) => setTimeout(resolve, 10))
+      await vi.waitFor(() => {
+        expect(layered.get(1)?.name).toBe(`Alpha renamed`)
+      })
 
-      const renamed = layered.get(1) as any
-      expect(renamed.name).toBe(`Alpha renamed`)
-      expect(sortedPlainRows(renamed.issues)).toEqual([
+      expect(sortedPlainRows(layered.get(1)!.issues)).toEqual([
         { id: 10, title: `Bug in Alpha` },
         { id: 11, title: `Feature for Alpha` },
       ])

--- a/packages/db/tests/query/includes.test.ts
+++ b/packages/db/tests/query/includes.test.ts
@@ -711,6 +711,58 @@ describe(`includes subqueries`, () => {
     })
   })
 
+  describe(`parent-only updates`, () => {
+    it(`keeps materialized includes on rows observed through a layered live query`, async () => {
+      const collection = createLiveQueryCollection((q) =>
+        q.from({ p: projects }).select(({ p }) => ({
+          id: p.id,
+          name: p.name,
+          issues: materialize(
+            q
+              .from({ i: issues })
+              .where(({ i }) => eq(i.projectId, p.id))
+              .select(({ i }) => ({
+                id: i.id,
+                title: i.title,
+              })),
+          ),
+        })),
+      )
+      await collection.preload()
+
+      // A second live query layered on top copies rows at emit time — the
+      // shape framework adapters produce for component-level queries. The
+      // emitted parent row must already carry its materialized includes: a
+      // post-commit in-place patch is invisible to this layer.
+      const layered = createLiveQueryCollection((q) =>
+        q.from({ row: collection }),
+      )
+      await layered.preload()
+
+      expect(sortedPlainRows((layered.get(1) as any).issues)).toEqual([
+        { id: 10, title: `Bug in Alpha` },
+        { id: 11, title: `Feature for Alpha` },
+      ])
+
+      // Update only the parent row; no child rows change.
+      projects.utils.begin()
+      projects.utils.write({
+        type: `update`,
+        value: { id: 1, name: `Alpha renamed` },
+      })
+      projects.utils.commit()
+
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      const renamed = layered.get(1) as any
+      expect(renamed.name).toBe(`Alpha renamed`)
+      expect(sortedPlainRows(renamed.issues)).toEqual([
+        { id: 10, title: `Bug in Alpha` },
+        { id: 11, title: `Feature for Alpha` },
+      ])
+    })
+  })
+
   describe(`inner join filtering`, () => {
     it(`only shows children for parents matching a WHERE clause`, async () => {
       const collection = createLiveQueryCollection((q) =>


### PR DESCRIPTION
## 🎯 Changes

Fixes #1635.

Live query includes are materialized into parent rows only **after** the parent collection commits: `flushIncludesState` patches the stored row in place (`setIncludedValue`) without emitting an event, and the follow-up re-emit (`inlineReEmitKeys`) only fires for correlation keys with pending **child** changes.

Any consumer that copies rows at emit time never observes that patch. The most common shape is another live query layered on the collection — which is what every framework adapter produces for component-level queries (`useLiveQuery((q) => q.from({ row: myLiveQuery }))`). For those consumers, a **parent-only update** (e.g. a status column change synced from the server, no child rows touched) re-emits the parent row with every included field unset, and since no child change follows, they keep the empty includes until an unrelated child change recomputes the row. This is the "nested includes are undefined on next render after collection.update, a forced re-render brings them back" behavior reported in #1635.

The fix: materialize the current includes state into the new parent change values **before** `begin()`/`commit()`, so the emitted events already carry the included values. The post-commit flush then re-applies the same values idempotently (it still owns child-collection bookkeeping and registry maintenance), and the child-change re-emit path is unchanged. Only inline materializations (`array`/`singleton`/`concat`) are patched pre-commit; `collection` materialization still attaches in the post-commit flush.

New regression test: `includes subqueries > parent-only updates > keeps materialized includes on rows observed through a layered live query` — fails on `main`, passes with this change.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Materialize behavior so included child fields are populated on parent rows before change events are emitted.
  * Ensured included values remain correct after parent-only updates, including when used in layered live queries.
  * Prevented included fields from temporarily appearing empty until a subsequent child change occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->