### PR TITLE
docs: document query cancellation semantics

### DIFF
--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -241,6 +241,54 @@ Some TanStack Query fields are owned or reinterpreted by Query Collection and ar
 
 `placeholderData` is intentionally unsupported. TanStack Query treats placeholder data as observer-local presentation state rather than cached Query data. Materializing it would expose temporary UI data as collection-wide normalized rows. Render placeholders in the consuming UI instead.
 
+### Request Cancellation with `QueryFunctionContext.signal`
+
+TanStack Query passes an `AbortSignal` to `queryFn` through the query function
+context. Forward `ctx.signal` to `fetch` or another abortable client to make the
+request cancellable:
+
+```typescript
+const todosCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ["todos"],
+    queryFn: async (ctx) => {
+      const response = await fetch("/api/todos", {
+        signal: ctx.signal,
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch todos")
+      }
+
+      return response.json() as Promise<Array<Todo>>
+    },
+    queryClient,
+    getKey: (todo) => todo.id,
+  }),
+)
+```
+
+Explicit collection cleanup cancels collection-owned queries before removing
+them from the Query cache:
+
+```typescript
+await todosCollection.cleanup()
+```
+
+The underlying request is aborted only when its client consumes `ctx.signal`.
+A client that ignores the signal may continue its request even though the
+collection has been cleaned up.
+
+On-demand subset unloading has different semantics. When the last subscriber
+unloads a subset, Query Collection does **not** cancel its in-flight request.
+TanStack Query can cache the completed response, preserving cache reuse and a
+fast remount if the same subset is requested again.
+
+Broader cancellation and lease-policy changes are being designed in
+[RFC #1657](https://github.com/TanStack/db/issues/1657) and
+[PR #1573](https://github.com/TanStack/db/pull/1573). Those proposals are not
+the current behavior described here.
+
 ### Using with `queryOptions(...)`
 
 If your app already uses TanStack Query's `queryOptions` helper (e.g. from `@tanstack/react-query`), you can spread compatible top-level options into `queryCollectionOptions`. Note that `queryFn` must be explicitly provided since query collections require it both in types and at runtime, and Query Collection's `select` option is for row extraction rather than TanStack Query observer-level selection:


### PR DESCRIPTION
## 🎯 Changes

- document how to forward `QueryFunctionContext.signal` to abortable request clients
- clarify explicit collection cleanup versus on-demand subset unload cancellation behavior
- distinguish current behavior from the broader cancellation proposals in RFC #1657 and PR #1573

Closes #350

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

Additional verification:
- `pnpm test:docs`
- `pnpm exec prettier --check docs/collections/query-collection.md`
- `pnpm lint`
- `pnpm test:sherif`
- `pnpm build`
- `pnpm --filter @tanstack/query-db-collection test`

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for making collection requests cancellable using `QueryFunctionContext.signal`.
  * Documented how collection cleanup affects in-flight requests and when underlying requests are aborted.
  * Clarified the difference between eager cleanup and on-demand subset unloading, including cache reuse behavior.
  * Added references to planned cancellation and lease-policy improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->