### PR TITLE
test(db): tighten includes oracle failure checks

### DIFF
--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -125,7 +125,6 @@ function ensureActionsTargetRows(
     { length: 5 },
     () => new Map<number, number>(),
   )
-  const rolledBackLevels = new Set<HistoryAction[`level`]>()
 
   return history.map((action) => {
     const keys = keysByLevel[action.level]!
@@ -137,13 +136,6 @@ function ensureActionsTargetRows(
       return { ...action, type: `put`, position }
     }
 
-    if (
-      rolledBackLevels.has(action.level) &&
-      (action.type === `optimisticConfirm` ||
-        action.type === `optimisticRollback`)
-    ) {
-      return normalizePut()
-    }
     if (action.type === `put`) {
       return normalizePut()
     }
@@ -156,11 +148,6 @@ function ensureActionsTargetRows(
     if (action.type === `delete`) {
       keys.delete(id)
       positions.delete(id)
-    }
-    if (action.type === `optimisticRollback`) {
-      // The shared mock sync helper retains its rejected mutation promise, so
-      // it cannot start another optimistic mutation on this source.
-      rolledBackLevels.add(action.level)
     }
     return { ...action, id }
   })
@@ -323,6 +310,8 @@ function recompute(
   }))
 }
 
+// Collection delivery metadata is independent of include materialization.
+// Compare only the user-defined row shape modeled by the recompute oracle.
 function stripVirtualProperties(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stripVirtualProperties)
