### PR TITLE
fix(db): compose optimistic updates from changes instead of whole-row snapshots

### DIFF
--- a/.changeset/soft-donkeys-shave.md
+++ b/.changeset/soft-donkeys-shave.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/db': patch
+---
+
+Fix concurrent optimistic updates to the same row overwriting each other's fields.
+
+Each pending update was stored as a whole-row snapshot taken at `mutate()` time, so whichever transaction applied last set every field — including fields it never touched. The clearest symptom: rolling back one of several in-flight transactions left its change visible, restored from a sibling transaction's snapshot.
+
+Updates now apply only the top-level fields they actually changed. Inserts are unaffected — they still apply the whole row, because an insert's `changes` omit schema defaults.

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -13,6 +13,7 @@ import type {
   ChangeMessage,
   CollectionConfig,
   OptimisticChangeMessage,
+  PendingMutation,
 } from '../types'
 import type { CollectionImpl } from './index.js'
 import type { CollectionLifecycleManager } from './lifecycle'
@@ -102,6 +103,11 @@ export class CollectionStateManager<
    */
   public pendingLocalChanges = new Set<TKey>()
   public pendingLocalOrigins = new Set<TKey>()
+
+  private composedUpserts = new WeakMap<
+    object,
+    { base: TOutput; composed: TOutput }
+  >()
 
   private virtualPropsCache = new WeakMap<
     object,
@@ -623,7 +629,7 @@ export class CollectionStateManager<
             case `update`:
               this.optimisticUpserts.set(
                 mutation.key,
-                mutation.modified as TOutput,
+                this.resolveOptimisticUpsert(mutation),
               )
               this.optimisticDeletes.delete(mutation.key)
               break
@@ -796,6 +802,36 @@ export class CollectionStateManager<
         })
       }
     }
