### PR TITLE
test(db): fuzz includes transition histories

### DIFF
--- a/packages/db/tests/expected-failure.test.ts
+++ b/packages/db/tests/expected-failure.test.ts
@@ -2,19 +2,20 @@ import { describe, expect, it } from 'vitest'
 import { expectAssertionFailure } from './expected-failure.js'
 import { TraceAssertionError } from './trace-runner.js'
 
+function assertionMismatch(checkpoint: number): Promise<void> {
+  try {
+    expect(`observed`).toBe(`expected`)
+    return Promise.resolve()
+  } catch (error) {
+    return Promise.reject(new TraceAssertionError(checkpoint, error))
+  }
+}
+
 describe(`expected failure guard`, () => {
   it(`accepts an assertion mismatch at the expected checkpoint`, async () => {
-    const guarded = expectAssertionFailure(
-      () => {
-        try {
-          expect(`observed`).toBe(`expected`)
-          return Promise.resolve()
-        } catch (error) {
-          return Promise.reject(new TraceAssertionError(2, error))
-        }
-      },
-      { checkpoint: 2 },
-    )
+    const guarded = expectAssertionFailure(() => assertionMismatch(2), {
+      checkpoint: 2,
+    })
 
     await guarded()
   })
@@ -39,6 +40,25 @@ describe(`expected failure guard`, () => {
         ),
       { checkpoint: 2 },
     )
+
+    await expect(guarded()).rejects.toBeInstanceOf(Error)
+  })
+
+  it(`accepts an assertion mismatch with the expected difference`, async () => {
+    const guarded = expectAssertionFailure(() => assertionMismatch(2), {
+      checkpoint: 2,
+      classify: ({ actual, expected }) =>
+        actual === `observed` && expected === `expected`,
+    })
+
+    await guarded()
+  })
+
+  it(`rejects an assertion mismatch with a different shape`, async () => {
+    const guarded = expectAssertionFailure(() => assertionMismatch(2), {
+      checkpoint: 2,
+      classify: ({ actual }) => actual === `different`,
+    })
 
     await expect(guarded()).rejects.toBeInstanceOf(Error)
   })

--- a/packages/db/tests/expected-failure.ts
+++ b/packages/db/tests/expected-failure.ts
@@ -1,8 +1,35 @@
 import { expect } from 'vitest'
 
+export type AssertionDifference = {
+  actual: unknown
+  expected: unknown
+}
+
 type ExpectedAssertionFailure =
-  | { checkpoint: number }
+  | {
+      checkpoint: number
+      classify?: (difference: AssertionDifference) => boolean
+    }
   | { message: string | RegExp }
