### PR TITLE
test(db): extract reusable trace runner

### DIFF
--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -929,6 +929,7 @@ type MaterializeModels = {
 type MaterializeTraceStep =
   | { type: `insert`; insert: MaterializeInsert }
   | { type: `incrementLeaf`; id: number }
+  | { type: `redirectMiddle`; id: number; sharedId: number }
 
 type MaterializeTraceContext = {
   sharedIntermediate: boolean
@@ -1097,6 +1098,15 @@ function createMaterializeTraceDriver(
         return
       }
 
+      if (step.type === `redirectMiddle`) {
+        const middle = models.middles.get(step.id)
+        if (!middle) throw new Error(`Missing middle ${step.id} in trace model`)
+        const updated = { ...middle, sharedId: step.sharedId }
+        sources.middles.write(`update`, updated)
+        models.middles.set(updated.id, updated)
+        return
+      }
+
       const leaf = models.leaves.get(step.id)
       if (!leaf) throw new Error(`Missing leaf ${step.id} in trace model`)
       const updated = { ...leaf, value: leaf.value + 1 }
@@ -1140,6 +1150,23 @@ async function expectMaterializeScenarioMatches({
 }
 
 describe(`includes recompute oracle`, () => {
+  fcTest(
+    `discovered seed: nested scalar materialization follows a reference update`,
+    expectAssertionFailure(async () => {
+      await runTrace({
+        steps: [
+          { type: `insert`, insert: `root-1` },
+          { type: `insert`, insert: `middle-1` },
+          { type: `insert`, insert: `shared-1` },
+          { type: `insert`, insert: `leaf-1` },
+          { type: `redirectMiddle`, id: 1, sharedId: 2 },
+        ],
+        driver: createMaterializeTraceDriver(false),
+        projection: materializeProjection,
+      })
+    }),
+  )
+
   fcTest(`matches recomputation for full-row sync batches`, async () => {
     await runTrace({
       steps: fullRowBatchTrace,

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -13,6 +13,12 @@ import {
   mockSyncCollectionOptions,
   withExpectedRejection,
 } from '../utils.js'
+import { runTrace } from '../trace-runner.js'
+import type {
+  TraceCheckpoint,
+  TraceDriver,
+  TraceProjection,
+} from '../trace-runner.js'
 
 type IncludeDepth = 1 | 2 | 3 | 4
 
@@ -604,7 +610,7 @@ async function applyAction(
   sources: Sources,
   roots: Map<number, RootRow>,
   levels: Array<Map<number, ChildRow>>,
-  assertMatches: () => void,
+  assertMatches: TraceCheckpoint,
 ): Promise<void> {
   if (action.level === 0) {
     const current = roots.get(action.id)
@@ -730,30 +736,62 @@ async function cleanupSources(sources: Sources) {
   )
 }
 
-async function expectScenarioMatches(scenario: Scenario): Promise<void> {
-  const sources = createSources()
-  const incremental = createIncrementalQuery(scenario.depth, sources)
-  const roots = new Map<number, RootRow>()
-  const levels = Array.from({ length: 4 }, () => new Map<number, ChildRow>())
+type StructuralTraceContext = {
+  depth: IncludeDepth
+  sources: Sources
+  incremental: ReturnType<typeof createIncrementalQuery>
+  roots: Map<number, RootRow>
+  levels: Array<Map<number, ChildRow>>
+}
 
-  try {
-    await incremental.preload()
-    expect(stripVirtualProperties(incremental.toArray)).toEqual([])
-
-    const assertMatches = () => {
-      expect(stripVirtualProperties(incremental.toArray)).toEqual(
-        recompute(roots, levels, scenario.depth),
-      )
-    }
-
-    for (const action of scenario.history) {
-      await applyAction(action, sources, roots, levels, assertMatches)
-      assertMatches()
-    }
-  } finally {
-    await incremental.cleanup()
-    await cleanupSources(sources)
+function createStructuralTraceDriver(
+  depth: IncludeDepth,
+): TraceDriver<HistoryAction, StructuralTraceContext> {
+  return {
+    setup: () => {
+      const sources = createSources()
+      return {
+        depth,
+        sources,
+        incremental: createIncrementalQuery(depth, sources),
+        roots: new Map<number, RootRow>(),
+        levels: Array.from({ length: 4 }, () => new Map<number, ChildRow>()),
+      }
+    },
+    start: ({ incremental }) => incremental.preload(),
+    apply: (action, context, checkpoint) =>
+      applyAction(
+        action,
+        context.sources,
+        context.roots,
+        context.levels,
+        checkpoint,
+      ),
+    cleanup: async ({ incremental, sources }) => {
+      await incremental.cleanup()
+      await cleanupSources(sources)
+    },
   }
+}
+
+const structuralProjection: TraceProjection<
+  StructuralTraceContext,
+  unknown,
+  Array<OracleNode>
+> = {
+  observe: ({ incremental }) => stripVirtualProperties(incremental.toArray),
+  recompute: ({ roots, levels, depth }) => recompute(roots, levels, depth),
+  assertEqual: (observed, expected) => {
+    expect(observed).toEqual(expected)
+  },
+}
+
+async function expectScenarioMatches(scenario: Scenario): Promise<void> {
+  await runTrace({
+    steps: scenario.history,
+    driver: createStructuralTraceDriver(scenario.depth),
+    projection: structuralProjection,
+  })
 }
 
 function createMaterializeSources() {
@@ -767,6 +805,24 @@ function createMaterializeSources() {
 }
 
 type MaterializeSources = ReturnType<typeof createMaterializeSources>
+
+type MaterializeModels = {
+  roots: Map<number, MaterializeRoot>
+  middles: Map<number, MaterializeMiddle>
+  shared: Map<number, MaterializeShared>
+  leaves: Map<number, MaterializeLeaf>
+}
+
+type MaterializeTraceStep =
+  | { type: `insert`; insert: MaterializeInsert }
+  | { type: `incrementLeaf`; id: number }
+
+type MaterializeTraceContext = {
+  sharedIntermediate: boolean
+  sources: MaterializeSources
+  live: ReturnType<typeof createMaterializeQuery>
+  models: MaterializeModels
+}
 
 function createMaterializeQuery(sources: MaterializeSources) {
   return createLiveQueryCollection((q) =>
@@ -843,12 +899,7 @@ function insertMaterializeRow(
   insert: MaterializeInsert,
   sharedIntermediate: boolean,
   sources: MaterializeSources,
-  models: {
-    roots: Map<number, MaterializeRoot>
-    middles: Map<number, MaterializeMiddle>
-    shared: Map<number, MaterializeShared>
-    leaves: Map<number, MaterializeLeaf>
-  },
+  models: MaterializeModels,
 ): void {
   switch (insert) {
     case `root-1`:
@@ -891,49 +942,88 @@ async function cleanupMaterializeSources(sources: MaterializeSources) {
   )
 }
 
+function createMaterializeTraceSteps(
+  insertOrder: Array<MaterializeInsert>,
+): Array<MaterializeTraceStep> {
+  const steps: Array<MaterializeTraceStep> = insertOrder.map((insert) => ({
+    type: `insert`,
+    insert,
+  }))
+
+  for (const insert of insertOrder) {
+    if (insert === `leaf-1` || insert === `leaf-2`) {
+      steps.push({ type: `incrementLeaf`, id: insert === `leaf-1` ? 1 : 2 })
+    }
+  }
+
+  return steps
+}
+
+function createMaterializeTraceDriver(
+  scenarioSharedIntermediate: boolean,
+): TraceDriver<MaterializeTraceStep, MaterializeTraceContext> {
+  return {
+    setup: () => {
+      const sources = createMaterializeSources()
+      return {
+        sharedIntermediate: scenarioSharedIntermediate,
+        sources,
+        live: createMaterializeQuery(sources),
+        models: {
+          roots: new Map<number, MaterializeRoot>(),
+          middles: new Map<number, MaterializeMiddle>(),
+          shared: new Map<number, MaterializeShared>(),
+          leaves: new Map<number, MaterializeLeaf>(),
+        },
+      }
+    },
+    start: ({ live }) => live.preload(),
+    apply: (step, { models, sources, sharedIntermediate }) => {
+      if (step.type === `insert`) {
+        insertMaterializeRow(step.insert, sharedIntermediate, sources, models)
+        return
+      }
+
+      const leaf = models.leaves.get(step.id)
+      if (!leaf) throw new Error(`Missing leaf ${step.id} in trace model`)
+      const updated = { ...leaf, value: leaf.value + 1 }
+      sources.leaves.write(`update`, updated)
+      models.leaves.set(updated.id, updated)
+    },
+    cleanup: async ({ live, sources }) => {
+      await live.cleanup()
+      await cleanupMaterializeSources(sources)
+    },
+  }
+}
+
+const materializeProjection: TraceProjection<
+  MaterializeTraceContext,
+  unknown,
+  Array<MaterializeTree>
+> = {
+  observe: ({ live }) => stripVirtualProperties(live.toArray),
+  recompute: ({ models }) =>
+    recomputeMaterialize(
+      models.roots,
+      models.middles,
+      models.shared,
+      models.leaves,
+    ),
+  assertEqual: (observed, expected) => {
+    expect(observed).toEqual(expected)
+  },
+}
+
 async function expectMaterializeScenarioMatches({
   sharedIntermediate,
   insertOrder,
 }: MaterializeScenario): Promise<void> {
-  const sources = createMaterializeSources()
-  const live = createMaterializeQuery(sources)
-  const models = {
-    roots: new Map<number, MaterializeRoot>(),
-    middles: new Map<number, MaterializeMiddle>(),
-    shared: new Map<number, MaterializeShared>(),
-    leaves: new Map<number, MaterializeLeaf>(),
-  }
-
-  const assertMatches = () => {
-    expect(stripVirtualProperties(live.toArray)).toEqual(
-      recomputeMaterialize(
-        models.roots,
-        models.middles,
-        models.shared,
-        models.leaves,
-      ),
-    )
-  }
-
-  try {
-    await live.preload()
-    assertMatches()
-
-    for (const insert of insertOrder) {
-      insertMaterializeRow(insert, sharedIntermediate, sources, models)
-      assertMatches()
-    }
-
-    for (const leaf of models.leaves.values()) {
-      const updated = { ...leaf, value: leaf.value + 1 }
-      sources.leaves.write(`update`, updated)
-      models.leaves.set(updated.id, updated)
-      assertMatches()
-    }
-  } finally {
-    await live.cleanup()
-    await cleanupMaterializeSources(sources)
-  }
+  await runTrace({
+    steps: createMaterializeTraceSteps(insertOrder),
+    driver: createMaterializeTraceDriver(sharedIntermediate),
+    projection: materializeProjection,
+  })
 }
 
 describe(`includes recompute oracle`, () => {

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -33,6 +33,11 @@ type ChildRow = RootRow & {
   parentGroup: number
 }
 
+type SyncChange<T> = {
+  type: `insert` | `update` | `delete`
+  value: T
+}
+
 type HistoryAction = {
   type: `put` | `delete` | `optimisticConfirm` | `optimisticRollback`
   level: 0 | IncludeDepth
@@ -252,21 +257,27 @@ let nextHarnessId = 0
 function createControlledCollection<T extends { id: number }>(
   name: string,
   initialData: Array<T> = [],
+  rowUpdateMode: `partial` | `full` = `partial`,
 ) {
   const options = mockSyncCollectionOptions<T>({
     id: `${name}-${nextHarnessId++}`,
     getKey: (row) => row.id,
     initialData,
   })
+  options.sync.rowUpdateMode = rowUpdateMode
   const collection = createCollection(options)
+  const writeBatch = (changes: ReadonlyArray<SyncChange<T>>): void => {
+    options.utils.begin()
+    changes.forEach((change) => options.utils.write(change))
+    options.utils.commit()
+  }
 
   return {
     collection,
     write(type: `insert` | `update` | `delete`, value: T): void {
-      options.utils.begin()
-      options.utils.write({ type, value })
-      options.utils.commit()
+      writeBatch([{ type, value }])
     },
+    writeBatch,
     resolveSync(): void {
       options.utils.resolveSync()
     },
@@ -550,14 +561,18 @@ function createIncrementalQuery(depth: IncludeDepth, sources: Sources) {
   }
 }
 
-function createSources() {
+function createSources(rowUpdateMode: `partial` | `full` = `partial`) {
   return {
-    roots: createControlledCollection<RootRow>(`oracle-roots`),
+    roots: createControlledCollection<RootRow>(
+      `oracle-roots`,
+      [],
+      rowUpdateMode,
+    ),
     levels: [
-      createControlledCollection<ChildRow>(`oracle-level-1`),
-      createControlledCollection<ChildRow>(`oracle-level-2`),
-      createControlledCollection<ChildRow>(`oracle-level-3`),
-      createControlledCollection<ChildRow>(`oracle-level-4`),
+      createControlledCollection<ChildRow>(`oracle-level-1`, [], rowUpdateMode),
+      createControlledCollection<ChildRow>(`oracle-level-2`, [], rowUpdateMode),
+      createControlledCollection<ChildRow>(`oracle-level-3`, [], rowUpdateMode),
+      createControlledCollection<ChildRow>(`oracle-level-4`, [], rowUpdateMode),
     ] as const,
   }
 }
@@ -744,20 +759,33 @@ type StructuralTraceContext = {
   levels: Array<Map<number, ChildRow>>
 }
 
+function createStructuralTraceContext(
+  depth: IncludeDepth,
+  rowUpdateMode: `partial` | `full` = `partial`,
+): StructuralTraceContext {
+  const sources = createSources(rowUpdateMode)
+  return {
+    depth,
+    sources,
+    incremental: createIncrementalQuery(depth, sources),
+    roots: new Map<number, RootRow>(),
+    levels: Array.from({ length: 4 }, () => new Map<number, ChildRow>()),
+  }
+}
+
+async function cleanupStructuralTrace({
+  incremental,
+  sources,
+}: StructuralTraceContext): Promise<void> {
+  await incremental.cleanup()
+  await cleanupSources(sources)
+}
+
 function createStructuralTraceDriver(
   depth: IncludeDepth,
 ): TraceDriver<HistoryAction, StructuralTraceContext> {
   return {
-    setup: () => {
-      const sources = createSources()
-      return {
-        depth,
-        sources,
-        incremental: createIncrementalQuery(depth, sources),
-        roots: new Map<number, RootRow>(),
-        levels: Array.from({ length: 4 }, () => new Map<number, ChildRow>()),
-      }
-    },
+    setup: () => createStructuralTraceContext(depth),
     start: ({ incremental }) => incremental.preload(),
     apply: (action, context, checkpoint) =>
       applyAction(
@@ -767,12 +795,97 @@ function createStructuralTraceDriver(
         context.levels,
         checkpoint,
       ),
-    cleanup: async ({ incremental, sources }) => {
-      await incremental.cleanup()
-      await cleanupSources(sources)
-    },
+    cleanup: cleanupStructuralTrace,
   }
 }
+
+type FullRowBatchStep =
+  | { level: 0; changes: Array<SyncChange<RootRow>> }
+  | { level: 1; changes: Array<SyncChange<ChildRow>> }
+
+function updateModel<T extends { id: number }>(
+  model: Map<number, T>,
+  changes: ReadonlyArray<SyncChange<T>>,
+): void {
+  for (const change of changes) {
+    if (change.type === `delete`) {
+      model.delete(change.value.id)
+    } else {
+      model.set(change.value.id, change.value)
+    }
+  }
+}
+
+function createFullRowBatchTraceDriver(): TraceDriver<
+  FullRowBatchStep,
+  StructuralTraceContext
+> {
+  return {
+    setup: () => createStructuralTraceContext(1, `full`),
+    start: ({ incremental }) => incremental.preload(),
+    apply: (step, { sources, roots, levels }) => {
+      if (step.level === 0) {
+        sources.roots.writeBatch(step.changes)
+        updateModel(roots, step.changes)
+        return
+      }
+
+      sources.levels[0].writeBatch(step.changes)
+      updateModel(levels[0]!, step.changes)
+    },
+    cleanup: cleanupStructuralTrace,
+  }
+}
+
+function batchRoot(
+  id: number,
+  group: number,
+  value = id * 10,
+  position = id - 1,
+): RootRow {
+  return { id, group, value, position }
+}
+
+function batchChild(
+  id: number,
+  parentGroup: number,
+  value = id * 10,
+  position = id - 1,
+): ChildRow {
+  return { id, parentGroup, group: id * 10, value, position }
+}
+
+const fullRowBatchTrace: Array<FullRowBatchStep> = [
+  {
+    level: 0,
+    changes: [
+      { type: `insert`, value: batchRoot(1, 1) },
+      { type: `insert`, value: batchRoot(2, 2) },
+    ],
+  },
+  {
+    level: 1,
+    changes: [
+      { type: `insert`, value: batchChild(1, 1, 10, 0) },
+      { type: `insert`, value: batchChild(2, 1, 20, 1) },
+      { type: `insert`, value: batchChild(3, 2, 30, 0) },
+    ],
+  },
+  {
+    level: 1,
+    changes: [
+      { type: `update`, value: batchChild(1, 2, 11, 0) },
+      { type: `update`, value: batchChild(2, 1, 22, 1) },
+    ],
+  },
+  {
+    level: 1,
+    changes: [
+      { type: `delete`, value: batchChild(3, 2, 30, 0) },
+      { type: `insert`, value: batchChild(4, 2, 40, 1) },
+    ],
+  },
+]
 
 const structuralProjection: TraceProjection<
   StructuralTraceContext,
@@ -1027,6 +1140,14 @@ async function expectMaterializeScenarioMatches({
 }
 
 describe(`includes recompute oracle`, () => {
+  fcTest(`matches recomputation for full-row sync batches`, async () => {
+    await runTrace({
+      steps: fullRowBatchTrace,
+      driver: createFullRowBatchTraceDriver(),
+      projection: structuralProjection,
+    })
+  })
+
   fcTest(`supports repeated optimistic rollbacks in one history`, async () => {
     await expectScenarioMatches({
       depth: 1,

--- a/packages/db/tests/trace-runner.test-d.ts
+++ b/packages/db/tests/trace-runner.test-d.ts
@@ -1,0 +1,12 @@
+import type { TraceProjection } from './trace-runner.js'
+
+const asyncAssertionProjection: TraceProjection<undefined, number> = {
+  observe: () => 0,
+  recompute: () => 0,
+  // @ts-expect-error trace assertions must finish synchronously
+  assertEqual: async () => {
+    await Promise.resolve()
+  },
+}
+
+void asyncAssertionProjection

--- a/packages/db/tests/trace-runner.test.ts
+++ b/packages/db/tests/trace-runner.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runTrace } from './trace-runner.js'
+import type { TraceDriver } from './trace-runner.js'
+
+type Context = {
+  observed: number
+  expected: number
+}
+
+describe(`runTrace`, () => {
+  it(`checks after startup, explicit checkpoints, and every step`, async () => {
+    const checkpoints: Array<number> = []
+    const cleanup = vi.fn()
+    const driver: TraceDriver<number, Context> = {
+      setup: () => ({ observed: 0, expected: 0 }),
+      start: (context) => {
+        context.observed = 1
+        context.expected = 1
+      },
+      apply: (step, context, checkpoint) => {
+        context.observed += step
+        context.expected += step
+        if (step === 2) checkpoint()
+      },
+      cleanup,
+    }
+
+    await runTrace({
+      steps: [2, 3],
+      driver,
+      projection: {
+        observe: (context) => context.observed,
+        recompute: (context) => context.expected,
+        assertEqual: (observed, expected) => {
+          expect(observed).toBe(expected)
+          checkpoints.push(observed)
+        },
+      },
+    })
+
+    expect(checkpoints).toEqual([1, 3, 3, 6])
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+
+  it(`cleans up when a checkpoint fails`, async () => {
+    const cleanup = vi.fn()
+
+    await expect(
+      runTrace({
+        steps: [1],
+        driver: {
+          setup: () => ({ observed: 0, expected: 1 }),
+          apply: () => undefined,
+          cleanup,
+        },
+        projection: {
+          observe: (context) => context.observed,
+          recompute: (context) => context.expected,
+          assertEqual: (observed, expected) => {
+            expect(observed).toBe(expected)
+          },
+        },
+      }),
+    ).rejects.toThrow()
+
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/db/tests/trace-runner.test.ts
+++ b/packages/db/tests/trace-runner.test.ts
@@ -65,4 +65,81 @@ describe(`runTrace`, () => {
 
     expect(cleanup).toHaveBeenCalledOnce()
   })
+
+  it(`checks synchronous steps before queued microtasks run`, async () => {
+    await expect(
+      runTrace({
+        steps: [1],
+        driver: {
+          setup: () => ({ observed: 0, expected: 0 }),
+          apply: (step, context) => {
+            context.expected = step
+            queueMicrotask(() => {
+              context.observed = step
+            })
+          },
+          cleanup: () => undefined,
+        },
+        projection: {
+          observe: (context) => context.observed,
+          recompute: (context) => context.expected,
+          assertEqual: (observed, expected) => {
+            expect(observed).toBe(expected)
+          },
+        },
+      }),
+    ).rejects.toThrow()
+  })
+
+  it(`preserves the trace failure when cleanup also fails`, async () => {
+    const traceError = new Error(`trace failed`)
+    const cleanupError = new Error(`cleanup failed`)
+
+    const run = runTrace({
+      steps: [],
+      driver: {
+        setup: () => ({ observed: 0, expected: 1 }),
+        apply: () => undefined,
+        cleanup: () => {
+          throw cleanupError
+        },
+      },
+      projection: {
+        observe: (context) => context.observed,
+        recompute: (context) => context.expected,
+        assertEqual: () => {
+          throw traceError
+        },
+      },
+    })
+
+    await expect(run).rejects.toBe(traceError)
+    expect(
+      (traceError as Error & { suppressed?: Array<unknown> }).suppressed,
+    ).toEqual([cleanupError])
+  })
+
+  it(`throws cleanup failures when the trace succeeds`, async () => {
+    const cleanupError = new Error(`cleanup failed`)
+
+    await expect(
+      runTrace({
+        steps: [],
+        driver: {
+          setup: () => ({ observed: 0, expected: 0 }),
+          apply: () => undefined,
+          cleanup: () => {
+            throw cleanupError
+          },
+        },
+        projection: {
+          observe: (context) => context.observed,
+          recompute: (context) => context.expected,
+          assertEqual: (observed, expected) => {
+            expect(observed).toBe(expected)
+          },
+        },
+      }),
+    ).rejects.toBe(cleanupError)
+  })
 })

--- a/packages/db/tests/trace-runner.ts
+++ b/packages/db/tests/trace-runner.ts
@@ -1,0 +1,55 @@
+export type TraceCheckpoint = () => void
+
+export type TraceDriver<TStep, TContext> = {
+  setup: () => TContext | Promise<TContext>
+  start?: (context: TContext) => void | Promise<void>
+  apply: (
+    step: TStep,
+    context: TContext,
+    checkpoint: TraceCheckpoint,
+  ) => void | Promise<void>
+  cleanup: (context: TContext) => void | Promise<void>
+}
+
+export type TraceProjection<TContext, TObserved, TExpected = TObserved> = {
+  observe: (context: TContext) => TObserved
+  recompute: (context: TContext) => TExpected
+  assertEqual: (observed: TObserved, expected: TExpected) => void
+}
+
+type RunTraceOptions<TStep, TContext, TObserved, TExpected> = {
+  steps: ReadonlyArray<TStep>
+  driver: TraceDriver<TStep, TContext>
+  projection: TraceProjection<TContext, TObserved, TExpected>
+}
+
+/**
+ * Drives a trace against a system and checks its observable state against an
+ * independent projection after startup, after each step, and at any explicit
+ * checkpoint requested by the driver.
+ */
+export async function runTrace<TStep, TContext, TObserved, TExpected>({
+  steps,
+  driver,
+  projection,
+}: RunTraceOptions<TStep, TContext, TObserved, TExpected>): Promise<void> {
+  const context = await driver.setup()
+  const checkpoint = () => {
+    projection.assertEqual(
+      projection.observe(context),
+      projection.recompute(context),
+    )
+  }
+
+  try {
+    await driver.start?.(context)
+    checkpoint()
+
+    for (const step of steps) {
+      await driver.apply(step, context, checkpoint)
+      checkpoint()
+    }
+  } finally {
+    await driver.cleanup(context)
+  }
+}

--- a/packages/db/tests/trace-runner.ts
+++ b/packages/db/tests/trace-runner.ts
@@ -1,26 +1,55 @@
-export type TraceCheckpoint = () => void
+type MaybePromise<T> = T | PromiseLike<T>
+
+type ErrorWithSuppressed = Error & {
+  suppressed?: Array<unknown>
+}
+
+export type TraceCheckpoint = () => undefined
 
 export type TraceDriver<TStep, TContext> = {
-  setup: () => TContext | Promise<TContext>
-  start?: (context: TContext) => void | Promise<void>
+  setup: () => MaybePromise<TContext>
+  start?: (context: TContext) => MaybePromise<void>
   apply: (
     step: TStep,
     context: TContext,
     checkpoint: TraceCheckpoint,
-  ) => void | Promise<void>
-  cleanup: (context: TContext) => void | Promise<void>
+  ) => MaybePromise<void>
+  cleanup: (context: TContext) => MaybePromise<void>
 }
 
 export type TraceProjection<TContext, TObserved, TExpected = TObserved> = {
   observe: (context: TContext) => TObserved
   recompute: (context: TContext) => TExpected
-  assertEqual: (observed: TObserved, expected: TExpected) => void
+  assertEqual: (observed: TObserved, expected: TExpected) => undefined
 }
 
 type RunTraceOptions<TStep, TContext, TObserved, TExpected> = {
   steps: ReadonlyArray<TStep>
   driver: TraceDriver<TStep, TContext>
   projection: TraceProjection<TContext, TObserved, TExpected>
+}
+
+function isPromiseLike<T>(value: MaybePromise<T>): value is PromiseLike<T> {
+  return (
+    value !== null &&
+    (typeof value === `object` || typeof value === `function`) &&
+    `then` in value &&
+    typeof value.then === `function`
+  )
+}
+
+function attachSuppressedError(error: unknown, suppressed: unknown): void {
+  if (!(error instanceof Error)) return
+
+  try {
+    const errorWithSuppressed = error as ErrorWithSuppressed
+    errorWithSuppressed.suppressed = [
+      ...(errorWithSuppressed.suppressed ?? []),
+      suppressed,
+    ]
+  } catch {
+    // A frozen or otherwise immutable error must still remain the primary one.
+  }
 }
 
 /**
@@ -33,23 +62,40 @@ export async function runTrace<TStep, TContext, TObserved, TExpected>({
   driver,
   projection,
 }: RunTraceOptions<TStep, TContext, TObserved, TExpected>): Promise<void> {
-  const context = await driver.setup()
-  const checkpoint = () => {
+  const setupResult = driver.setup()
+  const context = isPromiseLike(setupResult) ? await setupResult : setupResult
+  const checkpoint: TraceCheckpoint = () => {
     projection.assertEqual(
       projection.observe(context),
       projection.recompute(context),
     )
+    return undefined
   }
 
+  let traceFailed = false
+  let traceError: unknown
   try {
-    await driver.start?.(context)
+    const startResult = driver.start?.(context)
+    if (isPromiseLike(startResult)) await startResult
     checkpoint()
 
     for (const step of steps) {
-      await driver.apply(step, context, checkpoint)
+      const applyResult = driver.apply(step, context, checkpoint)
+      if (isPromiseLike(applyResult)) await applyResult
       checkpoint()
     }
-  } finally {
-    await driver.cleanup(context)
+  } catch (error) {
+    traceFailed = true
+    traceError = error
   }
+
+  try {
+    const cleanupResult = driver.cleanup(context)
+    if (isPromiseLike(cleanupResult)) await cleanupResult
+  } catch (cleanupError) {
+    if (!traceFailed) throw cleanupError
+    attachSuppressedError(traceError, cleanupError)
+  }
+
+  if (traceFailed) throw traceError
 }


### PR DESCRIPTION
Extract the includes recompute-oracle loop into a reusable trace runner, then validate the driver/projection boundary with structural histories, scalar materialization, and full-row sync batches. This is test-only, and the expanded scalar driver has already exposed a new deterministic incremental-materialization bug.

## Reviewer guidance

### Root cause

The includes oracle had two hand-written execution loops. That made each new mutation or lifecycle domain repeat setup, checkpoint, and cleanup behavior instead of sharing one contract.

The first extracted runner also awaited every hook unconditionally. Awaiting a synchronous `apply` yields to the microtask queue before the checkpoint, which could hide stale state repaired by a queued microtask. Its cleanup path could replace the useful trace failure, and `assertEqual: () => void` allowed an async assertion whose promise the runner ignored.

### Approach

- A driver owns setup, startup, step application, and cleanup.
- A projection observes live state, recomputes expected state independently, and compares the two.
- The runner checks after startup and every step. Drivers can request extra checkpoints within a step.
- The runner awaits only promise-like hook results, so synchronous mutations and checkpoints stay in the same turn.
- If both the trace and cleanup fail, the trace error remains primary and the cleanup error is attached as suppressed diagnostic data.
- Projection assertions must return `undefined`; a type test rejects async assertions.
- A deterministic full-row driver sends multi-change sync batches through the structural projection. Its trace covers inserts, updates, reparenting, deletion, and insertion.
- The scalar-materialization driver can update a nested reference. A reduced five-step expected-failure seed records the new bug it found: changing `middle.sharedId` updates the visible key but leaves the old nested shared row materialized.

### Key invariants

- Synchronous mutations and their checkpoints occur in the same turn.
- Async lifecycle hooks finish before the runner advances.
- Every trace checks its initial post-start state and the state after each step.
- Explicit checkpoints can verify intermediate optimistic states within a step.
- Cleanup runs after startup, step, or assertion failures.
- A trace failure stays primary if cleanup also fails; cleanup alone still fails the run.
- Observed state and recomputed state remain independent.
- Known and discovered runtime failures must reject with the oracle assertion, not an unrelated harness error.

### Non-goals

- No production query fix for the newly discovered nested-reference bug; that belongs in a separate small PR.
- No broad generators yet for full-row batches, timing, lifecycle, publication, rekeying, or deeper guaranteed paths.
- No changes to existing known-failure seeds.
- No replay system or multiple-projection orchestration.

### Trade-offs

Assertions remain synchronous to preserve exact checkpoint timing. The batch driver uses a short deterministic trace: it is enough to test the abstraction with a distinct mutation model while leaving the larger fuzz-domain expansion for later RFC slices. The new bug stays as an assertion-specific expected failure so this test-infrastructure PR remains green without hiding unrelated failures.

## Verification

From `packages/db`:

```bash
pnpm exec vitest run tests/query/includes-oracle.property.test.ts tests/trace-runner.test.ts tests/trace-runner.test-d.ts
pnpm test
```

- Oracle file: 12 tests passed; no type errors.
- Full DB suite: 110 files, 2,541 tests passed, 5 skipped; no type errors.
- ESLint, Prettier, and `git diff --check` pass.

## Files changed

- `packages/db/tests/trace-runner.ts`: adds the shared runner and its timing and error-handling guarantees.
- `packages/db/tests/trace-runner.test.ts`: tests checkpoints, same-turn timing, and cleanup failure precedence.
- `packages/db/tests/trace-runner.test-d.ts`: proves async projection assertions are rejected.
- `packages/db/tests/query/includes-oracle.property.test.ts`: migrates the existing oracle drivers, adds the full-row batch driver, and records the nested-reference failure.

## Release impact

- [x] This change is docs/CI/dev-only (no release).

---

Related work: RFC #1658, #1716, #1717.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive trace-based coverage for structural, full-row batch, and materialization scenarios.
  * Added validation for checkpoints during startup, after each step, and at explicit checkpoints.
  * Ensured cleanup runs reliably after assertion failures and preserves the original error.
  * Added coverage for batched partial and full-row updates.
  * Added materialization checks for leaf updates following inserts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
