### PR TITLE
feat(svelte-db): add infinite query binding

### DIFF
--- a/.changeset/spicy-roses-hide.md
+++ b/.changeset/spicy-roses-hide.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/svelte-db': minor
+---
+
+Add `useLiveInfiniteQuery` as a Svelte binding over the shared live-query window controller.

--- a/packages/svelte-db/src/index.ts
+++ b/packages/svelte-db/src/index.ts
@@ -1,5 +1,6 @@
 // Re-export all public APIs
 export * from './useLiveQuery.svelte.js'
+export * from './useLiveInfiniteQuery.svelte.js'
 
 // Re-export everything from @tanstack/db
 export * from '@tanstack/db'

--- a/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
+++ b/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
@@ -1,0 +1,264 @@
+import {
+  createLiveQueryCollection,
+  createLiveQueryWindowController,
+  isCollection,
+} from '@tanstack/db'
+import { untrack } from 'svelte'
+// Type-only: used in `ReturnType<typeof useLiveQuery>` below.
+import type { useLiveQuery } from './useLiveQuery.svelte.js'
+import type {
+  Collection,
+  Context,
+  InferResultType,
+  InitialQueryBuilder,
+  LiveQueryWindowController,
+  LiveQueryWindowSnapshot,
+  NonSingleResult,
+  QueryBuilder,
+} from '@tanstack/db'
+
+const DEFAULT_PAGE_SIZE = 20
+const DEFAULT_GC_TIME_MS = 1
+
+type MaybeGetter<T> = T | (() => T)
+
+type WindowedCollection = Collection<any, any, any> & {
+  utils: {
+    setWindow: (options: {
+      offset: number
+      limit: number
+    }) => true | Promise<void>
+    getWindow?: () => { offset: number; limit: number } | undefined
+  }
+}
+
+type ResolvedInput<TContext extends Context> =
+  | { kind: `collection`; collection: Collection<any, any, any> }
+  | {
+      kind: `query`
+      query: (q: InitialQueryBuilder) => QueryBuilder<TContext>
+    }
+
+function hasSetWindow(
+  collection: Collection<any, any, any>,
+): collection is WindowedCollection {
+  return typeof collection.utils?.setWindow === `function`
+}
+
+function resolveInput<TContext extends Context>(
+  input: unknown,
+): ResolvedInput<TContext> {
+  if (isCollection(input)) {
+    return { kind: `collection`, collection: input }
+  }
+
+  if (typeof input !== `function`) {
+    throw new Error(
+      `useLiveInfiniteQuery: First argument must be either a pre-created live query collection or a query function. ` +
+        `Received: ${typeof input}`,
+    )
+  }
+
+  // A zero-argument function can be a reactive collection getter. Query
+  // callbacks conventionally accept the builder, so avoid probing those.
+  if (input.length === 0) {
+    try {
+      const collection = (input as () => unknown)()
+      if (isCollection(collection)) {
+        return { kind: `collection`, collection }
+      }
+    } catch {
+      // Query callbacks that close over their builder can still have arity 0.
+    }
+  }
+
+  return {
+    kind: `query`,
+    query: input as (q: InitialQueryBuilder) => QueryBuilder<TContext>,
+  }
+}
+
+export type UseLiveInfiniteQueryConfig<TContext extends Context> = {
+  pageSize?: number
+  initialPageParam?: number
+  /**
+   * @deprecated Pagination uses the shared controller's peek-ahead strategy.
+   * This remains for compatibility with TanStack Query conventions.
+   */
+  getNextPageParam?: (
+    lastPage: Array<InferResultType<TContext>[number]>,
+    allPages: Array<Array<InferResultType<TContext>[number]>>,
+    lastPageParam: number,
+    allPageParams: Array<number>,
+  ) => number | undefined
+}
+
+export type UseLiveInfiniteQueryReturn<TContext extends Context> = Omit<
+  ReturnType<typeof useLiveQuery<TContext>>,
+  `data`
+> & {
+  data: InferResultType<TContext>
+  pages: Array<Array<InferResultType<TContext>[number]>>
+  pageParams: Array<number>
+  fetchNextPage: () => void
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  error: unknown
+}
+
+type EnabledLiveQueryReturn<TContext extends Context> = ReturnType<
+  typeof useLiveQuery<TContext>
+>
+
+/**
+ * Create a Svelte-native reactive view over the shared live-query window
+ * controller. The query must include an `orderBy` clause.
+ */
+export function useLiveInfiniteQuery<
+  TResult extends object,
+  TKey extends string | number,
+  TUtils extends Record<string, any>,
+>(
+  liveQueryCollection: MaybeGetter<
+    Collection<TResult, TKey, TUtils> & NonSingleResult
+  >,
+  config: UseLiveInfiniteQueryConfig<any>,
+): UseLiveInfiniteQueryReturn<any>
+
+export function useLiveInfiniteQuery<TContext extends Context>(
+  queryFn: (q: InitialQueryBuilder) => QueryBuilder<TContext>,
+  config: UseLiveInfiniteQueryConfig<TContext>,
+  deps?: Array<() => unknown>,
+): UseLiveInfiniteQueryReturn<TContext>
+
+export function useLiveInfiniteQuery<TContext extends Context>(
+  queryFnOrCollection: unknown,
+  config: UseLiveInfiniteQueryConfig<TContext>,
+  deps: Array<() => unknown> = [],
+): UseLiveInfiniteQueryReturn<TContext> {
+  let validatedCollection: Collection<any, any, any> | null = null
+
+  const pageSize = $derived(
+    config.pageSize !== undefined && config.pageSize > 0
+      ? config.pageSize
+      : DEFAULT_PAGE_SIZE,
+  )
+  const initialPageParam = $derived(config.initialPageParam ?? 0)
+
+  const controller = $derived.by(() => {
+    for (const dependency of deps) dependency()
+
+    const input = resolveInput<TContext>(queryFnOrCollection)
+    let collection: Collection<any, any, any>
+
+    if (input.kind === `collection`) {
+      collection = input.collection
+      if (!hasSetWindow(collection)) {
+        throw new Error(
+          `useLiveInfiniteQuery: Pre-created live query collection must have an orderBy clause for infinite pagination to work. ` +
+            `Please add .orderBy() to your createLiveQueryCollection query.`,
+        )
+      }
+
+      if (validatedCollection !== collection) {
+        validatedCollection = collection
+        const currentWindow = collection.utils.getWindow?.()
+        const expectedLimit = pageSize + 1
+        if (
+          currentWindow &&
+          (currentWindow.offset !== 0 || currentWindow.limit !== expectedLimit)
+        ) {
+          console.warn(
+            `useLiveInfiniteQuery: Pre-created collection has window {offset: ${currentWindow.offset}, limit: ${currentWindow.limit}} ` +
+              `but the hook expects {offset: 0, limit: ${expectedLimit}}. Adjusting window now.`,
+          )
+        }
+      }
+    } else {
+      collection = createLiveQueryCollection({
+        query: (q: InitialQueryBuilder) =>
+          input
+            .query(q)
+            .limit(pageSize + 1)
+            .offset(0),
+        startSync: false,
+        gcTime: DEFAULT_GC_TIME_MS,
+      })
+    }
+
+    return createLiveQueryWindowController(collection, {
+      pageSize,
+      initialPageParam,
+    })
+  })
+
+  let snapshot = $state.raw<LiveQueryWindowSnapshot<any, any>>(
+    untrack(() => controller.getSnapshot()),
+  )
+
+  $effect(() => {
+    const currentController: LiveQueryWindowController<any, any> = controller
+    snapshot = currentController.getSnapshot()
+    const unsubscribe = currentController.subscribe(() => {
+      snapshot = currentController.getSnapshot()
+    })
+    snapshot = currentController.getSnapshot()
+
+    return () => {
+      unsubscribe()
+      currentController.dispose()
+    }
+  })
+
+  const fetchNextPage = () => {
+    void controller.fetchNextPage().catch(() => {
+      // Pagination errors are exposed through the controller snapshot.
+    })
+  }
+
+  return {
+    get state() {
+      return snapshot.state as EnabledLiveQueryReturn<TContext>[`state`]
+    },
+    get data() {
+      return snapshot.data as InferResultType<TContext>
+    },
+    get collection() {
+      return snapshot.collection as EnabledLiveQueryReturn<TContext>[`collection`]
+    },
+    get status() {
+      return snapshot.status as EnabledLiveQueryReturn<TContext>[`status`]
+    },
+    get isLoading() {
+      return snapshot.isLoading
+    },
+    get isReady() {
+      return snapshot.isReady
+    },
+    get isIdle() {
+      return snapshot.isIdle
+    },
+    get isError() {
+      return snapshot.isError
+    },
+    get isCleanedUp() {
+      return snapshot.isCleanedUp
+    },
+    get pages() {
+      return snapshot.pages as Array<Array<InferResultType<TContext>[number]>>
+    },
+    get pageParams() {
+      return snapshot.pageParams as Array<number>
+    },
+    get hasNextPage() {
+      return snapshot.hasNextPage
+    },
+    get isFetchingNextPage() {
+      return snapshot.isFetchingNextPage
+    },
+    get error() {
+      return snapshot.error
+    },
+    fetchNextPage,
+  }
+}