@@ -948,6 +937,50 @@ async function expectMaterializeScenarioMatches({
 }
 
 describe(`includes recompute oracle`, () => {
+  fcTest(`supports repeated optimistic rollbacks in one history`, async () => {
+    await expectScenarioMatches({
+      depth: 1,
+      history: [
+        {
+          type: `put`,
+          level: 0,
+          id: 0,
+          parentGroup: 0,
+          group: 0,
+          value: 0,
+          position: 0,
+        },
+        {
+          type: `put`,
+          level: 1,
+          id: 0,
+          parentGroup: 0,
+          group: 0,
+          value: 0,
+          position: 0,
+        },
+        {
+          type: `optimisticRollback`,
+          level: 1,
+          id: 0,
+          parentGroup: 0,
+          group: 0,
+          value: 1,
+          position: 0,
+        },
+        {
+          type: `optimisticRollback`,
+          level: 1,
+          id: 0,
+          parentGroup: 0,
+          group: 0,
+          value: 2,
+          position: 0,
+        },
+      ],
+    })
+  })
+
   fcTest.prop([scenarioArbitrary], { numRuns: 40 })(
     `matches naive recomputation after every incremental change`,
     expectScenarioMatches,
@@ -974,7 +1007,7 @@ describe(`includes recompute oracle`, () => {
           value: fc.integer({ min: -3, max: 3 }),
           position: fc.integer({ min: -2, max: 2 }),
         }),
-        { selector: (row) => row.id, maxLength: 5 },
+        { selector: (row) => row.id, minLength: 1, maxLength: 5 },
       ),
       fc.uniqueArray(
         fc.record({
@@ -989,7 +1022,7 @@ describe(`includes recompute oracle`, () => {
     ],
     { numRuns: 25 },
   )(
-    `is unchanged by alpha-renaming, sibling reorder, or an unrelated sibling`,
+    `is unchanged by alpha-renaming, sibling declaration order, or an unrelated sibling`,
     async (rootRows, childRows) => {
       const roots = createControlledCollection<RootRow>(
         `metamorphic-roots`,

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -130,23 +130,25 @@ function ensureActionsTargetRows(
   return history.map((action) => {
     const keys = keysByLevel[action.level]!
     const positions = positionsByLevel[action.level]!
+    const normalizePut = (): HistoryAction => {
+      keys.add(action.id)
+      const position = positions.get(action.id) ?? action.position
+      positions.set(action.id, position)
+      return { ...action, type: `put`, position }
+    }
+
     if (
       rolledBackLevels.has(action.level) &&
       (action.type === `optimisticConfirm` ||
         action.type === `optimisticRollback`)
     ) {
-      keys.add(action.id)
-      return { ...action, type: `put` }
+      return normalizePut()
     }
     if (action.type === `put`) {
-      keys.add(action.id)
-      const position = positions.get(action.id) ?? action.position
-      positions.set(action.id, position)
-      return { ...action, position }
+      return normalizePut()
     }
     if (keys.size === 0) {
-      keys.add(action.id)
-      return { ...action, type: `put` }
+      return normalizePut()
     }
 
     const existingKeys = [...keys]
@@ -598,6 +600,16 @@ async function settleOptimisticAction(
   })
 }
 
+function expectAssertionFailure<TArgs extends Array<unknown>>(
+  assertion: (...args: TArgs) => Promise<void>,
+): (...args: TArgs) => Promise<void> {
+  return async (...args) => {
+    await expect(assertion(...args)).rejects.toMatchObject({
+      name: `AssertionError`,
+    })
+  }
+}
+
 async function applyAction(
   action: HistoryAction,
   sources: Sources,
@@ -615,6 +627,8 @@ async function applyAction(
       return
     }
 
+    // Keep correlation keys stable in green fuzz histories. The known
+    // correlation-key update failure has its own deterministic seed below.
     const next: RootRow = {
       id: action.id,
       group: current?.group ?? action.group,
@@ -673,6 +687,8 @@ async function applyAction(
     return
   }
 
+  // Keep correlation keys stable in green fuzz histories. The known
+  // correlation-key update failure has its own deterministic seed below.
   const next: ChildRow = {
     id: action.id,
     parentGroup: current?.parentGroup ?? action.parentGroup,
@@ -1149,30 +1165,30 @@ describe(`includes recompute oracle`, () => {
     },
   )
 
-  // These expected failures are the red seeds later refactors must make green.
-  // Once a bug is fixed, Vitest fails because the matching seed passes.
-  fcTest.fails.prop([fc.constant(confirmedChildReorderSeed)], {
+  // These known failures must reject with the oracle's assertion mismatch.
+  // A fixed bug or an unrelated runtime error makes the matching test fail.
+  fcTest.prop([fc.constant(confirmedChildReorderSeed)], {
     numRuns: 1,
     seed: 2051245230,
   })(
     `discovered seed: confirmed child reorder matches recomputation`,
-    expectScenarioMatches,
+    expectAssertionFailure(expectScenarioMatches),
   )
 
-  fcTest.fails.prop([fc.constant(sharedMaterializeSeed)], {
+  fcTest.prop([fc.constant(sharedMaterializeSeed)], {
     numRuns: 1,
     seed: 1685,
   })(
     `known seed: shared scalar materialization preserves the deepest row`,
-    expectMaterializeScenarioMatches,
+    expectAssertionFailure(expectMaterializeScenarioMatches),
   )
 
-  fcTest.fails.prop([fc.constant(`correlation-key-update`)], {
+  fcTest.prop([fc.constant(`correlation-key-update`)], {
     numRuns: 1,
     seed: 1658,
   })(
     `discovered seed: parent correlation-key update rematerializes children`,
-    async () => {
+    expectAssertionFailure(async () => {
       const roots = createControlledCollection<RootRow>(
         `correlation-seed-roots`,
       )
@@ -1221,12 +1237,12 @@ describe(`includes recompute oracle`, () => {
           children.collection.cleanup(),
         ])
       }
-    },
+    }),
   )
 
-  fcTest.fails.prop([fc.constant(`#1454`)], { numRuns: 1, seed: 1454 })(
+  fcTest.prop([fc.constant(`#1454`)], { numRuns: 1, seed: 1454 })(
     `known seed: alpha-renaming a duplicate sibling alias preserves results`,
-    async () => {
+    expectAssertionFailure(async () => {
       const roots = createControlledCollection<RootRow>(`alias-seed-roots`, [
         { id: 1, group: 1, value: 0, position: 0 },
       ])
@@ -1295,12 +1311,12 @@ describe(`includes recompute oracle`, () => {
           tags.collection.cleanup(),
         ])
       }
-    },
+    }),
   )
 
-  fcTest.fails.prop([fc.constant(`#1444`)], { numRuns: 1, seed: 1444 })(
+  fcTest.prop([fc.constant(`#1444`)], { numRuns: 1, seed: 1444 })(
     `known seed: optimistic child reorder matches recomputation`,
-    async () => {
+    expectAssertionFailure(async () => {
       const roots = createControlledCollection<RootRow>(`order-seed-roots`, [
         { id: 1, group: 1, value: 0, position: 0 },
       ])
@@ -1362,6 +1378,6 @@ describe(`includes recompute oracle`, () => {
           children.collection.cleanup(),
         ])
       }
-    },
+    }),
   )
 })

--- a/packages/db/tests/utils.ts
+++ b/packages/db/tests/utils.ts
@@ -238,12 +238,14 @@ export function mockSyncCollectionOptions<
       syncPendingResolve = resolve
       syncPendingReject = reject
     })
-    syncPendingPromise.then(() => {
-      syncPendingPromise = undefined
-      syncPendingResolve = undefined
-      syncPendingReject = undefined
-    })
+    void syncPendingPromise.finally(clearPendingSync)
     return syncPendingPromise
+  }
+
+  const clearPendingSync = () => {
+    syncPendingPromise = undefined
+    syncPendingResolve = undefined
+    syncPendingReject = undefined
   }
 
   const utils = {
@@ -336,12 +338,14 @@ export function mockSyncCollectionOptionsNoInitialState<
       syncPendingResolve = resolve
       syncPendingReject = reject
     })
-    syncPendingPromise.then(() => {
-      syncPendingPromise = undefined
-      syncPendingResolve = undefined
-      syncPendingReject = undefined
-    })
+    void syncPendingPromise.finally(clearPendingSync)
     return syncPendingPromise
+  }
+
+  const clearPendingSync = () => {
+    syncPendingPromise = undefined
+    syncPendingResolve = undefined
+    syncPendingReject = undefined
   }
 
   const utils = {


### PR DESCRIPTION
Tightens the recompute oracle added in #1716 so known-bug cases accept only the intended assertion mismatch. It also restores repeated optimistic rollback coverage and fixes generator normalization; there are no runtime or API changes.

## Root cause

`fcTest.fails` treats every thrown error as success. A setup, cleanup, runtime, or assertion error could therefore make a known-bug case look healthy.

Generated actions also had two state-machine gaps:

- Actions converted into `put` operations bypassed stable-position bookkeeping, which let the known reorder bug enter the required green property.
- The shared sync mocks cleared pending mutation state only after resolution. After a rejection, the generator had to rewrite later optimistic actions as ordinary puts, hiding repeated rollback histories.

## Approach

- Replace `.fails` with normal properties wrapped by `expectAssertionFailure`, which accepts only Vitest `AssertionError` mismatches.
- Route every generated or converted `put` through one normalization helper.
- Clear shared mock mutation state after either resolution or rejection while preserving the expected rejection signal.
- Remove the post-rollback generator workaround and add a deterministic repeated-rollback regression.
- Require at least one root in the metamorphic generator and clarify the sibling-order test name.
- Document the correlation-key and virtual-property coverage boundaries.

## Key invariants

- A known-bug case passes only when the system result differs from the recompute oracle through an assertion mismatch.
- A bug fix or unrelated exception fails the known-bug test.
- Every generated `put` preserves an existing row's generated position, including converted actions.
- Rejecting one optimistic mutation does not prevent a later optimistic mutation on the same source.

## Non-goals

This small follow-up does not fix the include bugs represented by the known-failure cases or broaden the structural oracle. RFC #1658 now assigns these cases to the generalized trace-oracle follow-up:

- guaranteed connected observations at every depth;
- full-row sync replacements, including the already-fixed #1495 class;
- transaction-sized multi-change batches;
- deeper correlation-key changes and reparenting; and
- confirmation checkpoints before optimistic transactions resolve.

The explicit depth-specific query shapes also remain in place so TypeScript checks the real public DSL at depths 1–4.

## Trade-offs

The review suggested asserting each exact current wrong output. Matching the assertion type keeps the correct recompute result as the sole semantic reference instead of encoding implementation-specific wrong states.

Required green histories still keep correlation keys and existing-row positions stable. Reparenting and reordering include known-broken classes with deterministic failing cases; enabling the whole transition domain now would make required random CI fail until the runtime fixes land. The generalized runner will add those domains as a separate, controlled track.

## Verification

```bash
cd packages/db
pnpm exec prettier --check tests/utils.ts tests/query/includes-oracle.property.test.ts
pnpm exec eslint tests/utils.ts tests/query/includes-oracle.property.test.ts
pnpm exec vitest --run tests/query/includes-oracle.property.test.ts tests/collection.test.ts -t "supports repeated optimistic rollbacks|open sync transaction isn't applied"
pnpm exec vitest --run --pool-options.threads.maxThreads=2
```

Red/green checks:

- An unrelated injected error passed under `.fails`; it fails under `expectAssertionFailure`.
- Repeated optimistic rollback failed while the mock retained its rejected promise; the regression passes after symmetric cleanup.
- Original PR CI found seed `1665011958`, where a converted put changed an existing position; normalization fixes it.
- A depth-4 coverage probe shrank immediately to a root-only history, confirming the deferred guaranteed-depth work.
- Full-row replacement, child reparenting, intermediate rekeying, a multi-child sync batch, and the pre-resolution confirmation checkpoint all passed as focused probes. They exposed no additional runtime bug.

Full local DB suite: 106 files passed, 2,493 tests passed, 5 skipped, no type errors. All required checks on this PR are green.

## Files changed

- `packages/db/tests/query/includes-oracle.property.test.ts` — narrows expected failures, normalizes converted puts, restores repeated rollback coverage, improves generator signal, and documents scope.
- `packages/db/tests/utils.ts` — clears mock mutation state after both resolve and reject.

---

Related: #1716, #1658, #1495.