+  }
+
+  /**
+   * Resolve the value an optimistic upsert contributes to the overlay. Updates
+   * compose `changes` over the value they were layered on so a mutation only
+   * owns the top-level fields it changed; inserts keep `modified` because their
+   * `changes` omit schema defaults. Composed rows are cached per `changes`
+   * object so an unchanged overlay keeps its reference and no-op events stay
+   * suppressed.
+   */
+  private resolveOptimisticUpsert(mutation: PendingMutation<any>): TOutput {
+    if (mutation.type !== `update`) {
+      return mutation.modified as TOutput
+    }
+
+    const key = mutation.key as TKey
+    const base = this.optimisticUpserts.get(key) ?? this.syncedData.get(key)
+    if (base === undefined) {
+      return mutation.modified as TOutput
+    }
+
+    const changes = mutation.changes as object
+    const cached = this.composedUpserts.get(changes)
+    if (cached !== undefined && cached.base === base) {
+      return cached.composed
+    }
+
+    const composed = { ...base, ...mutation.changes } as TOutput
+    this.composedUpserts.set(changes, { base, composed })
+    return composed
   }
 
   /**
@@ -1174,7 +1210,7 @@ export class CollectionStateManager<
                 case `update`:
                   this.optimisticUpserts.set(
                     mutation.key,
-                    mutation.modified as TOutput,
+                    this.resolveOptimisticUpsert(mutation),
                   )
                   this.optimisticDeletes.delete(mutation.key)
                   break

--- a/packages/db/tests/optimistic-composition.test.ts
+++ b/packages/db/tests/optimistic-composition.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createCollection } from '../src/collection/index.js'
+import { createTransaction } from '../src/transactions'
+import { mockSyncCollectionOptions, stripVirtualProps } from './utils'
+
+type Row = { id: number; a: string; b: string; c: string }
+
+const inFlight = () => new Promise<void>(() => {})
+
+function createRowCollection() {
+  return createCollection(
+    mockSyncCollectionOptions<Row>({
+      id: `optimistic-composition`,
+      getKey: (row) => row.id,
+      initialData: [{ id: 1, a: `a0`, b: `b0`, c: `c0` }],
+    }),
+  )
+}
+
+function inFlightTransaction() {
+  const transaction = createTransaction({
+    mutationFn: inFlight,
+    autoCommit: false,
+  })
+  transaction.isPersisted.promise.catch(() => {})
+  return transaction
+}
+
+describe(`optimistic overlay composition`, () => {
+  it(`keeps a field owned by a transaction that mutated after a later-sorting one`, () => {
+    const collection = createRowCollection()
+    const t1 = inFlightTransaction()
+    const t2 = inFlightTransaction()
+
+    t2.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.b = `b2`
+      }),
+    )
+    t1.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.a = `a1`
+      }),
+    )
+    t1.commit()
+    t2.commit()
+
+    expect(stripVirtualProps(collection.get(1))).toEqual({
+      id: 1,
+      a: `a1`,
+      b: `b2`,
+      c: `c0`,
+    })
+  })
+
+  it(`keeps a settled transaction's field when an unrelated key syncs`, async () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<Row>({
+        id: `optimistic-composition-unrelated-sync`,
+        getKey: (row) => row.id,
+        initialData: [
+          { id: 1, a: `a0`, b: `b0`, c: `c0` },
+          { id: 2, a: `x`, b: `y`, c: `z` },
+        ],
+      }),
+    )
+
+    const pending = inFlightTransaction()
+    pending.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.a = `a1`
+      }),
+    )
+    pending.commit()
+
+    const settled = collection.update(1, (draft) => {
+      draft.b = `b2`
+    })
+    collection.utils.resolveSync()
+    await settled.isPersisted.promise
+
+    collection.utils.begin()
+    collection.utils.write({
+      type: `update`,
+      value: { id: 2, a: `x2`, b: `y`, c: `z` },
+    })
+    collection.utils.commit()
+
+    expect(stripVirtualProps(collection.get(1))).toEqual({
+      id: 1,
+      a: `a1`,
+      b: `b2`,
+      c: `c0`,
+    })
+  })
+
+  it(`rolling back one transaction only reverts its own field`, () => {
+    const collection = createRowCollection()
+    const t1 = inFlightTransaction()
+    const t2 = inFlightTransaction()
+    const t3 = inFlightTransaction()
+
+    t1.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.a = `a1`
+      }),
+    )
+    t2.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.b = `b2`
+      }),
+    )
+    t3.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.c = `c3`
+      }),
+    )
+    t1.commit()
+    t2.commit()
+    t3.commit()
+
+    t2.rollback()
+
+    expect(stripVirtualProps(collection.get(1))).toEqual({
+      id: 1,
+      a: `a1`,
+      b: `b0`,
+      c: `c3`,
+    })
+  })
+
+  it(`surfaces a synced update to a field no uncommitted mutation touched`, () => {
+    const collection = createRowCollection()
+    const transaction = inFlightTransaction()
+
+    transaction.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.a = `a1`
+      }),
+    )
+
+    collection.utils.begin()
+    collection.utils.write({
+      type: `update`,
+      value: { id: 1, a: `a0`, b: `remote`, c: `c0` },
+    })
+    collection.utils.commit()
+
+    expect(stripVirtualProps(collection.get(1))).toEqual({
+      id: 1,
+      a: `a1`,
+      b: `remote`,
+      c: `c0`,
+    })
+  })
+
+  it(`preserves schema defaults from an optimistic insert when a later transaction updates the row`, () => {
+    const schema = z.object({
+      id: z.number(),
+      title: z.string(),
+      completed: z.boolean().default(false),
+      priority: z.number().default(3),
+    })
+
+    const collection = createCollection({
+      id: `optimistic-composition-defaults`,
+      getKey: (row) => row.id,
+      sync: {
+        sync: ({ begin, commit }) => {
+          begin()
+          commit()
+        },
+      },
+      schema,
+    })
+
+    const insertTransaction = inFlightTransaction()
+    insertTransaction.mutate(() => collection.insert({ id: 1, title: `first` }))
+    insertTransaction.commit()
+
+    const updateTransaction = inFlightTransaction()
+    updateTransaction.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.title = `second`
+      }),
+    )
+    updateTransaction.commit()
+
+    expect(stripVirtualProps(collection.get(1))).toEqual({
+      id: 1,
+      title: `second`,
+      completed: false,
+      priority: 3,
+    })
+  })
+
+  it(`does not emit redundant update events when recomputing an unchanged overlay`, () => {
+    const collection = createRowCollection()
+    const transaction = inFlightTransaction()
+
+    transaction.mutate(() =>
+      collection.update(1, (draft) => {
+        draft.a = `a1`
+      }),
+    )
+    transaction.commit()
+
+    const seen: Array<unknown> = []
+    collection.subscribeChanges((changes) => {
+      for (const change of changes) {
+        if (change.key === 1) {
+          seen.push(change)
+        }
+      }
+    })
+
+    const unrelated = inFlightTransaction()
+    unrelated.mutate(() => collection.insert({ id: 2, a: `x`, b: `y`, c: `z` }))
+    unrelated.commit()
+
+    expect(seen).toEqual([])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Small fix to how the optimistic overlay composes rows.

Today an optimistic insert/update stores `mutation.modified` — the whole row as it looked at `mutate()` time — into `optimisticUpserts`. Since `modified` is built from the *visible* row (`Object.assign({}, visibleRow, payload)` in `mutations.ts`), whichever transaction sorts last dictates **every** field, including ones it never touched.

The clearest symptom: rolling back one of several in-flight transactions doesn't actually remove its change.

It doesn't change **when** committed sync gets applied. Sync still stays queued while a transaction is `persisting`, exactly as today. That's the half of #1630 that turned out to be unsound without temp/server key mapping, and it's not needed for any of this.

So this is only the projection half — same base as before, just composed per-field instead of replaced wholesale.

Related to RFC #1625.

```ts
// three transactions in flight on the same row
t1.mutate(() => collection.update(1, (d) => { d.a = `a1` }))
t2.mutate(() => collection.update(1, (d) => { d.b = `b2` }))
t3.mutate(() => collection.update(1, (d) => { d.c = `c3` }))
t1.commit(); t2.commit(); t3.commit()

t2.rollback()
// expected: { a: 'a1', b: 'b0', c: 'c3' }
// actual:   { a: 'a1', b: 'b2', c: 'c3' }   <- b2 is back
```

t3's snapshot was taken when `b` was already `b2`, so once t2 is gone t3 puts it right back. I don't think there's a reading of that which is correct.

The fix: `update` mutations now compose `mutation.changes` over the value they were layered on, so a mutation only owns the fields it actually changed. Inserts keep using `modified`, since an insert's `changes` deliberately omit schema defaults (there's a comment in `mutations.ts` saying as much).

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed concurrent optimistic updates so each transaction changes only the fields it modified.
  - Prevented rollbacks from overwriting unrelated updates or leaving stale values visible.
  - Preserved optimistic insert defaults when subsequent updates are applied.
  - Prevented redundant change notifications when an optimistic overlay produces no effective change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->