### PR TITLE
test(db): expand includes oracle state coverage

### DIFF
--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -1,6 +1,7 @@
 import { fc, test as fcTest } from '@fast-check/vitest'
 import { describe, expect } from 'vitest'
 import {
+  concat,
   createLiveQueryCollection,
   eq,
   materialize,
@@ -776,7 +777,9 @@ function createStructuralTraceContext(
 async function cleanupStructuralTrace({
   incremental,
   sources,
-}: StructuralTraceContext): Promise<void> {
+}: Pick<StructuralTraceContext, `sources`> & {
+  incremental: { cleanup: () => Promise<void> }
+}): Promise<void> {
   await incremental.cleanup()
   await cleanupSources(sources)
 }
@@ -801,7 +804,24 @@ function createStructuralTraceDriver(
 
 type FullRowBatchStep =
   | { level: 0; changes: Array<SyncChange<RootRow>> }
-  | { level: 1; changes: Array<SyncChange<ChildRow>> }
+  | { level: IncludeDepth; changes: Array<SyncChange<ChildRow>> }
+
+type FullRowBatchInput = {
+  level: 0 | IncludeDepth
+  changes: Array<{
+    type: `put` | `delete`
+    id: number
+    parentGroup: number
+    group: number
+    value: number
+    position: number
+  }>
+}
+
+type FullRowBatchScenario = {
+  depth: IncludeDepth
+  steps: Array<FullRowBatchStep>
+}
 
 function updateModel<T extends { id: number }>(
   model: Map<number, T>,
@@ -816,12 +836,11 @@ function updateModel<T extends { id: number }>(
   }
 }
 
-function createFullRowBatchTraceDriver(): TraceDriver<
-  FullRowBatchStep,
-  StructuralTraceContext
-> {
+function createFullRowBatchTraceDriver(
+  depth: IncludeDepth,
+): TraceDriver<FullRowBatchStep, StructuralTraceContext> {
   return {
-    setup: () => createStructuralTraceContext(1, `full`),
+    setup: () => createStructuralTraceContext(depth, `full`),
     start: ({ incremental }) => incremental.preload(),
     apply: (step, { sources, roots, levels }) => {
       if (step.level === 0) {
@@ -830,8 +849,9 @@ function createFullRowBatchTraceDriver(): TraceDriver<
         return
       }
 
-      sources.levels[0].writeBatch(step.changes)
-      updateModel(levels[0]!, step.changes)
+      const level = step.level - 1
+      sources.levels[level]!.writeBatch(step.changes)
+      updateModel(levels[level]!, step.changes)
     },
     cleanup: cleanupStructuralTrace,
   }
@@ -886,6 +906,363 @@ const fullRowBatchTrace: Array<FullRowBatchStep> = [
     ],
   },
 ]
+
+const fullRowSharedRoutingSeed: FullRowBatchScenario = {
+  depth: 1,
+  steps: [
+    {
+      level: 0,
+      changes: [
+        { type: `insert`, value: batchRoot(0, 2, 0, 0) },
+        { type: `insert`, value: batchRoot(1, 2, 0, 0) },
+      ],
+    },
+    {
+      level: 0,
+      changes: [{ type: `delete`, value: batchRoot(1, 2, 0, 0) }],
+    },
+    {
+      level: 0,
+      changes: [{ type: `insert`, value: batchRoot(1, 0, 0, 0) }],
+    },
+    {
+      level: 1,
+      changes: [{ type: `insert`, value: batchChild(0, 2, 0, 0) }],
+    },
+  ],
+}
+
+function fullRowBatchInputArbitrary(
+  depth: IncludeDepth,
+  levels: `all` | `children`,
+  maxBatchSize = 3,
+): fc.Arbitrary<FullRowBatchInput> {
+  const levelsArbitrary =
+    levels === `all`
+      ? levelArbitrary(depth)
+      : fc.integer({ min: 1, max: depth }).map((level) => level as IncludeDepth)
+
+  return levelsArbitrary.chain((level) =>
+    fc
+      .uniqueArray(
+        fc.record({
+          // Root delete/reinsert has a known failing seed below. Keep the
+          // generated green corpus out of that class while still generating
+          // inserts, replacements, and multi-change batches at the root.
+          type:
+            level === 0
+              ? fc.constant(`put` as const)
+              : fc.constantFrom(`put` as const, `delete` as const),
+          id: fc.integer({ min: 0, max: 5 }),
+          parentGroup: fc.integer({ min: 0, max: 4 }),
+          group: fc.integer({ min: 0, max: 4 }),
+          value: fc.integer({ min: -3, max: 3 }),
+          position: fc.integer({ min: -2, max: 2 }),
+        }),
+        {
+          selector: (change) => change.id,
+          minLength: 1,
+          maxLength: maxBatchSize,
+        },
+      )
+      .map((changes) => ({ level, changes })),
+  )
+}
+
+function createConnectedBatchPrefix(
+  depth: IncludeDepth,
+): Array<FullRowBatchStep> {
+  // Generated ids stop at 5, so this path survives every later batch and
+  // guarantees that the selected depth is observable at every checkpoint.
+  const steps: Array<FullRowBatchStep> = [
+    {
+      level: 0,
+      changes: [{ type: `insert`, value: batchRoot(100, 100, 100, 0) }],
+    },
+  ]
+
+  for (let level = 1; level <= depth; level++) {
+    steps.push({
+      level: level as IncludeDepth,
+      changes: [
+        {
+          type: `insert`,
+          value: {
+            ...batchChild(100 + level, 99 + level, 100 + level, 0),
+            group: 100 + level,
+          },
+        },
+      ],
+    })
+  }
+
+  return steps
+}
+
+function normalizeFullRowBatchInputs(
+  depth: IncludeDepth,
+  inputs: Array<FullRowBatchInput>,
+  allowChildRelationshipUpdates: boolean,
+): FullRowBatchScenario {
+  const roots = new Map<number, RootRow>([[100, batchRoot(100, 100, 100, 0)]])
+  const levels = Array.from(
+    { length: 4 },
+    (_, level) =>
+      new Map<number, ChildRow>(
+        level < depth
+          ? [
+              [
+                101 + level,
+                {
+                  ...batchChild(101 + level, 100 + level, 101 + level, 0),
+                  group: 101 + level,
+                },
+              ],
+            ]
+          : [],
+      ),
+  )
+  const steps = createConnectedBatchPrefix(depth)
+
+  for (const input of inputs) {
+    if (input.level === 0) {
+      const changes = input.changes.map((change): SyncChange<RootRow> => {
+        const current = roots.get(change.id)
+        if (change.type === `delete` && current) {
+          roots.delete(change.id)
+          return { type: `delete`, value: current }
+        }
+
+        const value: RootRow = {
+          id: change.id,
+          group: current ? current.group : change.group,
+          value: change.value,
+          position: change.position,
+        }
+        roots.set(value.id, value)
+        return { type: current ? `update` : `insert`, value }
+      })
+      steps.push({ level: 0, changes })
+      continue
+    }
+
+    const model = levels[input.level - 1]!
+    const changes = input.changes.map((change): SyncChange<ChildRow> => {
+      const current = model.get(change.id)
+      if (change.type === `delete` && current) {
+        model.delete(change.id)
+        return { type: `delete`, value: current }
+      }
+
+      const value: ChildRow = {
+        id: change.id,
+        parentGroup:
+          !allowChildRelationshipUpdates && current
+            ? current.parentGroup
+            : change.parentGroup,
+        group:
+          !allowChildRelationshipUpdates && current
+            ? current.group
+            : change.group,
+        value: change.value,
+        position: change.position,
+      }
+      model.set(value.id, value)
+      return { type: current ? `update` : `insert`, value }
+    })
+    steps.push({ level: input.level, changes })
+  }
+
+  return { depth, steps }
+}
+
+function fullRowBatchScenarioArbitrary(
+  allowChildRelationshipUpdates: boolean,
+  levels: `all` | `children` = `all`,
+  maxBatchSize = 3,
+): fc.Arbitrary<FullRowBatchScenario> {
+  return depthArbitrary.chain((depth) =>
+    fc
+      .array(fullRowBatchInputArbitrary(depth, levels, maxBatchSize), {
+        minLength: 1,
+        maxLength: 10,
+      })
+      .map((inputs) =>
+        normalizeFullRowBatchInputs(
+          depth,
+          inputs,
+          allowChildRelationshipUpdates,
+        ),
+      ),
+  )
+}
+
+async function expectFullRowBatchScenarioMatches({
+  depth,
+  steps,
+}: FullRowBatchScenario): Promise<void> {
+  await runTrace({
+    steps,
+    driver: createFullRowBatchTraceDriver(depth),
+    projection: structuralProjection,
+  })
+}
+
+type FlatMaterialization = `array` | `concat`
+
+function createFlatMaterializationQuery(
+  materialization: FlatMaterialization,
+  sources: Sources,
+) {
+  if (materialization === `array`) {
+    return createLiveQueryCollection((q) =>
+      q
+        .from({ root: sources.roots.collection })
+        .orderBy(({ root }) => root.position)
+        .orderBy(({ root }) => root.id)
+        .select(({ root }) => ({
+          id: root.id,
+          group: root.group,
+          children: materialize(
+            q
+              .from({ child: sources.levels[0].collection })
+              .where(({ child }) => eq(child.parentGroup, root.group))
+              .orderBy(({ child }) => child.position)
+              .orderBy(({ child }) => child.id)
+              .select(({ child }) => ({ id: child.id, value: child.value })),
+          ),
+        })),
+    )
+  }
+
+  return createLiveQueryCollection((q) =>
+    q
+      .from({ root: sources.roots.collection })
+      .orderBy(({ root }) => root.position)
+      .orderBy(({ root }) => root.id)
+      .select(({ root }) => ({
+        id: root.id,
+        group: root.group,
+        content: concat(
+          toArray(
+            q
+              .from({ child: sources.levels[0].collection })
+              .where(({ child }) => eq(child.parentGroup, root.group))
+              .orderBy(({ child }) => child.position)
+              .orderBy(({ child }) => child.id)
+              .select(({ child }) => child.value),
+          ),
+        ),
+      })),
+  )
+}
+
+type FlatMaterializationContext = Omit<
+  StructuralTraceContext,
+  `incremental`
+> & {
+  incremental: ReturnType<typeof createFlatMaterializationQuery>
+}
+
+function createFlatMaterializationDriver(
+  materialization: FlatMaterialization,
+): TraceDriver<FullRowBatchStep, FlatMaterializationContext> {
+  return {
+    setup: () => {
+      const sources = createSources(`full`)
+      return {
+        depth: 1,
+        sources,
+        incremental: createFlatMaterializationQuery(materialization, sources),
+        roots: new Map<number, RootRow>(),
+        levels: Array.from({ length: 4 }, () => new Map<number, ChildRow>()),
+      }
+    },
+    start: ({ incremental }) => incremental.preload(),
+    apply: (step, { sources, roots, levels }) => {
+      if (step.level === 0) {
+        sources.roots.writeBatch(step.changes)
+        updateModel(roots, step.changes)
+        return
+      }
+
+      if (step.level !== 1) {
+        throw new Error(`Flat materialization only supports depth 1`)
+      }
+      sources.levels[0].writeBatch(step.changes)
+      updateModel(levels[0]!, step.changes)
+    },
+    cleanup: cleanupStructuralTrace,
+  }
+}
+
+type FlatMaterializationResult = Array<
+  | {
+      id: number
+      group: number
+      children: Array<{ id: number; value: number }>
+    }
+  | { id: number; group: number; content: string }
+>
+
+function recomputeFlatMaterialization(
+  materialization: FlatMaterialization,
+  roots: Map<number, RootRow>,
+  children: Map<number, ChildRow>,
+): FlatMaterializationResult {
+  return [...roots.values()].sort(compareRows).map((root) => {
+    const matching = [...children.values()]
+      .filter((child) => child.parentGroup === root.group)
+      .sort(compareRows)
+    return materialization === `array`
+      ? {
+          id: root.id,
+          group: root.group,
+          children: matching.map(({ id, value }) => ({ id, value })),
+        }
+      : {
+          id: root.id,
+          group: root.group,
+          content: matching.map(({ value }) => String(value)).join(``),
+        }
+  })
+}
+
+function flatMaterializationProjection(
+  materialization: FlatMaterialization,
+): TraceProjection<
+  FlatMaterializationContext,
+  unknown,
+  FlatMaterializationResult
+> {
+  return {
+    observe: ({ incremental }) => stripVirtualProperties(incremental.toArray),
+    recompute: ({ roots, levels }) =>
+      recomputeFlatMaterialization(materialization, roots, levels[0]!),
+    assertEqual: (observed, expected) => {
+      expect(observed).toEqual(expected)
+      return undefined
+    },
+  }
+}
+
+const flatMaterializationScenarioArbitrary = fc
+  .array(fullRowBatchInputArbitrary(1, `all`), {
+    minLength: 1,
+    maxLength: 12,
+  })
+  .map((inputs) => normalizeFullRowBatchInputs(1, inputs, false))
+
+async function expectFlatMaterializationScenarioMatches(
+  materialization: FlatMaterialization,
+  scenario: FullRowBatchScenario,
+): Promise<void> {
+  await runTrace({
+    steps: scenario.steps,
+    driver: createFlatMaterializationDriver(materialization),
+    projection: flatMaterializationProjection(materialization),
+  })
+}
 
 const structuralProjection: TraceProjection<
   StructuralTraceContext,
@@ -1149,7 +1526,75 @@ async function expectMaterializeScenarioMatches({
   })
 }
 
+const intraBatchChildHandOffScenario: FullRowBatchScenario = {
+  depth: 1,
+  steps: [
+    {
+      level: 0,
+      changes: [
+        { type: `insert`, value: batchRoot(0, 1, 0, 0) },
+        { type: `insert`, value: batchRoot(1, 3, 0, 0) },
+      ],
+    },
+    {
+      level: 1,
+      changes: [
+        { type: `insert`, value: batchChild(5, 3, 0, 0) },
+        { type: `insert`, value: batchChild(1, 1, 0, 0) },
+      ],
+    },
+    {
+      level: 1,
+      changes: [
+        { type: `update`, value: batchChild(1, 0, 0, 0) },
+        { type: `update`, value: batchChild(5, 1, 0, 0) },
+      ],
+    },
+  ],
+}
+
 describe(`includes recompute oracle`, () => {
+  for (const materialization of [`array`, `concat`] as const) {
+    fcTest(
+      `discovered trace: ${materialization} follows an intra-batch child hand-off`,
+      expectAssertionFailure(async () => {
+        await expectFlatMaterializationScenarioMatches(
+          materialization,
+          intraBatchChildHandOffScenario,
+        )
+      }),
+    )
+  }
+
+  fcTest.prop(
+    [
+      fc.constantFrom<FlatMaterialization>(`array`, `concat`),
+      flatMaterializationScenarioArbitrary,
+    ],
+    {
+      numRuns: 30,
+      seed: 1721,
+    },
+  )(`matches recomputation for flat materializations`, (kind, scenario) =>
+    expectFlatMaterializationScenarioMatches(kind, scenario),
+  )
+
+  fcTest.prop([fullRowBatchScenarioArbitrary(false)], {
+    numRuns: 40,
+    seed: 1719,
+  })(
+    `matches recomputation for generated full-row batches at every depth`,
+    expectFullRowBatchScenarioMatches,
+  )
+
+  fcTest.prop([fullRowBatchScenarioArbitrary(true, `children`, 1)], {
+    numRuns: 40,
+    seed: 1721,
+  })(
+    `matches recomputation for single-row child reparenting and rekeying`,
+    expectFullRowBatchScenarioMatches,
+  )
+
   fcTest(
     `discovered seed: nested scalar materialization follows a reference update`,
     expectAssertionFailure(async () => {
@@ -1170,10 +1615,17 @@ describe(`includes recompute oracle`, () => {
   fcTest(`matches recomputation for full-row sync batches`, async () => {
     await runTrace({
       steps: fullRowBatchTrace,
-      driver: createFullRowBatchTraceDriver(),
+      driver: createFullRowBatchTraceDriver(1),
       projection: structuralProjection,
     })
   })
+
+  fcTest(
+    `discovered seed: a reinserted parent drops its old shared route`,
+    expectAssertionFailure(() =>
+      expectFullRowBatchScenarioMatches(fullRowSharedRoutingSeed),
+    ),
+  )
 
   fcTest(`supports repeated optimistic rollbacks in one history`, async () => {
     await expectScenarioMatches({


### PR DESCRIPTION
Expand the includes recompute oracle across depths 1–4, generated full-row batches, reorders, child relationship changes, and flat array/concat materialization. This is test-only: it records two newly isolated runtime defect classes as assertion-specific expected failures but does not change query behavior.

## Reviewer guidance

### Coverage gap

The reusable trace runner from #1718 had only a short depth-1 full-row trace. It did not guarantee that generated histories reached the selected include depth, exercise full-row multi-change batches, preserve reorder coverage while isolating relationship changes, or compare flat `materialize()` and `concat(toArray(...))` outputs with independent recomputation.

Without those cases, the oracle could miss routing failures that depend on shared correlation keys, delete/reinsert lifetimes, or several child changes arriving in one batch.

### Approach

- Generalize the full-row batch driver to depths 1–4.
- Generate bounded multi-change histories and prepend a connected path whose reserved IDs cannot be overwritten by generated rows. This makes every selected depth observable at every checkpoint.
- Keep root reorder changes in the green corpus while excluding the known delete/reinsert failure class.
- Exercise child reparenting and rekeying one row at a time. Multi-row relationship changes remain represented by a reduced expected-failure trace.
- Add independent flat projections for array materialization and `concat(toArray(...))`.
- Reduce each discovered mismatch to a deterministic trace and accept only the oracle's equality assertion as the expected failure.

The expanded suite now preserves three unfixed state-equivalence defect classes:

1. A nested scalar reference redirect retains the old materialized row (landed with #1718).
2. Deleting and reinserting one of two parents that shared a correlation key can leave the reinserted parent subscribed to its old route.
3. Reparenting two children in one batch can leave aggregate membership stale. The array and concat traces are two projections of this same defect, not separate bugs.

### Key invariants

- The incremental result equals a fresh recomputation after startup and every batch.
- Every generated depth has a live, connected result path.
- Row ordering follows `position` and then `id`, including generated reorders.
- A child belongs only to parents whose current group matches its current `parentGroup`.
- Array and concat materializations derive from the same current child membership and order.
- Known failures pass only for an oracle assertion mismatch; setup, runtime, and cleanup errors still fail the test.

### Non-goals

- No production fix for any recorded defect.
- No readiness, progressive-sync timing, publication, adapter, or ownership driver.
- No claim that array and concat expose distinct underlying bugs.
- No unbounded fuzzing or replay framework.

### Trade-offs

The generated runs are deterministic and bounded to keep CI fast and reproducible. The green generators avoid state transitions already proven broken; those transitions live as small expected-failure traces until the routing refactor makes them green. Single-row child relationship changes keep reparent/rekey coverage active without masking the separate intra-batch hand-off defect.

## Verification

From `packages/db`:

```bash
pnpm exec vitest run tests/query/includes-oracle.property.test.ts
pnpm test
```

The focused oracle suite passes 18/18. TypeScript, ESLint, Prettier, the full DB suite, and `git diff --check` also pass.

## Files changed

- `packages/db/tests/query/includes-oracle.property.test.ts`: expands the full-row generators and depth coverage, adds flat materialization projections, and records the shared-route and intra-batch hand-off failures.

## Release impact

- [x] Tests only; no changeset or release is needed.

---

Related work: RFC #1658, #1718.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for nested data updates across multiple relationship levels.
  - Added scenarios for inserts, deletes, updates, reparenting, and key changes.
  - Added deterministic tests for shared routing and child handoffs within a batch.
  - Added validation for flat and array-based result materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->