### PR TITLE
perf(db): skip unchanged index updates

### DIFF
--- a/.changeset/quick-trees-rest.md
+++ b/.changeset/quick-trees-rest.md
@@ -2,5 +2,6 @@
 '@tanstack/db': patch
 ---
 
-Skip unchanged index writes, cache index evaluators, and preserve key counts
-after failed removals.
+Skip unchanged index writes while preserving index bookkeeping after failed
+removals. Cache index evaluators and avoid object normalization work for
+primitive values to reduce update overhead.

--- a/.changeset/quick-trees-rest.md
+++ b/.changeset/quick-trees-rest.md
@@ -2,4 +2,5 @@
 '@tanstack/db': patch
 ---
 
-Skip index writes when an update leaves the indexed value unchanged.
+Skip unchanged index writes, cache index evaluators, and preserve key counts
+after failed removals.

--- a/.changeset/quick-trees-rest.md
+++ b/.changeset/quick-trees-rest.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Skip index writes when an update leaves the indexed value unchanged.

--- a/packages/db/src/indexes/base-index.ts
+++ b/packages/db/src/indexes/base-index.ts
@@ -1,6 +1,7 @@
 import { compileSingleRowExpression } from '../query/compiler/evaluators.js'
 import { comparisonFunctions } from '../query/builder/functions.js'
 import { DEFAULT_COMPARE_OPTIONS, deepEquals } from '../utils.js'
+import type { CompiledSingleRowExpression } from '../query/compiler/evaluators.js'
 import type { RangeQueryOptions } from './btree-index.js'
 import type { CompareOptions } from '../query/builder/types.js'
 import type { BasicExpression, OrderByDirection } from '../query/ir.js'
@@ -99,6 +100,7 @@ export abstract class BaseIndex<
   protected totalLookupTime = 0
   protected lastUpdated = new Date()
   protected compareOptions: CompareOptions