+
+function assertionDifference(error: unknown): AssertionDifference {
+  if (
+    typeof error !== `object` ||
+    error === null ||
+    !(`cause` in error) ||
+    typeof error.cause !== `object` ||
+    error.cause === null ||
+    !(`actual` in error.cause) ||
+    !(`expected` in error.cause)
+  ) {
+    throw new Error(`Expected an assertion difference`)
+  }
+
+  return {
+    actual: error.cause.actual,
+    expected: error.cause.expected,
+  }
+}
 
 export function expectAssertionFailure<TArgs extends Array<unknown>>(
   assertion: (...args: TArgs) => Promise<void>,
@@ -10,11 +37,21 @@ export function expectAssertionFailure<TArgs extends Array<unknown>>(
 ): (...args: TArgs) => Promise<void> {
   return async (...args) => {
     if (`checkpoint` in expected) {
-      await expect(assertion(...args)).rejects.toMatchObject({
+      let error: unknown
+      try {
+        await assertion(...args)
+      } catch (caught) {
+        error = caught
+      }
+
+      expect(error).toMatchObject({
         name: `TraceAssertionError`,
         checkpoint: expected.checkpoint,
         cause: { name: `AssertionError` },
       })
+      if (expected.classify) {
+        expect(expected.classify(assertionDifference(error))).toBe(true)
+      }
       return
     }
 

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -1196,16 +1196,25 @@ type VisibleRelationshipScenarioOptions = {
 function assertDisjointRelationshipKeys(
   depth: IncludeDepth,
   branches: readonly [ConnectedBranch, ConnectedBranch],
-  rekeyGroup: number | undefined,
+  {
+    extraIds = [],
+    extraGroups = [],
+  }: {
+    extraIds?: ReadonlyArray<number>
+    extraGroups?: ReadonlyArray<number>
+  } = {},
 ): void {
-  const ids = branches.flatMap(({ idBase }) =>
-    Array.from({ length: depth + 1 }, (_, level) => idBase + level),
-  )
+  const ids = [
+    ...branches.flatMap(({ idBase }) =>
+      Array.from({ length: depth + 1 }, (_, level) => idBase + level),
+    ),
+    ...extraIds,
+  ]
   const groups = [
     ...branches.flatMap(({ groupBase }) =>
       Array.from({ length: depth + 1 }, (_, level) => groupBase + level),
     ),
-    ...(rekeyGroup === undefined ? [] : [rekeyGroup]),
+    ...extraGroups,
   ]
   if (
     new Set(ids).size !== ids.length ||
@@ -1223,7 +1232,7 @@ function createVisibleRelationshipScenario(
   assertDisjointRelationshipKeys(
     depth,
     branches,
-    transition === `rekey` ? options.rekeyGroup : undefined,
+    transition === `rekey` ? { extraGroups: [options.rekeyGroup] } : {},
   )
   const steps = createConnectedBatchBranches(depth, branches)
   const roots = new Map<number, RootRow>()
@@ -1387,6 +1396,509 @@ function visibleRelationshipScenarioArbitrary(
     )
 }
 
+type GeneratedBranchOptions = {
+  leftIdBase: number
+  leftGroupBase: number
+  rightIdBase: number
+  rightGroupBase: number
+}
+
+const generatedBranchArbitraries = {
+  leftIdBase: fc.integer({ min: 100, max: 500 }),
+  leftGroupBase: fc.integer({ min: 600, max: 1_000 }),
+  rightIdBase: fc.integer({ min: 1_100, max: 1_500 }),
+  rightGroupBase: fc.integer({ min: 1_600, max: 2_000 }),
+}
+
+function createGeneratedBranches({
+  leftIdBase,
+  leftGroupBase,
+  rightIdBase,
+  rightGroupBase,
+}: GeneratedBranchOptions): readonly [ConnectedBranch, ConnectedBranch] {
+  return [
+    { idBase: leftIdBase, groupBase: leftGroupBase },
+    { idBase: rightIdBase, groupBase: rightGroupBase },
+  ]
+}
+
+type TransitionHistoryScenario = FullRowBatchScenario & {
+  historyStartStepIndex: number
+}
+
+type TransitionHistoryScenarioOptions = {
+  depth: IncludeDepth
+  targetLevel: IncludeDepth
+  firstTransition: VisibleRelationshipTransition
+  secondTransition: VisibleRelationshipTransition
+  sourceBranch: 0 | 1
+  branches: readonly [ConnectedBranch, ConnectedBranch]
+  rekeyGroups: readonly [number, number]
+  insertedLevels: readonly [IncludeDepth, IncludeDepth]
+  insertedValues: readonly [number, number]
+  insertedPositions: readonly [number, number]
+}
+
+function createTransitionHistoryScenario({
+  depth,
+  targetLevel,
+  firstTransition,
+  secondTransition,
+  sourceBranch,
+  branches,
+  rekeyGroups,
+  insertedLevels,
+  insertedValues,
+  insertedPositions,
+}: TransitionHistoryScenarioOptions): TransitionHistoryScenario {
+  // Fresh keys keep this matrix green through both transitions. Separate
+  // state-aware families below reuse retired routes and replace existing rows,
+  // so those known failures remain shrinkable without masking later steps.
+  const insertedRows = [
+    {
+      id: 3_000,
+      group: 2_700,
+      value: insertedValues[0],
+      position: insertedPositions[0],
+    },
+    {
+      id: 3_001,
+      group: 2_800,
+      value: insertedValues[1],
+      position: insertedPositions[1],
+    },
+  ] as const
+  assertDisjointRelationshipKeys(depth, branches, {
+    extraIds: insertedRows.map(({ id }) => id),
+    extraGroups: [...rekeyGroups, ...insertedRows.map(({ group }) => group)],
+  })
+
+  const steps = createConnectedBatchBranches(depth, branches)
+  const historyStartStepIndex = steps.length
+  const source = branches[sourceBranch]
+  let current = {
+    ...batchChild(
+      source.idBase + targetLevel,
+      source.groupBase + targetLevel - 1,
+      source.idBase + targetLevel,
+      0,
+    ),
+    group: source.groupBase + targetLevel,
+  }
+  const appendStep = (
+    level: IncludeDepth,
+    changes: Array<SyncChange<ChildRow>>,
+  ): void => {
+    steps.push({ level, changes })
+  }
+  const insertRow = (
+    row: (typeof insertedRows)[number],
+    level: IncludeDepth,
+  ): ChildRow => {
+    if (level !== targetLevel && level !== targetLevel + 1) {
+      throw new Error(`History inserts must touch the target or its child`)
+    }
+    return {
+      ...row,
+      parentGroup: level === targetLevel ? current.parentGroup : current.group,
+    }
+  }
+  const transition = (
+    kind: VisibleRelationshipTransition,
+    rekeyGroup: number,
+  ): void => {
+    const currentParentBranch = branches.findIndex(
+      ({ groupBase }) => current.parentGroup === groupBase + targetLevel - 1,
+    )
+    if (currentParentBranch !== 0 && currentParentBranch !== 1) {
+      throw new Error(`Transition target has no visible parent branch`)
+    }
+    const destination = branches[otherBranch(currentParentBranch)]
+    current = {
+      ...current,
+      parentGroup:
+        kind === `reparent`
+          ? destination.groupBase + targetLevel - 1
+          : current.parentGroup,
+      group: kind === `rekey` ? rekeyGroup : current.group,
+    }
+    appendStep(targetLevel, [{ type: `update`, value: current }])
+  }
+  const interleaveTransition = (
+    kind: VisibleRelationshipTransition,
+    rekeyGroup: number,
+    row: (typeof insertedRows)[number],
+    level: IncludeDepth,
+  ): void => {
+    const inserted = insertRow(row, level)
+    appendStep(level, [{ type: `insert`, value: inserted }])
+    transition(kind, rekeyGroup)
+    appendStep(level, [{ type: `delete`, value: inserted }])
+  }
+
+  interleaveTransition(
+    firstTransition,
+    rekeyGroups[0],
+    insertedRows[0],
+    insertedLevels[0],
+  )
+  interleaveTransition(
+    secondTransition,
+    rekeyGroups[1],
+    insertedRows[1],
+    insertedLevels[1],
+  )
+
+  return {
+    depth,
+    steps,
+    historyStartStepIndex,
+  }
+}
+
+function transitionHistoryPlacements(
+  depth: IncludeDepth,
+  firstTransition: VisibleRelationshipTransition,
+  secondTransition: VisibleRelationshipTransition,
+): Array<{
+  targetLevel: IncludeDepth
+  insertedLevels: readonly [IncludeDepth, IncludeDepth]
+}> {
+  // A rekey with two descendant levels is already a known failure. Keep this
+  // history corpus on the green side of that boundary so the first transition
+  // cannot mask a later mismatch.
+  const minimumTargetLevel =
+    firstTransition === `rekey` || secondTransition === `rekey`
+      ? Math.max(1, depth - 1)
+      : 1
+  const placements: Array<{
+    targetLevel: IncludeDepth
+    insertedLevels: readonly [IncludeDepth, IncludeDepth]
+  }> = []
+
+  for (let level = minimumTargetLevel; level <= depth; level++) {
+    const targetLevel = level as IncludeDepth
+    const insertedLevels = (
+      transition: VisibleRelationshipTransition,
+    ): ReadonlyArray<IncludeDepth> =>
+      // Rekeying disconnects an existing child from the target. Restrict that
+      // interleave to the target row so its later delete remains observable.
+      transition === `reparent` && targetLevel < depth
+        ? [targetLevel, (targetLevel + 1) as IncludeDepth]
+        : [targetLevel]
+
+    for (const firstInsertedLevel of insertedLevels(firstTransition)) {
+      for (const secondInsertedLevel of insertedLevels(secondTransition)) {
+        placements.push({
+          targetLevel,
+          insertedLevels: [firstInsertedLevel, secondInsertedLevel],
+        })
+      }
+    }
+  }
+
+  return placements
+}
+
+function transitionHistoryScenariosArbitrary(
+  depth: IncludeDepth,
+  firstTransition: VisibleRelationshipTransition,
+  secondTransition: VisibleRelationshipTransition,
+): fc.Arbitrary<ReadonlyArray<TransitionHistoryScenario>> {
+  const placements = transitionHistoryPlacements(
+    depth,
+    firstTransition,
+    secondTransition,
+  )
+
+  return fc
+    .record({
+      sourceBranch: fc.constantFrom<0 | 1>(0, 1),
+      ...generatedBranchArbitraries,
+      firstRekeyGroup: fc.integer({ min: 2_100, max: 2_300 }),
+      secondRekeyGroup: fc.integer({ min: 2_400, max: 2_600 }),
+      firstInsertedValue: fc.integer({ min: -3, max: 3 }),
+      secondInsertedValue: fc.integer({ min: -3, max: 3 }),
+      firstInsertedPosition: fc.integer({ min: -2, max: 2 }),
+      secondInsertedPosition: fc.integer({ min: -2, max: 2 }),
+    })
+    .map(
+      ({
+        sourceBranch,
+        leftIdBase,
+        leftGroupBase,
+        rightIdBase,
+        rightGroupBase,
+        firstRekeyGroup,
+        secondRekeyGroup,
+        firstInsertedValue,
+        secondInsertedValue,
+        firstInsertedPosition,
+        secondInsertedPosition,
+      }) =>
+        placements.map(({ targetLevel, insertedLevels }) =>
+          createTransitionHistoryScenario({
+            depth,
+            targetLevel,
+            firstTransition,
+            secondTransition,
+            sourceBranch,
+            branches: createGeneratedBranches({
+              leftIdBase,
+              leftGroupBase,
+              rightIdBase,
+              rightGroupBase,
+            }),
+            rekeyGroups: [firstRekeyGroup, secondRekeyGroup],
+            insertedLevels,
+            insertedValues: [firstInsertedValue, secondInsertedValue],
+            insertedPositions: [firstInsertedPosition, secondInsertedPosition],
+          }),
+        ),
+    )
+}
+
+function expectEveryHistoryStepVisible(
+  scenario: TransitionHistoryScenario,
+): void {
+  for (
+    let stepIndex = scenario.historyStartStepIndex;
+    stepIndex < scenario.steps.length;
+    stepIndex++
+  ) {
+    const before = recomputeFullRowBatchScenario(scenario, stepIndex)
+    const after = recomputeFullRowBatchScenario(scenario, stepIndex + 1)
+    expect(after).not.toEqual(before)
+  }
+}
+
+type ClassifiedHistoryScenario = {
+  control: FullRowBatchScenario
+  candidate: FullRowBatchScenario
+  candidateCheckpoint: number
+}
+
+type RekeyRouteReuseOptions = {
+  depth: 2 | 3 | 4
+  sourceBranch: 0 | 1
+  branches: readonly [ConnectedBranch, ConnectedBranch]
+  rekeyGroup: number
+  insertedId: number
+  insertedValue: number
+  insertedPosition: number
+}
+
+function createRekeyRouteReuseScenarios({
+  depth,
+  sourceBranch,
+  branches,
+  rekeyGroup,
+  insertedId,
+  insertedValue,
+  insertedPosition,
+}: RekeyRouteReuseOptions): ClassifiedHistoryScenario {
+  const targetLevel = (depth - 1) as IncludeDepth
+  assertDisjointRelationshipKeys(depth, branches, {
+    extraIds: [insertedId],
+    extraGroups: [rekeyGroup],
+  })
+
+  const prefix = createConnectedBatchBranches(depth, branches)
+  const source = branches[sourceBranch]
+  const parentGroup = source.groupBase + targetLevel - 1
+  const oldGroup = source.groupBase + targetLevel
+  const inserted = {
+    ...batchChild(insertedId, parentGroup, insertedValue, insertedPosition),
+    group: oldGroup,
+  }
+  const insertOldRoute: FullRowBatchStep = {
+    level: targetLevel,
+    changes: [{ type: `insert`, value: inserted }],
+  }
+  const rekey: FullRowBatchStep = {
+    level: targetLevel,
+    changes: [
+      {
+        type: `update`,
+        value: {
+          ...batchChild(
+            source.idBase + targetLevel,
+            parentGroup,
+            source.idBase + targetLevel,
+            0,
+          ),
+          group: rekeyGroup,
+        },
+      },
+    ],
+  }
+
+  return {
+    control: { depth, steps: [...prefix, insertOldRoute] },
+    candidate: { depth, steps: [...prefix, rekey, insertOldRoute] },
+    candidateCheckpoint: prefix.length + 2,
+  }
+}
+
+function rekeyRouteReuseScenarioArbitrary(
+  depth: 2 | 3 | 4,
+  sourceBranch: 0 | 1,
+): fc.Arbitrary<ClassifiedHistoryScenario> {
+  return fc
+    .record({
+      ...generatedBranchArbitraries,
+      rekeyGroup: fc.integer({ min: 2_100, max: 2_600 }),
+      insertedId: fc.integer({ min: 3_000, max: 3_200 }),
+      insertedValue: fc.integer({ min: -3, max: 3 }),
+      insertedPosition: fc.integer({ min: -2, max: 2 }),
+    })
+    .map(
+      ({
+        leftIdBase,
+        leftGroupBase,
+        rightIdBase,
+        rightGroupBase,
+        rekeyGroup,
+        insertedId,
+        insertedValue,
+        insertedPosition,
+      }) =>
+        createRekeyRouteReuseScenarios({
+          depth,
+          sourceBranch,
+          branches: createGeneratedBranches({
+            leftIdBase,
+            leftGroupBase,
+            rightIdBase,
+            rightGroupBase,
+          }),
+          rekeyGroup,
+          insertedId,
+          insertedValue,
+          insertedPosition,
+        }),
+    )
+}
+
+type MovedChildReplacementOptions = {
+  depth: 3 | 4
+  targetLevel: IncludeDepth
+  sourceBranch: 0 | 1
+  branches: readonly [ConnectedBranch, ConnectedBranch]
+  insertedId: number
+  insertedValue: number
+  insertedPosition: number
+}
+
+function createMovedChildReplacementScenarios({
+  depth,
+  targetLevel,
+  sourceBranch,
+  branches,
+  insertedId,
+  insertedValue,
+  insertedPosition,
+}: MovedChildReplacementOptions): ClassifiedHistoryScenario {
+  if (targetLevel + 2 > depth) {
+    throw new Error(`Child replacement needs a visible grandchild`)
+  }
+  assertDisjointRelationshipKeys(depth, branches, {
+    extraIds: [insertedId],
+  })
+
+  const prefix = createConnectedBatchBranches(depth, branches)
+  const source = branches[sourceBranch]
+  const destination = branches[otherBranch(sourceBranch)]
+  const targetGroup = source.groupBase + targetLevel
+  const childLevel = (targetLevel + 1) as IncludeDepth
+  const childGroup = source.groupBase + childLevel
+  const existingChild = {
+    ...batchChild(
+      source.idBase + childLevel,
+      targetGroup,
+      source.idBase + childLevel,
+      0,
+    ),
+    group: childGroup,
+  }
+  const replacementChild = {
+    ...batchChild(insertedId, targetGroup, insertedValue, insertedPosition),
+    group: childGroup,
+  }
+  const replaceChild: Array<FullRowBatchStep> = [
+    {
+      level: childLevel,
+      changes: [{ type: `delete`, value: existingChild }],
+    },
+    {
+      level: childLevel,
+      changes: [{ type: `insert`, value: replacementChild }],
+    },
+  ]
+  const reparent: FullRowBatchStep = {
+    level: targetLevel,
+    changes: [
+      {
+        type: `update`,
+        value: {
+          ...batchChild(
+            source.idBase + targetLevel,
+            destination.groupBase + targetLevel - 1,
+            source.idBase + targetLevel,
+            0,
+          ),
+          group: targetGroup,
+        },
+      },
+    ],
+  }
+
+  return {
+    control: { depth, steps: [...prefix, ...replaceChild] },
+    candidate: { depth, steps: [...prefix, reparent, ...replaceChild] },
+    candidateCheckpoint: prefix.length + 3,
+  }
+}
+
+function movedChildReplacementScenarioArbitrary(
+  depth: 3 | 4,
+  targetLevel: IncludeDepth,
+  sourceBranch: 0 | 1,
+): fc.Arbitrary<ClassifiedHistoryScenario> {
+  return fc
+    .record({
+      ...generatedBranchArbitraries,
+      insertedId: fc.integer({ min: 3_000, max: 3_200 }),
+      insertedValue: fc.integer({ min: -3, max: 3 }),
+      insertedPosition: fc.integer({ min: -2, max: 2 }),
+    })
+    .map(
+      ({
+        leftIdBase,
+        leftGroupBase,
+        rightIdBase,
+        rightGroupBase,
+        insertedId,
+        insertedValue,
+        insertedPosition,
+      }) =>
+        createMovedChildReplacementScenarios({
+          depth,
+          targetLevel,
+          sourceBranch,
+          branches: createGeneratedBranches({
+            leftIdBase,
+            leftGroupBase,
+            rightIdBase,
+            rightGroupBase,
+          }),
+          insertedId,
+          insertedValue,
+          insertedPosition,
+        }),
+    )
+}
+
 async function expectFullRowBatchScenarioMatches({
   depth,
   steps,
@@ -1396,6 +1908,26 @@ async function expectFullRowBatchScenarioMatches({
     driver: createFullRowBatchTraceDriver(depth),
     projection: structuralProjection,
   })
+}
+
+async function expectClassifiedHistoryFailure({
+  control,
+  candidate,
+  candidateCheckpoint,
+}: ClassifiedHistoryScenario): Promise<void> {
+  await expectFullRowBatchScenarioMatches(control)
+  await expectAssertionFailure(
+    () => expectFullRowBatchScenarioMatches(candidate),
+    { checkpoint: candidateCheckpoint },
+  )()
+}
+
+async function expectClassifiedHistoryMatches({
+  control,
+  candidate,
+}: ClassifiedHistoryScenario): Promise<void> {
+  await expectFullRowBatchScenarioMatches(control)
+  await expectFullRowBatchScenarioMatches(candidate)
 }
 
 function recomputeFullRowBatchScenario(
@@ -1893,6 +2425,43 @@ const minimalRekeyScenario = createVisibleRelationshipScenario({
   noise: [],
 })
 
+const transitionHistoryBranches = [
+  { idBase: 100, groupBase: 600 },
+  { idBase: 1_100, groupBase: 1_600 },
+] as const
+
+// The first rekey is correct on its own. Reusing its old correlation key for a
+// new visible row then resurrects the detached descendant under the old row.
+const {
+  control: rekeyRouteReuseControl,
+  candidate: rekeyRouteResurrectionScenario,
+  candidateCheckpoint: rekeyRouteResurrectionCheckpoint,
+} = createRekeyRouteReuseScenarios({
+  depth: 2,
+  sourceBranch: 0,
+  branches: transitionHistoryBranches,
+  rekeyGroup: 2_100,
+  insertedId: 3_000,
+  insertedValue: 0,
+  insertedPosition: 0,
+})
+
+// The reparent and delete are each correct. Replacing the moved row's child
+// under the same correlation key then loses the existing grandchild snapshot.
+const {
+  control: childReplacementControl,
+  candidate: movedSubtreeChildReplacementScenario,
+  candidateCheckpoint: movedSubtreeChildReplacementCheckpoint,
+} = createMovedChildReplacementScenarios({
+  depth: 3,
+  targetLevel: 1,
+  sourceBranch: 0,
+  branches: transitionHistoryBranches,
+  insertedId: 3_000,
+  insertedValue: 0,
+  insertedPosition: 0,
+})
+
 describe(`includes recompute oracle`, () => {
   fcTest(`rejects overlapping visible relationship keys`, () => {
     const base = {
@@ -1979,6 +2548,76 @@ describe(`includes recompute oracle`, () => {
     ),
   )
 
+  fcTest(
+    `discovered trace: reusing a rekeyed row's old route does not resurrect its child`,
+    expectAssertionFailure(
+      () => expectFullRowBatchScenarioMatches(rekeyRouteResurrectionScenario),
+      { checkpoint: rekeyRouteResurrectionCheckpoint },
+    ),
+  )
+
+  fcTest(
+    `matches recomputation when sharing a route without rekeying its existing row`,
+    () => expectFullRowBatchScenarioMatches(rekeyRouteReuseControl),
+  )
+
+  fcTest(
+    `discovered trace: replacing a moved subtree child retains its grandchild`,
+    expectAssertionFailure(
+      () =>
+        expectFullRowBatchScenarioMatches(movedSubtreeChildReplacementScenario),
+      { checkpoint: movedSubtreeChildReplacementCheckpoint },
+    ),
+  )
+
+  fcTest(
+    `matches recomputation when replacing a child without reparenting its ancestor`,
+    () => expectFullRowBatchScenarioMatches(childReplacementControl),
+  )
+
+  for (const depth of [2, 3, 4] as const) {
+    for (const sourceBranch of [0, 1] as const) {
+      fcTest.prop([rekeyRouteReuseScenarioArbitrary(depth, sourceBranch)], {
+        numRuns: 4,
+        seed: 1726 + depth * 10 + sourceBranch,
+      })(
+        `discovered histories: reusing a retired route at depth ${depth}, branch ${sourceBranch}`,
+        expectClassifiedHistoryFailure,
+      )
+    }
+  }
+
+  for (const depth of [3, 4] as const) {
+    for (let targetLevel = 1; targetLevel <= depth - 2; targetLevel++) {
+      for (const sourceBranch of [0, 1] as const) {
+        // (depth 4, target level 2, source branch 1) is the observed green
+        // boundary. Pin it so this expected-failure class cannot expand unseen.
+        const expectsFailure =
+          depth !== 4 || targetLevel !== 2 || sourceBranch !== 1
+        fcTest.prop(
+          [
+            movedChildReplacementScenarioArbitrary(
+              depth,
+              targetLevel as IncludeDepth,
+              sourceBranch,
+            ),
+          ],
+          {
+            numRuns: 4,
+            seed: 1727 + depth * 10 + targetLevel * 2 + sourceBranch,
+          },
+        )(
+          expectsFailure
+            ? `discovered histories: replacing a moved child at depth ${depth}, level ${targetLevel}, branch ${sourceBranch}`
+            : `matches recomputation when replacing a moved child at depth ${depth}, level ${targetLevel}, branch ${sourceBranch}`,
+          expectsFailure
+            ? expectClassifiedHistoryFailure
+            : expectClassifiedHistoryMatches,
+        )
+      }
+    }
+  }
+
   fcTest.prop(
     [
       fc.constantFrom<FlatMaterialization>(`array`, `concat`),
@@ -2050,6 +2689,38 @@ describe(`includes recompute oracle`, () => {
               } else {
                 await expectFullRowBatchScenarioMatches(scenario)
               }
+            }
+          },
+        )
+      }
+    }
+  }
+
+  for (const depth of [1, 2, 3, 4] as const) {
+    const transitions: Array<VisibleRelationshipTransition> = [
+      `reparent`,
+      `rekey`,
+    ]
+    for (const [firstIndex, firstTransition] of transitions.entries()) {
+      for (const [secondIndex, secondTransition] of transitions.entries()) {
+        fcTest.prop(
+          [
+            transitionHistoryScenariosArbitrary(
+              depth,
+              firstTransition,
+              secondTransition,
+            ),
+          ],
+          {
+            numRuns: 3,
+            seed: 1725 + depth * 10 + firstIndex * 2 + secondIndex,
+          },
+        )(
+          `matches recomputation for ${firstTransition} → ${secondTransition} histories at depth ${depth}`,
+          async (scenarios) => {
+            for (const scenario of scenarios) {
+              expectEveryHistoryStepVisible(scenario)
+              await expectFullRowBatchScenarioMatches(scenario)
             }
           },
         )

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils.js'
 import { expectAssertionFailure } from '../expected-failure.js'
 import { runTrace } from '../trace-runner.js'
+import type { AssertionDifference } from '../expected-failure.js'
 import type {
   TraceCheckpoint,
   TraceDriver,
@@ -57,6 +58,86 @@ type Scenario = {
 
 type OracleNode = RootRow & {
   children?: Array<OracleNode>
+}
+
+type RelationshipNode = {
+  id: number
+  children?: unknown
+}
+
+function isRelationshipNode(value: unknown): value is RelationshipNode {
+  return (
+    typeof value === `object` &&
+    value !== null &&
+    `id` in value &&
+    typeof value.id === `number`
+  )
+}
+
+function findRelationshipNode(
+  value: unknown,
+  id: number,
+): RelationshipNode | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  for (const entry of value) {
+    if (!isRelationshipNode(entry)) continue
+    if (entry.id === id) return entry
+    const nested = findRelationshipNode(entry.children, id)
+    if (nested) return nested
+  }
+  return undefined
+}
+
+function hasDirectChild(value: unknown, parentId: number, childId: number) {
+  const parent = findRelationshipNode(value, parentId)
+  return (
+    Array.isArray(parent?.children) &&
+    parent.children.some(
+      (child) => isRelationshipNode(child) && child.id === childId,
+    )
+  )
+}
+
+function classifyUnexpectedSharedChild(
+  { actual, expected }: AssertionDifference,
+  unexpectedParentId: number,
+  expectedParentId: number,
+  childId: number,
+): boolean {
+  return (
+    hasDirectChild(actual, unexpectedParentId, childId) &&
+    !hasDirectChild(expected, unexpectedParentId, childId) &&
+    hasDirectChild(actual, expectedParentId, childId) &&
+    hasDirectChild(expected, expectedParentId, childId)
+  )
+}
+
+function classifyMissingReplacementChild(
+  { actual, expected }: AssertionDifference,
+  replacementRowId: number,
+  childId: number,
+): boolean {
+  return (
+    findRelationshipNode(actual, replacementRowId) !== undefined &&
+    findRelationshipNode(expected, replacementRowId) !== undefined &&
+    !hasDirectChild(actual, replacementRowId, childId) &&
+    hasDirectChild(expected, replacementRowId, childId)
+  )
+}
+
+type RelationshipProjectionNode = {
+  id: number
+  children?: Array<RelationshipProjectionNode>
+}
+
+function relationshipOnly(
+  nodes: ReadonlyArray<OracleNode>,
+): Array<RelationshipProjectionNode> {
+  return nodes.map(({ id, children }) => ({
+    id,
+    ...(children ? { children: relationshipOnly(children) } : {}),
+  }))
 }
 
 type MaterializeRoot = { id: number; middleId: number }
@@ -1160,9 +1241,28 @@ function fullRowBatchScenarioAtDepthArbitrary(
 }
 
 type VisibleRelationshipTransition = `reparent` | `rekey`
+type BranchDeliveryOrder = `forward` | `reverse`
+const branchDeliveryOrders: ReadonlyArray<BranchDeliveryOrder> = [
+  `forward`,
+  `reverse`,
+]
 
 function otherBranch(branch: 0 | 1): 0 | 1 {
   return branch === 0 ? 1 : 0
+}
+
+function deliverBranches(
+  branches: readonly [ConnectedBranch, ConnectedBranch],
+  order: BranchDeliveryOrder,
+): readonly [ConnectedBranch, ConnectedBranch] {
+  return order === `forward` ? branches : [branches[1], branches[0]]
+}
+
+function deliveredBranchIndex(
+  branch: 0 | 1,
+  order: BranchDeliveryOrder,
+): 0 | 1 {
+  return order === `forward` ? branch : otherBranch(branch)
 }
 
 type VisibleRelationshipScenario = FullRowBatchScenario & {
@@ -1530,6 +1630,15 @@ function createTransitionHistoryScenario({
     row: (typeof insertedRows)[number],
     level: IncludeDepth,
   ): void => {
+    if (kind === `rekey`) {
+      if (level !== targetLevel + 1) {
+        throw new Error(`Rekey histories must seed the new child route`)
+      }
+      transition(kind, rekeyGroup)
+      appendStep(level, [{ type: `insert`, value: insertRow(row, level) }])
+      return
+    }
+
     const inserted = insertRow(row, level)
     appendStep(level, [{ type: `insert`, value: inserted }])
     transition(kind, rekeyGroup)
@@ -1564,28 +1673,32 @@ function transitionHistoryPlacements(
   targetLevel: IncludeDepth
   insertedLevels: readonly [IncludeDepth, IncludeDepth]
 }> {
-  // A rekey with two descendant levels is already a known failure. Keep this
-  // history corpus on the green side of that boundary so the first transition
-  // cannot mask a later mismatch.
+  // A rekey needs one child level so it changes relationship membership. It
+  // also fails when two descendant levels remain. The single-transition matrix
+  // pins that failure and will turn red when this continuation can be widened.
   const minimumTargetLevel =
     firstTransition === `rekey` || secondTransition === `rekey`
       ? Math.max(1, depth - 1)
       : 1
+  const maximumTargetLevel =
+    firstTransition === `rekey` || secondTransition === `rekey`
+      ? depth - 1
+      : depth
   const placements: Array<{
     targetLevel: IncludeDepth
     insertedLevels: readonly [IncludeDepth, IncludeDepth]
   }> = []
 
-  for (let level = minimumTargetLevel; level <= depth; level++) {
+  for (let level = minimumTargetLevel; level <= maximumTargetLevel; level++) {
     const targetLevel = level as IncludeDepth
     const insertedLevels = (
       transition: VisibleRelationshipTransition,
     ): ReadonlyArray<IncludeDepth> =>
-      // Rekeying disconnects an existing child from the target. Restrict that
-      // interleave to the target row so its later delete remains observable.
-      transition === `reparent` && targetLevel < depth
-        ? [targetLevel, (targetLevel + 1) as IncludeDepth]
-        : [targetLevel]
+      transition === `rekey`
+        ? [(targetLevel + 1) as IncludeDepth]
+        : targetLevel < depth
+          ? [targetLevel, (targetLevel + 1) as IncludeDepth]
+          : [targetLevel]
 
     for (const firstInsertedLevel of insertedLevels(firstTransition)) {
       for (const secondInsertedLevel of insertedLevels(secondTransition)) {
@@ -1604,6 +1717,7 @@ function transitionHistoryScenariosArbitrary(
   depth: IncludeDepth,
   firstTransition: VisibleRelationshipTransition,
   secondTransition: VisibleRelationshipTransition,
+  sourceBranch: 0 | 1,
 ): fc.Arbitrary<ReadonlyArray<TransitionHistoryScenario>> {
   const placements = transitionHistoryPlacements(
     depth,
@@ -1613,7 +1727,6 @@ function transitionHistoryScenariosArbitrary(
 
   return fc
     .record({
-      sourceBranch: fc.constantFrom<0 | 1>(0, 1),
       ...generatedBranchArbitraries,
       firstRekeyGroup: fc.integer({ min: 2_100, max: 2_300 }),
       secondRekeyGroup: fc.integer({ min: 2_400, max: 2_600 }),
@@ -1624,7 +1737,6 @@ function transitionHistoryScenariosArbitrary(
     })
     .map(
       ({
-        sourceBranch,
         leftIdBase,
         leftGroupBase,
         rightIdBase,
@@ -1666,16 +1778,22 @@ function expectEveryHistoryStepVisible(
     stepIndex < scenario.steps.length;
     stepIndex++
   ) {
-    const before = recomputeFullRowBatchScenario(scenario, stepIndex)
-    const after = recomputeFullRowBatchScenario(scenario, stepIndex + 1)
+    const before = relationshipOnly(
+      recomputeFullRowBatchScenario(scenario, stepIndex),
+    )
+    const after = relationshipOnly(
+      recomputeFullRowBatchScenario(scenario, stepIndex + 1),
+    )
     expect(after).not.toEqual(before)
   }
 }
 
 type ClassifiedHistoryScenario = {
   control: FullRowBatchScenario
+  greenVariants?: ReadonlyArray<FullRowBatchScenario>
   candidate: FullRowBatchScenario
   candidateCheckpoint: number
+  classify: (difference: AssertionDifference) => boolean
 }
 
 type RekeyRouteReuseOptions = {
@@ -1688,7 +1806,7 @@ type RekeyRouteReuseOptions = {
   insertedPosition: number
 }
 
-function createRekeyRouteReuseScenarios({
+function createRekeyRouteReuseFixture({
   depth,
   sourceBranch,
   branches,
@@ -1696,7 +1814,12 @@ function createRekeyRouteReuseScenarios({
   insertedId,
   insertedValue,
   insertedPosition,
-}: RekeyRouteReuseOptions): ClassifiedHistoryScenario {
+}: RekeyRouteReuseOptions): {
+  prefix: Array<FullRowBatchStep>
+  rekey: FullRowBatchStep
+  reuse: FullRowBatchStep
+  classify: (difference: AssertionDifference) => boolean
+} {
   const targetLevel = (depth - 1) as IncludeDepth
   assertDisjointRelationshipKeys(depth, branches, {
     extraIds: [insertedId],
@@ -1733,16 +1856,74 @@ function createRekeyRouteReuseScenarios({
     ],
   }
 
+  const retiredRowId = source.idBase + targetLevel
+  const childId = source.idBase + targetLevel + 1
+
   return {
-    control: { depth, steps: [...prefix, insertOldRoute] },
-    candidate: { depth, steps: [...prefix, rekey, insertOldRoute] },
+    prefix,
+    rekey,
+    reuse: insertOldRoute,
+    classify: (difference) =>
+      classifyUnexpectedSharedChild(
+        difference,
+        retiredRowId,
+        insertedId,
+        childId,
+      ),
+  }
+}
+
+function createRekeyRouteReuseScenarios(
+  options: RekeyRouteReuseOptions,
+): ClassifiedHistoryScenario {
+  const { depth } = options
+  const { prefix, rekey, reuse, classify } =
+    createRekeyRouteReuseFixture(options)
+
+  return {
+    control: { depth, steps: [...prefix, reuse] },
+    candidate: { depth, steps: [...prefix, rekey, reuse] },
     candidateCheckpoint: prefix.length + 2,
+    classify,
+  }
+}
+
+function createIntraBatchRekeyRouteReuseScenarios(
+  options: RekeyRouteReuseOptions,
+): ClassifiedHistoryScenario {
+  const { depth } = options
+  const { prefix, rekey, reuse, classify } =
+    createRekeyRouteReuseFixture(options)
+  if (rekey.level === 0 || rekey.level !== reuse.level) {
+    throw new Error(`Intra-batch route reuse must share a child level`)
+  }
+
+  return {
+    control: {
+      depth,
+      steps: [
+        ...prefix,
+        { level: rekey.level, changes: [...reuse.changes, ...rekey.changes] },
+      ],
+    },
+    candidate: {
+      depth,
+      steps: [
+        ...prefix,
+        { level: rekey.level, changes: [...rekey.changes, ...reuse.changes] },
+      ],
+    },
+    candidateCheckpoint: prefix.length + 1,
+    classify,
   }
 }
 
 function rekeyRouteReuseScenarioArbitrary(
   depth: 2 | 3 | 4,
   sourceBranch: 0 | 1,
+  createScenario: (
+    options: RekeyRouteReuseOptions,
+  ) => ClassifiedHistoryScenario = createRekeyRouteReuseScenarios,
 ): fc.Arbitrary<ClassifiedHistoryScenario> {
   return fc
     .record({
@@ -1763,7 +1944,7 @@ function rekeyRouteReuseScenarioArbitrary(
         insertedValue,
         insertedPosition,
       }) =>
-        createRekeyRouteReuseScenarios({
+        createScenario({
           depth,
           sourceBranch,
           branches: createGeneratedBranches({
@@ -1852,19 +2033,48 @@ function createMovedChildReplacementScenarios({
       },
     ],
   }
+  const atomicReplacement = (
+    order: `delete-first` | `insert-first`,
+  ): FullRowBatchScenario => ({
+    depth,
+    steps: [
+      ...prefix,
+      reparent,
+      {
+        level: childLevel,
+        changes:
+          order === `delete-first`
+            ? [
+                { type: `delete`, value: existingChild },
+                { type: `insert`, value: replacementChild },
+              ]
+            : [
+                { type: `insert`, value: replacementChild },
+                { type: `delete`, value: existingChild },
+              ],
+      },
+    ],
+  })
+  const grandchildId = source.idBase + targetLevel + 2
 
   return {
     control: { depth, steps: [...prefix, ...replaceChild] },
+    greenVariants: [
+      atomicReplacement(`delete-first`),
+      atomicReplacement(`insert-first`),
+    ],
     candidate: { depth, steps: [...prefix, reparent, ...replaceChild] },
     candidateCheckpoint: prefix.length + 3,
+    classify: (difference) =>
+      classifyMissingReplacementChild(difference, insertedId, grandchildId),
   }
 }
 
-function movedChildReplacementScenarioArbitrary(
+function movedChildReplacementMirrorsArbitrary(
   depth: 3 | 4,
   targetLevel: IncludeDepth,
   sourceBranch: 0 | 1,
-): fc.Arbitrary<ClassifiedHistoryScenario> {
+): fc.Arbitrary<Record<BranchDeliveryOrder, ClassifiedHistoryScenario>> {
   return fc
     .record({
       ...generatedBranchArbitraries,
@@ -1881,22 +2091,121 @@ function movedChildReplacementScenarioArbitrary(
         insertedId,
         insertedValue,
         insertedPosition,
-      }) =>
-        createMovedChildReplacementScenarios({
-          depth,
-          targetLevel,
-          sourceBranch,
-          branches: createGeneratedBranches({
-            leftIdBase,
-            leftGroupBase,
-            rightIdBase,
-            rightGroupBase,
-          }),
-          insertedId,
-          insertedValue,
-          insertedPosition,
-        }),
+      }) => {
+        const branches = createGeneratedBranches({
+          leftIdBase,
+          leftGroupBase,
+          rightIdBase,
+          rightGroupBase,
+        })
+        const createMirror = (deliveryOrder: BranchDeliveryOrder) =>
+          createMovedChildReplacementScenarios({
+            depth,
+            targetLevel,
+            sourceBranch: deliveredBranchIndex(sourceBranch, deliveryOrder),
+            branches: deliverBranches(branches, deliveryOrder),
+            insertedId,
+            insertedValue,
+            insertedPosition,
+          })
+
+        return {
+          forward: createMirror(`forward`),
+          reverse: createMirror(`reverse`),
+        }
+      },
     )
+}
+
+function createSharedRouteLifetimeScenarios(
+  parentLevel: 0 | 1,
+): ClassifiedHistoryScenario {
+  if (parentLevel === 0) {
+    const departed = batchRoot(100, 600, 100, 0)
+    const remaining = batchRoot(1_100, 600, 1_100, 1)
+    const child = { ...batchChild(101, 600, 101, 0), group: 601 }
+    const controlSteps: Array<FullRowBatchStep> = [
+      { level: 0, changes: [{ type: `insert`, value: departed }] },
+      { level: 1, changes: [{ type: `insert`, value: child }] },
+      {
+        level: 0,
+        changes: [{ type: `update`, value: { ...departed, group: 700 } }],
+      },
+      {
+        level: 1,
+        changes: [
+          { type: `update`, value: { ...child, value: child.value + 1 } },
+        ],
+      },
+    ]
+    const candidateSteps: Array<FullRowBatchStep> = [
+      {
+        level: 0,
+        changes: [
+          { type: `insert`, value: departed },
+          { type: `insert`, value: remaining },
+        ],
+      },
+      ...controlSteps.slice(1),
+    ]
+
+    return {
+      control: { depth: 1, steps: controlSteps },
+      candidate: { depth: 1, steps: candidateSteps },
+      candidateCheckpoint: candidateSteps.length,
+      classify: (difference) =>
+        classifyUnexpectedSharedChild(
+          difference,
+          departed.id,
+          remaining.id,
+          child.id,
+        ),
+    }
+  }
+
+  const root = batchRoot(100, 600, 100, 0)
+  const departed = { ...batchChild(101, 600, 101, 0), group: 601 }
+  const remaining = { ...batchChild(1_101, 600, 1_101, 1), group: 601 }
+  const child = { ...batchChild(102, 601, 102, 0), group: 602 }
+  const controlSteps: Array<FullRowBatchStep> = [
+    { level: 0, changes: [{ type: `insert`, value: root }] },
+    { level: 1, changes: [{ type: `insert`, value: departed }] },
+    { level: 2, changes: [{ type: `insert`, value: child }] },
+    {
+      level: 1,
+      changes: [{ type: `update`, value: { ...departed, group: 700 } }],
+    },
+    {
+      level: 2,
+      changes: [
+        { type: `update`, value: { ...child, value: child.value + 1 } },
+      ],
+    },
+  ]
+  const candidateSteps: Array<FullRowBatchStep> = [
+    controlSteps[0]!,
+    {
+      level: 1,
+      changes: [
+        { type: `insert`, value: departed },
+        { type: `insert`, value: remaining },
+      ],
+    },
+    ...controlSteps.slice(2),
+  ]
+
+  return {
+    control: { depth: 2, steps: controlSteps },
+    candidate: { depth: 2, steps: candidateSteps },
+    candidateCheckpoint: candidateSteps.length,
+    classify: (difference) =>
+      classifyUnexpectedSharedChild(
+        difference,
+        departed.id,
+        remaining.id,
+        child.id,
+      ),
+  }
 }
 
 async function expectFullRowBatchScenarioMatches({
@@ -1912,21 +2221,30 @@ async function expectFullRowBatchScenarioMatches({
 
 async function expectClassifiedHistoryFailure({
   control,
+  greenVariants = [],
   candidate,
   candidateCheckpoint,
+  classify,
 }: ClassifiedHistoryScenario): Promise<void> {
   await expectFullRowBatchScenarioMatches(control)
+  for (const greenVariant of greenVariants) {
+    await expectFullRowBatchScenarioMatches(greenVariant)
+  }
   await expectAssertionFailure(
     () => expectFullRowBatchScenarioMatches(candidate),
-    { checkpoint: candidateCheckpoint },
+    { checkpoint: candidateCheckpoint, classify },
   )()
 }
 
 async function expectClassifiedHistoryMatches({
   control,
+  greenVariants = [],
   candidate,
 }: ClassifiedHistoryScenario): Promise<void> {
   await expectFullRowBatchScenarioMatches(control)
+  for (const greenVariant of greenVariants) {
+    await expectFullRowBatchScenarioMatches(greenVariant)
+  }
   await expectFullRowBatchScenarioMatches(candidate)
 }
 
@@ -2436,6 +2754,7 @@ const {
   control: rekeyRouteReuseControl,
   candidate: rekeyRouteResurrectionScenario,
   candidateCheckpoint: rekeyRouteResurrectionCheckpoint,
+  classify: classifyRekeyRouteResurrection,
 } = createRekeyRouteReuseScenarios({
   depth: 2,
   sourceBranch: 0,
@@ -2452,6 +2771,7 @@ const {
   control: childReplacementControl,
   candidate: movedSubtreeChildReplacementScenario,
   candidateCheckpoint: movedSubtreeChildReplacementCheckpoint,
+  classify: classifyMovedSubtreeChildReplacement,
 } = createMovedChildReplacementScenarios({
   depth: 3,
   targetLevel: 1,
@@ -2552,7 +2872,10 @@ describe(`includes recompute oracle`, () => {
     `discovered trace: reusing a rekeyed row's old route does not resurrect its child`,
     expectAssertionFailure(
       () => expectFullRowBatchScenarioMatches(rekeyRouteResurrectionScenario),
-      { checkpoint: rekeyRouteResurrectionCheckpoint },
+      {
+        checkpoint: rekeyRouteResurrectionCheckpoint,
+        classify: classifyRekeyRouteResurrection,
+      },
     ),
   )
 
@@ -2566,7 +2889,10 @@ describe(`includes recompute oracle`, () => {
     expectAssertionFailure(
       () =>
         expectFullRowBatchScenarioMatches(movedSubtreeChildReplacementScenario),
-      { checkpoint: movedSubtreeChildReplacementCheckpoint },
+      {
+        checkpoint: movedSubtreeChildReplacementCheckpoint,
+        classify: classifyMovedSubtreeChildReplacement,
+      },
     ),
   )
 
@@ -2584,19 +2910,42 @@ describe(`includes recompute oracle`, () => {
         `discovered histories: reusing a retired route at depth ${depth}, branch ${sourceBranch}`,
         expectClassifiedHistoryFailure,
       )
+
+      fcTest.prop(
+        [
+          rekeyRouteReuseScenarioArbitrary(
+            depth,
+            sourceBranch,
+            createIntraBatchRekeyRouteReuseScenarios,
+          ),
+        ],
+        {
+          numRuns: 4,
+          seed: 1733 + depth * 10 + sourceBranch,
+        },
+      )(
+        `discovered histories: intra-batch rekey then retired-route reuse at depth ${depth}, branch ${sourceBranch}`,
+        expectClassifiedHistoryFailure,
+      )
     }
+  }
+
+  for (const parentLevel of [0, 1] as const) {
+    fcTest(
+      `discovered trace: a departed level-${parentLevel} shared-route subscriber receives later child updates`,
+      () =>
+        expectClassifiedHistoryFailure(
+          createSharedRouteLifetimeScenarios(parentLevel),
+        ),
+    )
   }
 
   for (const depth of [3, 4] as const) {
     for (let targetLevel = 1; targetLevel <= depth - 2; targetLevel++) {
       for (const sourceBranch of [0, 1] as const) {
-        // (depth 4, target level 2, source branch 1) is the observed green
-        // boundary. Pin it so this expected-failure class cannot expand unseen.
-        const expectsFailure =
-          depth !== 4 || targetLevel !== 2 || sourceBranch !== 1
         fcTest.prop(
           [
-            movedChildReplacementScenarioArbitrary(
+            movedChildReplacementMirrorsArbitrary(
               depth,
               targetLevel as IncludeDepth,
               sourceBranch,
@@ -2604,15 +2953,28 @@ describe(`includes recompute oracle`, () => {
           ],
           {
             numRuns: 4,
-            seed: 1727 + depth * 10 + targetLevel * 2 + sourceBranch,
+            seed: 1727 + depth * 100 + targetLevel * 10 + sourceBranch,
           },
         )(
-          expectsFailure
-            ? `discovered histories: replacing a moved child at depth ${depth}, level ${targetLevel}, branch ${sourceBranch}`
-            : `matches recomputation when replacing a moved child at depth ${depth}, level ${targetLevel}, branch ${sourceBranch}`,
-          expectsFailure
-            ? expectClassifiedHistoryFailure
-            : expectClassifiedHistoryMatches,
+          `classifies forward/reverse delivery mirrors when replacing a moved child at depth ${depth}, level ${targetLevel}, source ${sourceBranch}`,
+          async (scenarios) => {
+            for (const deliveryOrder of branchDeliveryOrders) {
+              const deliveredSource = deliveredBranchIndex(
+                sourceBranch,
+                deliveryOrder,
+              )
+              // At depth 4, level 2, replacement stays green only when the
+              // moved branch was delivered second. The mirrors share one
+              // generated fixture, so delivery order is the only difference.
+              const expectsFailure =
+                depth !== 4 || targetLevel !== 2 || deliveredSource !== 1
+              await (
+                expectsFailure
+                  ? expectClassifiedHistoryFailure
+                  : expectClassifiedHistoryMatches
+              )(scenarios[deliveryOrder])
+            }
+          },
         )
       }
     }
@@ -2703,27 +3065,42 @@ describe(`includes recompute oracle`, () => {
     ]
     for (const [firstIndex, firstTransition] of transitions.entries()) {
       for (const [secondIndex, secondTransition] of transitions.entries()) {
-        fcTest.prop(
-          [
-            transitionHistoryScenariosArbitrary(
-              depth,
-              firstTransition,
-              secondTransition,
-            ),
-          ],
-          {
-            numRuns: 3,
-            seed: 1725 + depth * 10 + firstIndex * 2 + secondIndex,
-          },
-        )(
-          `matches recomputation for ${firstTransition} → ${secondTransition} histories at depth ${depth}`,
-          async (scenarios) => {
-            for (const scenario of scenarios) {
-              expectEveryHistoryStepVisible(scenario)
-              await expectFullRowBatchScenarioMatches(scenario)
-            }
-          },
-        )
+        if (
+          transitionHistoryPlacements(depth, firstTransition, secondTransition)
+            .length === 0
+        ) {
+          continue
+        }
+
+        for (const sourceBranch of [0, 1] as const) {
+          fcTest.prop(
+            [
+              transitionHistoryScenariosArbitrary(
+                depth,
+                firstTransition,
+                secondTransition,
+                sourceBranch,
+              ),
+            ],
+            {
+              numRuns: 3,
+              seed:
+                1725 +
+                depth * 100 +
+                firstIndex * 10 +
+                secondIndex * 2 +
+                sourceBranch,
+            },
+          )(
+            `matches recomputation for ${firstTransition} → ${secondTransition} histories at depth ${depth}, branch ${sourceBranch}`,
+            async (scenarios) => {
+              for (const scenario of scenarios) {
+                expectEveryHistoryStepVisible(scenario)
+                await expectFullRowBatchScenarioMatches(scenario)
+              }
+            },
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a state-aware recompute oracle for ordered relationship-transition histories in nested `includes`, plus strict structural classifiers for known oracle mismatches. This is test-only: runtime behavior does not change, but four new incremental-materialization defect classes are now reproducible across their full observed boundaries instead of being pinned to lucky seeds.

## Reviewer guide

### Why this oracle shape

Fresh, disjoint histories test whether valid transition sequences stay correct, but they cannot exercise stale relationship routes, shared-route subscriber lifetimes, or replacement rows that deliberately reuse correlation keys. Those cases need generators that derive later actions from earlier state.

The expected-failure guard also used to classify only the checkpoint. Two unrelated structural mismatches at the same checkpoint could therefore satisfy one expected-failure test. It now accepts an optional predicate over Vitest's `actual`/`expected` difference so each red matrix cell must fail for the intended relationship defect.

### Approach

The green history grammar runs every observable ordered pair of `reparent` and `rekey` across include depths 1–4, both source branches, every valid target level, and target/immediate-child insertion placement. Rekey histories seed the new child route after rekeying; histories that would enter the already pinned deep-rekey failure class remain outside this green continuation matrix.

Every generated step must change the independently recomputed relationship projection before the incremental result is compared. This prevents scalar-only or no-op steps from making a relationship cell look covered.

Four state-aware candidate/control families cover the histories fresh-key generation cannot express:

1. **Sequential retired-route reuse.** Rekey a penultimate row, then insert another visible row on its retired route. The old row incorrectly keeps the shared child.
2. **Intra-batch retired-route reuse.** Deliver `rekey → route reuse` in one batch. This fails, while the same changes in `route reuse → rekey` order are the green control.
3. **Departed shared-route subscriber lifetime.** Two parents share a route; one departs; a later child update still reaches the departed parent. The single-subscriber history is green.
4. **Moved-child replacement.** Reparent a subtree, delete its child, then insert a replacement with the same route. The replacement can lose its grandchild. No-reparent replacement and both atomic replacement orders are green variants.

The moved-child generator produces forward/reverse delivery mirrors from the same generated fixture. Delivery order is therefore the only changed variable.

### Classified boundaries

- **Sequential retired-route reuse:** depths 2–4, source branches 0 and 1; expected mismatch at `prefix.length + 2` (checkpoint 5 in the minimal depth-2 trace).
- **Intra-batch retired-route reuse:** depths 2–4, source branches 0 and 1; expected mismatch at `prefix.length + 1`. Reversing the two batch changes is green.
- **Departed subscriber:** parent levels 0 and 1; expected mismatch on the final later-child update (checkpoints 4 and 5 respectively).
- **Moved-child replacement:** depths 3–4, every level with a visible grandchild, both logical source branches, and forward/reverse branch delivery. The expected mismatch is at `prefix.length + 3` (checkpoint 7 at depth 3 and checkpoint 8 at depth 4). At depth 4, target level 2, the delivered-first source fails while the delivered-second source is the observed green boundary; the metamorphic mirror pins both outcomes.

The retired/departed-route classifier requires the child to appear under both the stale parent and the correct remaining parent in the incremental result, but only under the correct parent after recomputation. The replacement classifier requires the replacement row to exist in both results while its expected grandchild is missing only from the incremental result.

### Key invariants

- IDs and relationship keys are disjoint unless a state-aware family deliberately reuses a route.
- Every green history step changes relationship membership in the recompute model.
- Candidate histories may diverge only at the exact classified checkpoint and with the classified structural difference.
- Each candidate has an adjacent green control or variant built from the same operations.
- Forward/reverse mirrors preserve logical rows and history while changing only initial branch delivery order.
- Expected failures describe defect classes, not seeds; a fix, boundary change, runtime error, or different mismatch makes the test fail.

### Non-goals

- This PR does not fix any of the four runtime defects.
- It does not run histories through already pinned deep-rekey failures, which would mask later checkpoints.
- It does not close #1658. The RFC still owns the later production refactor, runtime fixes, and expansion of the affected-subtree matrix after those fixes land.

### Trade-offs

The general ordered-pair grammar stays green and separate from the classified state-aware families. Combining them would let a known early mismatch hide the later transition under test. The focused families add code, but preserve FastCheck shrinking, exact boundaries, and strong green controls.

## Verification

Final verification at `65b34f14` passed 102/102 tests: 7 expected-failure helper tests and 95 oracle tests.

```bash
# From the repository root
pnpm exec vitest run tests/expected-failure.test.ts tests/query/includes-oracle.property.test.ts --maxWorkers=2

# From packages/db
pnpm exec tsc --noEmit -p tsconfig.json
pnpm exec eslint tests/expected-failure.ts tests/expected-failure.test.ts tests/query/includes-oracle.property.test.ts
pnpm exec prettier --check tests/expected-failure.ts tests/expected-failure.test.ts tests/query/includes-oracle.property.test.ts

# From the repository root
git diff --check
```

Before the final classifier and metamorphic hardening, an extended campaign ran the initial 28 history cells at 400 runs per cell across two unrelated seed sets and found no mismatch beyond the then-classified defects. The commands above are the final checks for the current commit; CI keeps the committed FastCheck budget small.

## Files changed

- `packages/db/tests/query/includes-oracle.property.test.ts` — adds ordered transition histories, state-aware defect families, deterministic reproductions, generated boundaries, structural classifiers, green controls, and forward/reverse delivery mirrors.
- `packages/db/tests/expected-failure.ts` — optionally classifies the `actual`/`expected` assertion difference after validating the expected checkpoint and error type.
- `packages/db/tests/expected-failure.test.ts` — verifies matching structural classifications pass and unrelated differences fail.

## Release impact

- [x] Tested locally.
- [x] Test-only change; no changeset or published-code release.

---
Related: #1658


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded database relationship tests to cover reparenting, route reuse, shared-child lifetimes, delivery-order variations, subtree replacement, and multi-step transitions.
  * Added deterministic regression coverage for previously unhandled relationship scenarios.
  * Improved assertion-failure tests to classify mismatches using expected and actual values.
* **Developer Experience**
  * Checkpoint assertions now support optional custom mismatch classification while preserving existing message-based checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->