--- a/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
+++ b/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
@@ -14,10 +14,9 @@ import type {
   Context,
   InferResultType,
   InitialQueryBuilder,
-  LiveQueryWindowController,
-  LiveQueryWindowSnapshot,
   NonSingleResult,
   QueryBuilder,
+  UtilsRecord,
 } from '@tanstack/db'
 
 const DEFAULT_PAGE_SIZE = 20
@@ -25,7 +24,9 @@ const DEFAULT_GC_TIME_MS = 1
 
 type MaybeGetter<T> = T | (() => T)
 
-type WindowedCollection = Collection<any, any, any> & {
+type InternalCollection = Collection<object, string | number, UtilsRecord>
+
+type WindowedCollection = InternalCollection & {
   utils: {
     setWindow: (options: {
       offset: number
@@ -36,7 +37,7 @@ type WindowedCollection = Collection<any, any, any> & {
 }
 
 type ResolvedInput<TContext extends Context> =
-  | { kind: `collection`; collection: Collection<any, any, any> }
+  | { kind: `collection`; collection: InternalCollection }
   | {
       kind: `query`
       query: (q: InitialQueryBuilder) => QueryBuilder<TContext>
@@ -48,9 +49,9 @@ type InfiniteQueryOptions = {
 }
 
 function hasSetWindow(
-  collection: Collection<any, any, any>,
+  collection: InternalCollection,
 ): collection is WindowedCollection {
-  return typeof collection.utils?.setWindow === `function`
+  return typeof collection.utils.setWindow === `function`
 }
 
 function normalizePageSize(pageSize: number | undefined): number {
@@ -173,7 +174,7 @@ export function useLiveInfiniteQuery<TContext extends Context>(
   config: InfiniteQueryOptions,
   deps: Array<() => unknown> = [],
 ): UseLiveInfiniteQueryReturn<TContext> {
-  let validatedCollection: Collection<any, any, any> | null = null
+  let validatedCollection: InternalCollection | null = null
 
   const pageSize = $derived(normalizePageSize(config.pageSize))
   const initialPageParam = $derived(config.initialPageParam ?? 0)
@@ -182,10 +183,8 @@ export function useLiveInfiniteQuery<TContext extends Context>(
     for (const dependency of deps) dependency()
 
     const input = resolveInput<TContext>(queryFnOrCollection)
-    let collection: Collection<any, any, any>
-
     if (input.kind === `collection`) {
-      collection = input.collection
+      const collection = input.collection
       if (!hasSetWindow(collection)) {
         throw new Error(
           `useLiveInfiniteQuery: Pre-created live query collection must have an orderBy clause for infinite pagination to work. ` +
@@ -207,30 +206,31 @@ export function useLiveInfiniteQuery<TContext extends Context>(
           )
         }
       }
-    } else {
-      collection = createLiveQueryCollection({
-        query: (q: InitialQueryBuilder) =>
-          input
-            .query(q)
-            .limit(pageSize + 1)
-            .offset(0),
-        startSync: false,
-        gcTime: DEFAULT_GC_TIME_MS,
+      return createLiveQueryWindowController(collection, {
+        pageSize,
+        initialPageParam,
       })
     }
 
+    const collection = createLiveQueryCollection({
+      query: (q: InitialQueryBuilder) =>
+        input
+          .query(q)
+          .limit(pageSize + 1)
+          .offset(0),
+      startSync: false,
+      gcTime: DEFAULT_GC_TIME_MS,
+    })
     return createLiveQueryWindowController(collection, {
       pageSize,
       initialPageParam,
     })
   })
 
-  let snapshot = $state.raw<LiveQueryWindowSnapshot<any, any>>(
-    untrack(() => controller.getSnapshot()),
-  )
+  let snapshot = $state.raw(untrack(() => controller.getSnapshot()))
 
   $effect(() => {
-    const currentController: LiveQueryWindowController<any, any> = controller
+    const currentController = controller
     snapshot = currentController.getSnapshot()
     const unsubscribe = currentController.subscribe(() => {
       snapshot = currentController.getSnapshot()

--- a/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
+++ b/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
@@ -5,7 +5,10 @@ import {
 } from '@tanstack/db'
 import { untrack } from 'svelte'
 // Type-only: used in `ReturnType<typeof useLiveQuery>` below.
-import type { useLiveQuery } from './useLiveQuery.svelte.js'
+import type {
+  UseLiveQueryReturnWithCollection,
+  useLiveQuery,
+} from './useLiveQuery.svelte.js'
 import type {
   Collection,
   Context,
@@ -39,10 +42,26 @@ type ResolvedInput<TContext extends Context> =
       query: (q: InitialQueryBuilder) => QueryBuilder<TContext>
     }
 
+type InfiniteQueryOptions = {
+  pageSize?: number
+  initialPageParam?: number
+}
+
 function hasSetWindow(
   collection: Collection<any, any, any>,
 ): collection is WindowedCollection {
   return typeof collection.utils?.setWindow === `function`
+}
+
+function normalizePageSize(pageSize: number | undefined): number {
+  if (
+    pageSize === undefined ||
+    !Number.isSafeInteger(pageSize) ||
+    pageSize <= 0
+  ) {
+    return DEFAULT_PAGE_SIZE
+  }
+  return pageSize
 }
 
 function resolveInput<TContext extends Context>(
@@ -78,20 +97,21 @@ function resolveInput<TContext extends Context>(
   }
 }
 
-export type UseLiveInfiniteQueryConfig<TContext extends Context> = {
-  pageSize?: number
-  initialPageParam?: number
+export type LiveInfiniteQueryConfig<TRow> = InfiniteQueryOptions & {
   /**
    * @deprecated Pagination uses the shared controller's peek-ahead strategy.
    * This remains for compatibility with TanStack Query conventions.
    */
   getNextPageParam?: (
-    lastPage: Array<InferResultType<TContext>[number]>,
-    allPages: Array<Array<InferResultType<TContext>[number]>>,
+    lastPage: Array<TRow>,
+    allPages: Array<Array<TRow>>,
     lastPageParam: number,
     allPageParams: Array<number>,
   ) => number | undefined
 }
+
+export type UseLiveInfiniteQueryConfig<TContext extends Context> =
+  LiveInfiniteQueryConfig<InferResultType<TContext>[number]>
 
 export type UseLiveInfiniteQueryReturn<TContext extends Context> = Omit<
   ReturnType<typeof useLiveQuery<TContext>>,
@@ -100,7 +120,24 @@ export type UseLiveInfiniteQueryReturn<TContext extends Context> = Omit<
   data: InferResultType<TContext>
   pages: Array<Array<InferResultType<TContext>[number]>>
   pageParams: Array<number>
-  fetchNextPage: () => void
+  fetchNextPage: () => Promise<void>
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  error: unknown
+}
+
+export type UseLiveInfiniteQueryReturnWithCollection<
+  TResult extends object,
+  TKey extends string | number,
+  TUtils extends Record<string, any>,
+> = Omit<
+  UseLiveQueryReturnWithCollection<TResult, TKey, TUtils, Array<TResult>>,
+  `data`
+> & {
+  data: Array<TResult>
+  pages: Array<Array<TResult>>
+  pageParams: Array<number>
+  fetchNextPage: () => Promise<void>
   hasNextPage: boolean
   isFetchingNextPage: boolean
   error: unknown
@@ -122,8 +159,8 @@ export function useLiveInfiniteQuery<
   liveQueryCollection: MaybeGetter<
     Collection<TResult, TKey, TUtils> & NonSingleResult
   >,
-  config: UseLiveInfiniteQueryConfig<any>,
-): UseLiveInfiniteQueryReturn<any>
+  config: LiveInfiniteQueryConfig<TResult>,
+): UseLiveInfiniteQueryReturnWithCollection<TResult, TKey, TUtils>
 
 export function useLiveInfiniteQuery<TContext extends Context>(
   queryFn: (q: InitialQueryBuilder) => QueryBuilder<TContext>,
@@ -133,16 +170,12 @@ export function useLiveInfiniteQuery<TContext extends Context>(
 
 export function useLiveInfiniteQuery<TContext extends Context>(
   queryFnOrCollection: unknown,
-  config: UseLiveInfiniteQueryConfig<TContext>,
+  config: InfiniteQueryOptions,
   deps: Array<() => unknown> = [],
 ): UseLiveInfiniteQueryReturn<TContext> {
   let validatedCollection: Collection<any, any, any> | null = null
 
-  const pageSize = $derived(
-    config.pageSize !== undefined && config.pageSize > 0
-      ? config.pageSize
-      : DEFAULT_PAGE_SIZE,
-  )
+  const pageSize = $derived(normalizePageSize(config.pageSize))
   const initialPageParam = $derived(config.initialPageParam ?? 0)
 
   const controller = $derived.by(() => {
@@ -210,11 +243,7 @@ export function useLiveInfiniteQuery<TContext extends Context>(
     }
   })
 
-  const fetchNextPage = () => {
-    void controller.fetchNextPage().catch(() => {
-      // Pagination errors are exposed through the controller snapshot.
-    })
-  }
+  const fetchNextPage = () => controller.fetchNextPage()
 
   return {
     get state() {

--- a/packages/svelte-db/tests/useLiveInfiniteQuery.svelte.test.ts
+++ b/packages/svelte-db/tests/useLiveInfiniteQuery.svelte.test.ts
@@ -33,6 +33,32 @@ function createPostsCollection(id: string, count: number) {
   )
 }
 
+function usePostsInfiniteQuery(
+  posts: ReturnType<typeof createPostsCollection>,
+  config: { pageSize?: number; initialPageParam?: number },
+) {
+  return useLiveInfiniteQuery(
+    (q: InitialQueryBuilder) =>
+      q.from({ posts }).orderBy(({ posts: post }) => post.createdAt, `desc`),
+    config,
+  )
+}
+
+function useFilteredPostsInfiniteQuery(
+  posts: ReturnType<typeof createPostsCollection>,
+  minimum: () => number,
+) {
+  return useLiveInfiniteQuery(
+    (q: InitialQueryBuilder) =>
+      q
+        .from({ posts })
+        .where(({ posts: post }) => gt(post.createdAt, minimum()))
+        .orderBy(({ posts: post }) => post.createdAt, `desc`),
+    { pageSize: 3 },
+    [minimum],
+  )
+}
+
 describe(`useLiveInfiniteQuery`, () => {
   let cleanup: (() => void) | undefined
 
@@ -42,119 +68,136 @@ describe(`useLiveInfiniteQuery`, () => {
     vi.restoreAllMocks()
   })
 
-  it(`delegates page windows and snapshots to the shared controller`, () => {
+  function mountPostsQuery(
+    posts: ReturnType<typeof createPostsCollection>,
+    config: { pageSize?: number; initialPageParam?: number },
+  ): ReturnType<typeof usePostsInfiniteQuery> {
+    let query: ReturnType<typeof usePostsInfiniteQuery> | undefined
+    cleanup = $effect.root(() => {
+      query = usePostsInfiniteQuery(posts, config)
+    })
+    flushSync()
+    if (!query) throw new Error(`Failed to mount infinite query`)
+    return query
+  }
+
+  it(`delegates page windows and snapshots to the shared controller`, async () => {
     const posts = createPostsCollection(`svelte-infinite-controller`, 12)
-
-    cleanup = $effect.root(() => {
-      const query = useLiveInfiniteQuery(
-        (q: InitialQueryBuilder) =>
-          q
-            .from({ posts })
-            .orderBy(({ posts: post }) => post.createdAt, `desc`),
-        { pageSize: 5, initialPageParam: 3 },
-      )
-
-      flushSync()
-
-      expect(query.data).toHaveLength(5)
-      expect(query.pages.map((page) => page.length)).toEqual([5])
-      expect(query.pageParams).toEqual([3])
-      expect(query.hasNextPage).toBe(true)
-      expect(
-        (query.collection.utils as LiveQueryCollectionUtils).getWindow(),
-      ).toEqual({ offset: 0, limit: 6 })
-
-      query.fetchNextPage()
-      flushSync()
-
-      expect(query.data).toHaveLength(10)
-      expect(query.pages.map((page) => page.length)).toEqual([5, 5])
-      expect(query.pageParams).toEqual([3, 4])
-      expect(query.hasNextPage).toBe(true)
-      expect(
-        (query.collection.utils as LiveQueryCollectionUtils).getWindow(),
-      ).toEqual({ offset: 0, limit: 11 })
-
-      query.fetchNextPage()
-      flushSync()
-
-      expect(query.data).toHaveLength(12)
-      expect(query.pages.map((page) => page.length)).toEqual([5, 5, 2])
-      expect(query.hasNextPage).toBe(false)
+    const query = mountPostsQuery(posts, {
+      pageSize: 5,
+      initialPageParam: 3,
     })
+
+    expect(query.data).toHaveLength(5)
+    expect(query.pages.map((page) => page.length)).toEqual([5])
+    expect(query.pageParams).toEqual([3])
+    expect(query.hasNextPage).toBe(true)
+    expect(
+      (query.collection.utils as LiveQueryCollectionUtils).getWindow(),
+    ).toEqual({ offset: 0, limit: 6 })
+
+    await query.fetchNextPage()
+    flushSync()
+
+    expect(query.data).toHaveLength(10)
+    expect(query.pages.map((page) => page.length)).toEqual([5, 5])
+    expect(query.pageParams).toEqual([3, 4])
+    expect(query.hasNextPage).toBe(true)
+    expect(
+      (query.collection.utils as LiveQueryCollectionUtils).getWindow(),
+    ).toEqual({ offset: 0, limit: 11 })
+
+    await query.fetchNextPage()
+    flushSync()
+
+    expect(query.data).toHaveLength(12)
+    expect(query.pages.map((page) => page.length)).toEqual([5, 5, 2])
+    expect(query.hasNextPage).toBe(false)
   })
 
-  it(`keeps loaded pages live when rows enter or leave the window`, () => {
+  it(`keeps loaded pages live when rows enter or leave the window`, async () => {
     const posts = createPostsCollection(`svelte-infinite-live-rows`, 8)
+    const query = mountPostsQuery(posts, { pageSize: 3 })
 
-    cleanup = $effect.root(() => {
-      const query = useLiveInfiniteQuery(
-        (q: InitialQueryBuilder) =>
-          q
-            .from({ posts })
-            .orderBy(({ posts: post }) => post.createdAt, `desc`),
-        { pageSize: 3 },
-      )
+    await query.fetchNextPage()
+    flushSync()
+    expect(query.data.map((post) => post.id)).toEqual([
+      `1`,
+      `2`,
+      `3`,
+      `4`,
+      `5`,
+      `6`,
+    ])
 
-      flushSync()
-      query.fetchNextPage()
-      flushSync()
-      expect(query.data.map((post) => post.id)).toEqual([
-        `1`,
-        `2`,
-        `3`,
-        `4`,
-        `5`,
-        `6`,
-      ])
-
-      posts.utils.begin()
-      posts.utils.write({
-        type: `insert`,
-        value: { id: `new`, title: `Newest`, createdAt: 100 },
-      })
-      posts.utils.commit()
-      flushSync()
-
-      expect(query.data.map((post) => post.id)).toEqual([
-        `new`,
-        `1`,
-        `2`,
-        `3`,
-        `4`,
-        `5`,
-      ])
-      expect(query.pages.map((page) => page.length)).toEqual([3, 3])
+    posts.utils.begin()
+    posts.utils.write({
+      type: `insert`,
+      value: { id: `new`, title: `Newest`, createdAt: 100 },
     })
+    posts.utils.commit()
+    flushSync()
+
+    expect(query.data.map((post) => post.id)).toEqual([
+      `new`,
+      `1`,
+      `2`,
+      `3`,
+      `4`,
+      `5`,
+    ])
+    expect(query.pages.map((page) => page.length)).toEqual([3, 3])
   })
 
-  it(`recreates the controller at the first page when a dependency changes`, () => {
+  it(`recreates the controller at the first page when a dependency changes`, async () => {
     const posts = createPostsCollection(`svelte-infinite-dependency`, 10)
+    let query: ReturnType<typeof useFilteredPostsInfiniteQuery> | undefined
+    let setMinimum: ((value: number) => void) | undefined
 
     cleanup = $effect.root(() => {
       let minimum = $state(0)
-      const query = useLiveInfiniteQuery(
-        (q: InitialQueryBuilder) =>
-          q
-            .from({ posts })
-            .where(({ posts: post }) => gt(post.createdAt, minimum))
-            .orderBy(({ posts: post }) => post.createdAt, `desc`),
-        { pageSize: 3 },
-        [() => minimum],
-      )
-
-      flushSync()
-      query.fetchNextPage()
-      flushSync()
-      expect(query.pages).toHaveLength(2)
-
-      minimum = 5
-      flushSync()
-
-      expect(query.pages).toHaveLength(1)
-      expect(query.data.map((post) => post.createdAt)).toEqual([10, 9, 8])
+      query = useFilteredPostsInfiniteQuery(posts, () => minimum)
+      setMinimum = (value) => {
+        minimum = value
+      }
     })
+    flushSync()
+    if (!query || !setMinimum) throw new Error(`Failed to mount infinite query`)
+
+    await query.fetchNextPage()
+    flushSync()
+    expect(query.pages).toHaveLength(2)
+
+    setMinimum(5)
+    flushSync()
+
+    expect(query.pages).toHaveLength(1)
+    expect(query.data.map((post) => post.createdAt)).toEqual([10, 9, 8])
   })
+
+  it.each([
+    { label: `empty`, count: 0, pageSize: 5, pageLengths: [0], limit: 6 },
+    { label: `single row`, count: 1, pageSize: 5, pageLengths: [1], limit: 6 },
+    {
+      label: `zero page size`,
+      count: 1,
+      pageSize: 0,
+      pageLengths: [1],
+      limit: 21,
+    },
+  ])(
+    `handles $label pagination boundaries`,
+    ({ label, count, pageSize, pageLengths, limit }) => {
+      const posts = createPostsCollection(`svelte-infinite-${label}`, count)
+      const query = mountPostsQuery(posts, { pageSize })
+
+      expect(query.pages.map((page) => page.length)).toEqual(pageLengths)
+      expect(query.hasNextPage).toBe(false)
+      expect(
+        (query.collection.utils as LiveQueryCollectionUtils).getWindow(),
+      ).toEqual({ offset: 0, limit })
+    },
+  )
 
   it(`accepts a reactive getter for a pre-created ordered collection`, async () => {
     const posts = createPostsCollection(`svelte-infinite-precreated`, 7)
@@ -170,11 +213,15 @@ describe(`useLiveInfiniteQuery`, () => {
     const warning = vi.spyOn(console, `warn`).mockImplementation(() => {})
 
     cleanup = $effect.root(() => {
-      const query = useLiveInfiniteQuery(() => livePosts, { pageSize: 3 })
+      const query = useLiveInfiniteQuery(() => livePosts, {
+        pageSize: 3,
+        getNextPageParam: (lastPage) => lastPage[0]?.createdAt,
+      })
       flushSync()
 
       expect(query.collection).toBe(livePosts)
-      expect(query.data!.map((post: Post) => post.id)).toEqual([`1`, `2`, `3`])
+      expect(query.data.map((post) => post.id)).toEqual([`1`, `2`, `3`])
+      expect(query.state.get(`1`)?.title).toBe(`Post 1`)
       expect(query.hasNextPage).toBe(true)
       expect(warning).toHaveBeenCalledOnce()
       expect(livePosts.utils.getWindow()).toEqual({ offset: 0, limit: 4 })

--- a/packages/svelte-db/tests/useLiveInfiniteQuery.svelte.test.ts
+++ b/packages/svelte-db/tests/useLiveInfiniteQuery.svelte.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { flushSync } from 'svelte'
+import { createCollection, createLiveQueryCollection, gt } from '@tanstack/db'
+import { useLiveInfiniteQuery } from '../src/useLiveInfiniteQuery.svelte.js'
+import { mockSyncCollectionOptions } from '../../db/tests/utils'
+import type {
+  InitialQueryBuilder,
+  LiveQueryCollectionUtils,
+} from '@tanstack/db'
+
+type Post = {
+  id: string
+  title: string
+  createdAt: number
+}
+
+function createPosts(count: number): Array<Post> {
+  return Array.from({ length: count }, (_, index) => ({
+    id: String(index + 1),
+    title: `Post ${index + 1}`,
+    createdAt: count - index,
+  }))
+}
+
+function createPostsCollection(id: string, count: number) {
+  return createCollection(
+    mockSyncCollectionOptions<Post>({
+      autoIndex: `eager`,
+      id,
+      getKey: (post) => post.id,
+      initialData: createPosts(count),
+    }),
+  )
+}
+
+describe(`useLiveInfiniteQuery`, () => {
+  let cleanup: (() => void) | undefined
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = undefined
+    vi.restoreAllMocks()
+  })
+
+  it(`delegates page windows and snapshots to the shared controller`, () => {
+    const posts = createPostsCollection(`svelte-infinite-controller`, 12)
+
+    cleanup = $effect.root(() => {
+      const query = useLiveInfiniteQuery(
+        (q: InitialQueryBuilder) =>
+          q
+            .from({ posts })
+            .orderBy(({ posts: post }) => post.createdAt, `desc`),
+        { pageSize: 5, initialPageParam: 3 },
+      )
+
+      flushSync()
+
+      expect(query.data).toHaveLength(5)
+      expect(query.pages.map((page) => page.length)).toEqual([5])
+      expect(query.pageParams).toEqual([3])
+      expect(query.hasNextPage).toBe(true)
+      expect(
+        (query.collection.utils as LiveQueryCollectionUtils).getWindow(),
+      ).toEqual({ offset: 0, limit: 6 })
+
+      query.fetchNextPage()
+      flushSync()
+
+      expect(query.data).toHaveLength(10)
+      expect(query.pages.map((page) => page.length)).toEqual([5, 5])
+      expect(query.pageParams).toEqual([3, 4])
+      expect(query.hasNextPage).toBe(true)
+      expect(
+        (query.collection.utils as LiveQueryCollectionUtils).getWindow(),
+      ).toEqual({ offset: 0, limit: 11 })
+
+      query.fetchNextPage()
+      flushSync()
+
+      expect(query.data).toHaveLength(12)
+      expect(query.pages.map((page) => page.length)).toEqual([5, 5, 2])
+      expect(query.hasNextPage).toBe(false)
+    })
+  })
+
+  it(`keeps loaded pages live when rows enter or leave the window`, () => {
+    const posts = createPostsCollection(`svelte-infinite-live-rows`, 8)
+
+    cleanup = $effect.root(() => {
+      const query = useLiveInfiniteQuery(
+        (q: InitialQueryBuilder) =>
+          q
+            .from({ posts })
+            .orderBy(({ posts: post }) => post.createdAt, `desc`),
+        { pageSize: 3 },
+      )
+
+      flushSync()
+      query.fetchNextPage()
+      flushSync()
+      expect(query.data.map((post) => post.id)).toEqual([
+        `1`,
+        `2`,
+        `3`,
+        `4`,
+        `5`,
+        `6`,
+      ])
+
+      posts.utils.begin()
+      posts.utils.write({
+        type: `insert`,
+        value: { id: `new`, title: `Newest`, createdAt: 100 },
+      })
+      posts.utils.commit()
+      flushSync()
+
+      expect(query.data.map((post) => post.id)).toEqual([
+        `new`,
+        `1`,
+        `2`,
+        `3`,
+        `4`,
+        `5`,
+      ])
+      expect(query.pages.map((page) => page.length)).toEqual([3, 3])
+    })
+  })
+
+  it(`recreates the controller at the first page when a dependency changes`, () => {
+    const posts = createPostsCollection(`svelte-infinite-dependency`, 10)
+
+    cleanup = $effect.root(() => {
+      let minimum = $state(0)
+      const query = useLiveInfiniteQuery(
+        (q: InitialQueryBuilder) =>
+          q
+            .from({ posts })
+            .where(({ posts: post }) => gt(post.createdAt, minimum))
+            .orderBy(({ posts: post }) => post.createdAt, `desc`),
+        { pageSize: 3 },
+        [() => minimum],
+      )
+
+      flushSync()
+      query.fetchNextPage()
+      flushSync()
+      expect(query.pages).toHaveLength(2)
+
+      minimum = 5
+      flushSync()
+
+      expect(query.pages).toHaveLength(1)
+      expect(query.data.map((post) => post.createdAt)).toEqual([10, 9, 8])
+    })
+  })
+
+  it(`accepts a reactive getter for a pre-created ordered collection`, async () => {
+    const posts = createPostsCollection(`svelte-infinite-precreated`, 7)
+    const livePosts = createLiveQueryCollection({
+      query: (q) =>
+        q
+          .from({ posts })
+          .orderBy(({ posts: post }) => post.createdAt, `desc`)
+          .limit(2)
+          .offset(1),
+    })
+    await livePosts.preload()
+    const warning = vi.spyOn(console, `warn`).mockImplementation(() => {})
+
+    cleanup = $effect.root(() => {
+      const query = useLiveInfiniteQuery(() => livePosts, { pageSize: 3 })
+      flushSync()
+
+      expect(query.collection).toBe(livePosts)
+      expect(query.data!.map((post: Post) => post.id)).toEqual([`1`, `2`, `3`])
+      expect(query.hasNextPage).toBe(true)
+      expect(warning).toHaveBeenCalledOnce()
+      expect(livePosts.utils.getWindow()).toEqual({ offset: 0, limit: 4 })
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

- Add `useLiveInfiniteQuery` as a Svelte 5 binding over the shared live-query window controller.
- Preserve query-function, reactive collection getter, page, pagination-state, and typed pre-created collection APIs from #1447.
- Cover exact peek-ahead windows, live row movement, dependency resets, pre-created collections, promise completion, and pagination boundaries.
- Retain Reijhanniel Jearl Campos's contribution through commit co-authorship.

Reworks #1447 without closing it.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

Validation:
- `pnpm --filter @tanstack/svelte-db test` (64 tests)
- `pnpm --filter @tanstack/svelte-db test:types`
- `pnpm --filter @tanstack/svelte-db build`
- ESLint and Prettier

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `useLiveInfiniteQuery` for reactive infinite queries in Svelte.
  - Supports paginated data, live updates, query state, and fetching additional pages.
  - Works with pre-created live-query collections or query functions.
  - Exposed the new hook through the Svelte DB package.

- **Bug Fixes**
  - Added validation and warnings for unsupported pagination configurations.

- **Tests**
  - Added coverage for pagination boundaries, live updates, dependency changes, and reactive collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->