+  private compiledIndexEvaluator: CompiledSingleRowExpression | undefined
   /**
    * Set by subclasses when constructed with a user-supplied comparator, whose
    * ordering may not match the WHERE evaluator's relational operators.
@@ -210,7 +212,8 @@ export abstract class BaseIndex<
   protected abstract initialize(options?: any): void
 
   protected evaluateIndexExpression(item: any): any {
-    const evaluator = compileSingleRowExpression(this.expression)
+    const evaluator = (this.compiledIndexEvaluator ??=
+      compileSingleRowExpression(this.expression))
     return evaluator(item as Record<string, unknown>)
   }
 

--- a/packages/db/src/indexes/basic-index.ts
+++ b/packages/db/src/indexes/basic-index.ts
@@ -1,4 +1,8 @@
-import { defaultComparator, normalizeValue } from '../utils/comparison.js'
+import {
+  areSameValueZeroEqual,
+  defaultComparator,
+  normalizeValue,
+} from '../utils/comparison.js'
 import {
   deleteInSortedArray,
   findInsertPositionInArray,
@@ -89,9 +93,17 @@ export class BasicIndex<
 
     const normalizedValue = normalizeValue(indexedValue)
 
-    if (this.valueMap.has(normalizedValue)) {
+    this.addToBucket(key, normalizedValue)
+
+    this.indexedKeys.add(key)
+    this.updateTimestamp()
+  }
+
+  private addToBucket(key: TKey, normalizedValue: any): void {
+    const keySet = this.valueMap.get(normalizedValue)
+    if (keySet) {
       // Value already exists, just add the key to the set
-      this.valueMap.get(normalizedValue)!.add(key)
+      keySet.add(key)
     } else {
       // New value - add to map and insert into sorted array
       this.valueMap.set(normalizedValue, new Set([key]))
@@ -104,9 +116,6 @@ export class BasicIndex<
       )
       this.sortedValues.splice(insertIdx, 0, normalizedValue)
     }
-
-    this.indexedKeys.add(key)
-    this.updateTimestamp()
   }
 
   /**
@@ -128,8 +137,15 @@ export class BasicIndex<
 
     const normalizedValue = normalizeValue(indexedValue)
 
-    if (this.valueMap.has(normalizedValue)) {
-      const keySet = this.valueMap.get(normalizedValue)!
+    this.removeFromBucket(key, normalizedValue)
+
+    this.indexedKeys.delete(key)
+    this.updateTimestamp()
+  }
+
+  private removeFromBucket(key: TKey, normalizedValue: any): void {
+    const keySet = this.valueMap.get(normalizedValue)
+    if (keySet) {
       keySet.delete(key)
 
       if (keySet.size === 0) {
@@ -138,17 +154,34 @@ export class BasicIndex<
         deleteInSortedArray(this.sortedValues, normalizedValue, this.compareFn)
       }
     }
-
-    this.indexedKeys.delete(key)
-    this.updateTimestamp()
   }
 
   /**
    * Updates a value in the index
    */
   update(key: TKey, oldItem: any, newItem: any): void {
-    this.remove(key, oldItem)
-    this.add(key, newItem)
+    let oldValue: any
+    let newValue: any
+    try {
+      oldValue = normalizeValue(this.evaluateIndexExpression(oldItem))
+      newValue = normalizeValue(this.evaluateIndexExpression(newItem))
+    } catch {
+      this.remove(key, oldItem)
+      this.add(key, newItem)
+      return
+    }
+
+    if (
+      areSameValueZeroEqual(oldValue, newValue) &&
+      this.valueMap.get(newValue)?.has(key)
+    ) {
+      return
+    }
+
+    this.removeFromBucket(key, oldValue)
+    this.addToBucket(key, newValue)
+    this.indexedKeys.add(key)
+    this.updateTimestamp()
   }
 
   /**

--- a/packages/db/src/indexes/basic-index.ts
+++ b/packages/db/src/indexes/basic-index.ts
@@ -99,7 +99,7 @@ export class BasicIndex<
     this.updateTimestamp()
   }
 
-  private addToBucket(key: TKey, normalizedValue: any): void {
+  private addToBucket(key: TKey, normalizedValue: unknown): void {
     const keySet = this.valueMap.get(normalizedValue)
     if (keySet) {
       // Value already exists, just add the key to the set
@@ -143,7 +143,7 @@ export class BasicIndex<
     this.updateTimestamp()
   }
 
-  private removeFromBucket(key: TKey, normalizedValue: any): void {
+  private removeFromBucket(key: TKey, normalizedValue: unknown): void {
     const keySet = this.valueMap.get(normalizedValue)
     if (keySet) {
       keySet.delete(key)
@@ -160,8 +160,8 @@ export class BasicIndex<
    * Updates a value in the index
    */
   update(key: TKey, oldItem: any, newItem: any): void {
-    let oldValue: any
-    let newValue: any
+    let oldValue: unknown
+    let newValue: unknown
     try {
       oldValue = normalizeValue(this.evaluateIndexExpression(oldItem))
       newValue = normalizeValue(this.evaluateIndexExpression(newItem))

--- a/packages/db/src/indexes/basic-index.ts
+++ b/packages/db/src/indexes/basic-index.ts
@@ -173,7 +173,8 @@ export class BasicIndex<
 
     if (
       areSameValueZeroEqual(oldValue, newValue) &&
-      this.valueMap.get(newValue)?.has(key)
+      this.valueMap.get(newValue)?.has(key) &&
+      this.indexedKeys.has(key)
     ) {
       return
     }

--- a/packages/db/src/indexes/btree-index.ts
+++ b/packages/db/src/indexes/btree-index.ts
@@ -1,6 +1,7 @@
 import { compareKeys } from '@tanstack/db-ivm'
 import { BTree } from '../utils/btree.js'
 import {
+  areSameValueZeroEqual,
   defaultComparator,
   denormalizeUndefined,
   normalizeForBTree,
@@ -94,19 +95,23 @@ export class BTreeIndex<
     // Normalize the value for Map key usage
     const normalizedValue = normalizeForBTree(indexedValue)
 
-    // Check if this value already exists
-    if (this.valueMap.has(normalizedValue)) {
-      // Add to existing set
-      this.valueMap.get(normalizedValue)!.add(key)
-    } else {
-      // Create new set for this value
-      const keySet = new Set<TKey>([key])
-      this.valueMap.set(normalizedValue, keySet)
-      this.orderedEntries.set(normalizedValue, undefined)
-    }
+    this.addToBucket(key, normalizedValue)
 
     this.indexedKeys.add(key)
     this.updateTimestamp()
+  }
+
+  private addToBucket(key: TKey, normalizedValue: any): void {
+    const keySet = this.valueMap.get(normalizedValue)
+    if (keySet) {
+      // Add to existing set
+      keySet.add(key)
+    } else {
+      // Create new set for this value
+      const newKeySet = new Set<TKey>([key])
+      this.valueMap.set(normalizedValue, newKeySet)
+      this.orderedEntries.set(normalizedValue, undefined)
+    }
   }
 
   /**
@@ -127,8 +132,15 @@ export class BTreeIndex<
     // Normalize the value for Map key usage
     const normalizedValue = normalizeForBTree(indexedValue)
 
-    if (this.valueMap.has(normalizedValue)) {
-      const keySet = this.valueMap.get(normalizedValue)!
+    this.removeFromBucket(key, normalizedValue)
+
+    this.indexedKeys.delete(key)
+    this.updateTimestamp()
+  }
+
+  private removeFromBucket(key: TKey, normalizedValue: any): void {
+    const keySet = this.valueMap.get(normalizedValue)
+    if (keySet) {
       keySet.delete(key)
 
       // If set is now empty, remove the entry entirely
@@ -139,17 +151,34 @@ export class BTreeIndex<
         this.orderedEntries.delete(normalizedValue)
       }
     }
-
-    this.indexedKeys.delete(key)
-    this.updateTimestamp()
   }
 
   /**
    * Updates a value in the index
    */
   update(key: TKey, oldItem: any, newItem: any): void {
-    this.remove(key, oldItem)
-    this.add(key, newItem)
+    let oldValue: any
+    let newValue: any
+    try {
+      oldValue = normalizeForBTree(this.evaluateIndexExpression(oldItem))
+      newValue = normalizeForBTree(this.evaluateIndexExpression(newItem))
+    } catch {
+      this.remove(key, oldItem)
+      this.add(key, newItem)
+      return
+    }
+
+    if (
+      areSameValueZeroEqual(oldValue, newValue) &&
+      this.valueMap.get(newValue)?.has(key)
+    ) {
+      return
+    }
+
+    this.removeFromBucket(key, oldValue)
+    this.addToBucket(key, newValue)
+    this.indexedKeys.add(key)
+    this.updateTimestamp()
   }
 
   /**

--- a/packages/db/src/indexes/btree-index.ts
+++ b/packages/db/src/indexes/btree-index.ts
@@ -101,7 +101,7 @@ export class BTreeIndex<
     this.updateTimestamp()
   }
 
-  private addToBucket(key: TKey, normalizedValue: any): void {
+  private addToBucket(key: TKey, normalizedValue: unknown): void {
     const keySet = this.valueMap.get(normalizedValue)
     if (keySet) {
       // Add to existing set
@@ -138,7 +138,7 @@ export class BTreeIndex<
     this.updateTimestamp()
   }
 
-  private removeFromBucket(key: TKey, normalizedValue: any): void {
+  private removeFromBucket(key: TKey, normalizedValue: unknown): void {
     const keySet = this.valueMap.get(normalizedValue)
     if (keySet) {
       keySet.delete(key)
@@ -157,8 +157,8 @@ export class BTreeIndex<
    * Updates a value in the index
    */
   update(key: TKey, oldItem: any, newItem: any): void {
-    let oldValue: any
-    let newValue: any
+    let oldValue: unknown
+    let newValue: unknown
     try {
       oldValue = normalizeForBTree(this.evaluateIndexExpression(oldItem))
       newValue = normalizeForBTree(this.evaluateIndexExpression(newItem))

--- a/packages/db/src/utils/comparison.ts
+++ b/packages/db/src/utils/comparison.ts
@@ -230,7 +230,7 @@ export function normalizeForBTree(value: any): any {
  * Compare values using the equality semantics used by Map keys.
  */
 export function areSameValueZeroEqual(a: unknown, b: unknown): boolean {
-  return a === b || (a !== a && b !== b)
+  return a === b || (Number.isNaN(a) && Number.isNaN(b))
 }
 
 /**

--- a/packages/db/src/utils/comparison.ts
+++ b/packages/db/src/utils/comparison.ts
@@ -227,6 +227,13 @@ export function normalizeForBTree(value: any): any {
 }
 
 /**
+ * Compare values using the equality semantics used by Map keys.
+ */
+export function areSameValueZeroEqual(a: any, b: any): boolean {
+  return a === b || (Number.isNaN(a) && Number.isNaN(b))
+}
+
+/**
  * Converts the `UNDEFINED_SENTINEL` back to `undefined`.
  * Needed such that the sentinel is converted back to `undefined` before comparison.
  */

--- a/packages/db/src/utils/comparison.ts
+++ b/packages/db/src/utils/comparison.ts
@@ -185,6 +185,10 @@ export const UNDEFINED_SENTINEL = `__TS_DB_BTREE_UNDEFINED_VALUE__`
  * for BTree index operations that need to distinguish undefined values.
  */
 export function normalizeValue(value: any): any {
+  if (typeof value !== `object` || value === null) {
+    return value
+  }
+
   if (value instanceof Date) {
     return value.getTime()
   }

--- a/packages/db/src/utils/comparison.ts
+++ b/packages/db/src/utils/comparison.ts
@@ -229,8 +229,8 @@ export function normalizeForBTree(value: any): any {
 /**
  * Compare values using the equality semantics used by Map keys.
  */
-export function areSameValueZeroEqual(a: any, b: any): boolean {
-  return a === b || (Number.isNaN(a) && Number.isNaN(b))
+export function areSameValueZeroEqual(a: unknown, b: unknown): boolean {
+  return a === b || (a !== a && b !== b)
 }
 
 /**

--- a/packages/db/tests/index-update-short-circuit.test.ts
+++ b/packages/db/tests/index-update-short-circuit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { BasicIndex } from '../src/indexes/basic-index.js'
+import { BTreeIndex } from '../src/indexes/btree-index.js'
+import { PropRef } from '../src/query/ir.js'
+import { normalizeValue } from '../src/utils/comparison.js'
+import type { BaseIndex } from '../src/indexes/base-index.js'
+
+type IndexConstructor = new (
+  id: number,
+  expression: PropRef,
+  name?: string,
+  options?: unknown,
+) => BaseIndex<string> & {
+  valueMapData: Map<unknown, Set<string>>
+}
+
+const indexTypes: Array<[string, IndexConstructor]> = [
+  [`BasicIndex`, BasicIndex as IndexConstructor],
+  [`BTreeIndex`, BTreeIndex as IndexConstructor],
+]
+
+describe.each(indexTypes)(`%s update`, (_indexName, IndexType) => {
+  function createIndex(options?: unknown) {
+    return new IndexType(1, new PropRef([`value`]), `test_index`, options)
+  }
+
+  it(`keeps the existing bucket when the indexed value does not change`, () => {
+    const index = createIndex()
+    index.add(`a`, { value: 1, version: 1 })
+    const bucket = index.valueMapData.get(1)
+    const lastUpdated = index.getStats().lastUpdated
+
+    index.update(`a`, { value: 1, version: 1 }, { value: 1, version: 2 })
+
+    expect(index.valueMapData.get(1)).toBe(bucket)
+    expect(index.getStats().lastUpdated).toBe(lastUpdated)
+    expect(index.lookup(`eq`, 1)).toEqual(new Set([`a`]))
+  })
+
+  it.each([
+    [`undefined`, undefined, undefined],
+    [`NaN`, Number.NaN, Number.NaN],
+    [`signed zero`, 0, -0],
+    [`equal dates`, new Date(1000), new Date(1000)],
+    [`equal byte arrays`, new Uint8Array([1, 2]), new Uint8Array([1, 2])],
+  ])(`keeps the existing bucket for %s`, (_caseName, oldValue, newValue) => {
+    const index = createIndex()
+    index.add(`a`, { value: oldValue })
+    const bucket = index.valueMapData.get(normalizeValue(oldValue))
+
+    index.update(`a`, { value: oldValue }, { value: newValue })
+
+    expect(index.valueMapData.get(normalizeValue(newValue))).toBe(bucket)
+  })
+
+  it(`moves the key when the indexed value changes`, () => {
+    const index = createIndex()
+    index.add(`a`, { value: 1 })
+
+    index.update(`a`, { value: 1 }, { value: 2 })
+
+    expect(index.lookup(`eq`, 1)).toEqual(new Set())
+    expect(index.lookup(`eq`, 2)).toEqual(new Set([`a`]))
+  })
+
+  it(`does not use comparator equality to skip an update`, () => {
+    const index = createIndex({
+      compareFn: (a: string, b: string) =>
+        a.toLowerCase().localeCompare(b.toLowerCase()),
+    })
+    index.add(`a`, { value: `A` })
+
+    index.update(`a`, { value: `A` }, { value: `a` })
+
+    expect(index.lookup(`eq`, `A`)).toEqual(new Set())
+    expect(index.lookup(`eq`, `a`)).toEqual(new Set([`a`]))
+  })
+})

--- a/packages/db/tests/index-update-short-circuit.test.ts
+++ b/packages/db/tests/index-update-short-circuit.test.ts
@@ -63,6 +63,16 @@ describe.each(indexTypes)(`%s update`, (_indexName, IndexType) => {
     expect(index.lookup(`eq`, 2)).toEqual(new Set([`a`]))
   })
 
+  it(`does not conflate undefined and null`, () => {
+    const index = createIndex()
+    index.add(`a`, { value: undefined })
+
+    index.update(`a`, { value: undefined }, { value: null })
+
+    expect(index.lookup(`eq`, undefined)).toEqual(new Set())
+    expect(index.lookup(`eq`, null)).toEqual(new Set([`a`]))
+  })
+
   it(`does not use comparator equality to skip an update`, () => {
     const index = createIndex({
       compareFn: (a: string, b: string) =>

--- a/packages/db/tests/index-update-short-circuit.test.ts
+++ b/packages/db/tests/index-update-short-circuit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { BasicIndex } from '../src/indexes/basic-index.js'
 import { BTreeIndex } from '../src/indexes/btree-index.js'
 import { PropRef } from '../src/query/ir.js'
@@ -47,6 +47,7 @@ describe.each(indexTypes)(`%s update`, (_indexName, IndexType) => {
     const index = createIndex()
     index.add(`a`, { value: oldValue })
     const bucket = index.valueMapData.get(normalizeValue(oldValue))
+    expect(bucket).toBeDefined()
 
     index.update(`a`, { value: oldValue }, { value: newValue })
 
@@ -84,5 +85,49 @@ describe.each(indexTypes)(`%s update`, (_indexName, IndexType) => {
 
     expect(index.lookup(`eq`, `A`)).toEqual(new Set())
     expect(index.lookup(`eq`, `a`)).toEqual(new Set([`a`]))
+  })
+
+  it(`preserves the previous error behavior when evaluation fails`, () => {
+    const index = createIndex()
+    index.add(`a`, { value: 1 })
+    const newItem = Object.defineProperty({}, `value`, {
+      get() {
+        throw new Error(`evaluation failed`)
+      },
+    })
+
+    expect(() => index.update(`a`, { value: 1 }, newItem)).toThrow(
+      `evaluation failed`,
+    )
+
+    expect(index.lookup(`eq`, 1)).toEqual(new Set())
+    expect(index.keyCount).toBe(0)
+  })
+})
+
+describe(`BasicIndex update bookkeeping`, () => {
+  it(`repairs indexed key membership after a failed removal`, () => {
+    const index = new BasicIndex<string>(1, new PropRef([`value`]))
+    index.add(`a`, { value: 1 })
+    const itemWithThrowingValue = Object.defineProperty({}, `value`, {
+      get() {
+        throw new Error(`evaluation failed`)
+      },
+    })
+    const warn = vi.spyOn(console, `warn`).mockImplementation(() => {})
+
+    try {
+      index.remove(`a`, itemWithThrowingValue)
+    } finally {
+      warn.mockRestore()
+    }
+
+    expect(index.lookup(`eq`, 1)).toEqual(new Set([`a`]))
+    expect(index.keyCount).toBe(0)
+
+    index.update(`a`, { value: 1 }, { value: 1 })
+
+    expect(index.lookup(`eq`, 1)).toEqual(new Set([`a`]))
+    expect(index.keyCount).toBe(1)
   })
 })

--- a/packages/db/tests/index-update.property.test.ts
+++ b/packages/db/tests/index-update.property.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect } from 'vitest'
+import { fc, test as fcTest } from '@fast-check/vitest'
+import { BasicIndex } from '../src/indexes/basic-index.js'
+import { BTreeIndex } from '../src/indexes/btree-index.js'
+import { PropRef } from '../src/query/ir.js'
+import type { BaseIndex } from '../src/indexes/base-index.js'
+
+type IndexValue = number
+
+type IndexConstructor = new (
+  id: number,
+  expression: PropRef,
+) => BaseIndex<string>
+
+type IndexAction =
+  | { type: `put`; key: string; value: IndexValue }
+  | { type: `delete`; key: string }
+
+const indexTypes: Array<[string, IndexConstructor]> = [
+  [`BasicIndex`, BasicIndex as IndexConstructor],
+  [`BTreeIndex`, BTreeIndex as IndexConstructor],
+]
+
+const arbitraryValue: fc.Arbitrary<IndexValue> = fc.integer({
+  min: -3,
+  max: 3,
+})
+
+const arbitraryAction: fc.Arbitrary<IndexAction> = fc.oneof(
+  fc.record({
+    type: fc.constant(`put` as const),
+    key: fc.integer({ min: 0, max: 7 }).map(String),
+    value: arbitraryValue,
+  }),
+  fc.record({
+    type: fc.constant(`delete` as const),
+    key: fc.integer({ min: 0, max: 7 }).map(String),
+  }),
+)
+
+const probeValues: Array<IndexValue> = [-3, -2, -1, -0, 0, 1, 2, 3, 99]
+const rangeBoundaries: Array<IndexValue> = [-2, 0, 2]
+
+function groupKeysByValue(
+  rows: Map<string, IndexValue>,
+): Map<IndexValue, Set<string>> {
+  const groups = new Map<IndexValue, Set<string>>()
+  for (const [key, value] of rows) {
+    const keys = groups.get(value)
+    if (keys) {
+      keys.add(key)
+    } else {
+      groups.set(value, new Set([key]))
+    }
+  }
+  return groups
+}
+
+function expectIndexMatchesModel(
+  index: BaseIndex<string>,
+  rows: Map<string, IndexValue>,
+): void {
+  const groups = groupKeysByValue(rows)
+
+  expect(index.keyCount).toBe(rows.size)
+  expect(index.indexedKeysSet).toEqual(new Set(rows.keys()))
+  expect(index.valueMapData).toEqual(groups)
+  expect(index.orderedEntriesArray).toEqual(
+    [...groups].sort(([left], [right]) => left - right),
+  )
+
+  for (const value of probeValues) {
+    expect(index.lookup(`eq`, value)).toEqual(groups.get(value) ?? new Set())
+  }
+
+  for (const boundary of rangeBoundaries) {
+    const keysAtOrAbove = new Set(
+      [...rows].filter(([, value]) => value >= boundary).map(([key]) => key),
+    )
+    const keysAtOrBelow = new Set(
+      [...rows].filter(([, value]) => value <= boundary).map(([key]) => key),
+    )
+
+    expect(index.rangeQuery({ from: boundary })).toEqual(keysAtOrAbove)
+    expect(index.rangeQuery({ to: boundary })).toEqual(keysAtOrBelow)
+  }
+}
+
+describe.each(indexTypes)(`%s update properties`, (_indexName, IndexType) => {
+  fcTest.prop([
+    fc.array(arbitraryAction, {
+      minLength: 1,
+      maxLength: 100,
+    }),
+  ])(
+    `matches a reference model across valid operation sequences`,
+    (actions) => {
+      const index = new IndexType(1, new PropRef([`value`]))
+      const rows = new Map<string, IndexValue>()
+
+      for (const action of actions) {
+        if (action.type === `put`) {
+          if (rows.has(action.key)) {
+            index.update(
+              action.key,
+              { value: rows.get(action.key) },
+              { value: action.value },
+            )
+          } else {
+            index.add(action.key, { value: action.value })
+          }
+          rows.set(action.key, action.value)
+        } else if (rows.has(action.key)) {
+          index.remove(action.key, { value: rows.get(action.key) })
+          rows.delete(action.key)
+        }
+
+        expectIndexMatchesModel(index, rows)
+      }
+
+      const rebuilt = new IndexType(2, new PropRef([`value`]))
+      rebuilt.build([...rows].map(([key, value]) => [key, { value }] as const))
+      expectIndexMatchesModel(rebuilt, rows)
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Index updates now skip bucket, tree, and timestamp writes when the indexed value is unchanged. The combined change also caches compiled index evaluators, avoids object-normalization work for primitive values, repairs a `BasicIndex` bookkeeping edge case, and adds model-based property coverage for both index types.

## Root cause

Every update previously called the public remove/add paths for every index, even when the indexed value stayed in the same normalized bucket. That repeated expression compilation, normalization, map/set or B+ tree writes, and timestamp updates for changes to unrelated row fields.

The first no-op guard also exposed an existing partial-state case in `BasicIndex`: if removal expression evaluation failed, the value bucket could retain the key while `indexedKeys` dropped it. Checking only bucket membership could then return early without repairing `keyCount`.

## Approach

- Evaluate and normalize the old and new indexed values once.
- Compare normalized values with SameValueZero semantics, matching JavaScript `Map` keys for values such as `NaN` and signed zero.
- Return early only when the value is unchanged and the expected bucket contains the key. `BasicIndex` also confirms membership in `indexedKeys`.
- Move changed values through private bucket helpers, avoiding duplicate evaluation and updating the timestamp once.
- Preserve the existing public remove/add fallback when expression evaluation fails.
- Compile each index expression once and reuse its evaluator.
- Return primitive values from `normalizeValue()` before object-specific checks.
- Check randomized valid mutation sequences against a reference model after every operation.

## Key invariants

- A no-op update leaves buckets, ordered entries, key counts, and timestamps unchanged.
- A real move removes the key from the old bucket and adds it to the new bucket exactly once.
- SameValueZero governs bucket identity; custom ordering comparators do not redefine equality.
- `undefined`, `null`, `NaN`, signed zero, dates, byte arrays, object identity, and custom comparators retain their prior lookup semantics.
- `keyCount`, indexed keys, exact buckets, ordered entries, equality lookups, range queries, and rebuilt state agree with the reference model.
- Expression-evaluation failures retain the prior fallback behavior.

## Non-goals

- This does not change how stale caller-supplied `oldItem` values are handled. #1517 owns the one-key/one-bucket invariant and its extra reverse-map memory cost.
- This does not take the full #1645 change set. It absorbs only evaluator caching and primitive normalization, allowing the remaining useful parts to be cherry-picked separately.
- This does not change public APIs or timestamp semantics.

## Trade-offs

The no-op path performs cheap membership checks before returning. This is slightly more work than comparing values alone, but prevents an optimization from hiding inconsistent bookkeeping.

A reverse key-to-bucket map would also solve stale `oldItem` values, but adds one map entry per indexed row per index and broadens this performance change into a separate correctness invariant. That work remains isolated in #1517.

## Benchmark

The original #1691 microbenchmark used 10,000 unique indexed rows, four indexes, 5,000 updates, and five runs; medians are shown:

| Index | Workload | `main` | This PR |
| --- | --- | ---: | ---: |
| BasicIndex | indexed value unchanged | 293.6 ms | 1.3 ms |
| BTreeIndex | indexed value unchanged | 274.7 ms | 1.1 ms |
| BasicIndex | indexed value changes | 244.1 ms | 141.4 ms |
| BTreeIndex | indexed value changes | 232.4 ms | 129.1 ms |

This is a focused index microbenchmark, not an end-to-end application result. The gain depends on index count, bucket shape, and how often indexed values change. Evaluator caching and the primitive normalization fast path were added after this measurement.

## Verification

```bash
pnpm exec vitest run packages/db/tests/index-update.property.test.ts packages/db/tests/index-update-short-circuit.test.ts
pnpm --filter @tanstack/db test
pnpm --filter @tanstack/db build
pnpm exec eslint packages/db/src/indexes/base-index.ts packages/db/src/indexes/basic-index.ts packages/db/src/indexes/btree-index.ts packages/db/src/utils/comparison.ts packages/db/tests/index-update-short-circuit.test.ts packages/db/tests/index-update.property.test.ts
pnpm exec prettier --check .changeset/quick-trees-rest.md packages/db/src/indexes/base-index.ts packages/db/src/indexes/basic-index.ts packages/db/src/indexes/btree-index.ts packages/db/src/utils/comparison.ts packages/db/tests/index-update-short-circuit.test.ts packages/db/tests/index-update.property.test.ts
```

- Focused update and property suite: 23 tests passed.
- Full `@tanstack/db` suite: 2,483 tests passed, 5 skipped.
- Package build, ESLint, and Prettier checks passed.

## Files changed

- `base-index.ts`: cache the compiled expression evaluator.
- `basic-index.ts`: short-circuit unchanged updates, use direct bucket moves, and guard key bookkeeping.
- `btree-index.ts`: short-circuit unchanged updates and use direct bucket moves.
- `comparison.ts`: add SameValueZero equality and a primitive normalization fast path.
- `index-update-short-circuit.test.ts`: cover no-op updates, real moves, edge values, comparators, and evaluation failures.
- `index-update.property.test.ts`: compare randomized mutation sequences with a reference model.
- `quick-trees-rest.md`: provide one combined patch changeset.

---

Related: #1517, #1645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Avoid unnecessary bucket writes on no-op updates; preserves timestamps and reuses bucket instances.
  - Improve indexed value comparison with SameValueZero semantics (e.g., `NaN`), while keeping `undefined` and `null` distinct.
  - Incrementally move keys between index buckets on changes, with consistent state even when index value evaluation fails.
- **Tests**
  - Added cross-index update short-circuit tests and expanded failure/edge-case coverage.
  - Added property-based randomized put/delete invariants tests for update correctness.
- **Chores**
  - Cache compiled index expression evaluation to speed up repeated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->