### PR TITLE
test(db): fuzz includes route lifecycles

### DIFF
--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -101,17 +101,22 @@ function hasDirectChild(value: unknown, parentId: number, childId: number) {
   )
 }
 
-function classifyUnexpectedSharedChild(
+function classifyUnexpectedSharedRoute(
   { actual, expected }: AssertionDifference,
   unexpectedParentId: number,
   expectedParentId: number,
   childId: number,
 ): boolean {
+  const expectedParent = findRelationshipNode(expected, expectedParentId)
+  const expectedWithSharedRoute = replaceDirectChildren(
+    expected,
+    unexpectedParentId,
+    Array.isArray(expectedParent?.children) ? expectedParent.children : [],
+  )
   return (
-    hasDirectChild(actual, unexpectedParentId, childId) &&
     !hasDirectChild(expected, unexpectedParentId, childId) &&
-    hasDirectChild(actual, expectedParentId, childId) &&
-    hasDirectChild(expected, expectedParentId, childId)
+    hasDirectChild(expected, expectedParentId, childId) &&
+    isDeepStrictEqual(actual, expectedWithSharedRoute)
   )
 }
 
@@ -120,11 +125,13 @@ function classifyMissingReplacementChild(
   replacementRowId: number,
   childId: number,
 ): boolean {
+  const expectedWithoutChild = removeDirectChild(expected, replacementRowId, [
+    childId,
+  ])
   return (
-    findRelationshipNode(actual, replacementRowId) !== undefined &&
     findRelationshipNode(expected, replacementRowId) !== undefined &&
-    !hasDirectChild(actual, replacementRowId, childId) &&
-    hasDirectChild(expected, replacementRowId, childId)
+    hasDirectChild(expected, replacementRowId, childId) &&
+    isDeepStrictEqual(actual, expectedWithoutChild)
   )
 }
 
@@ -172,6 +179,29 @@ function removeDirectChild(
             )
             .map((child) => removeDirectChild(child, parentId, childIds))
         : removeDirectChild(entry, parentId, childIds),
+    ]),
+  )
+}
+
+function replaceDirectChildren(
+  value: unknown,
+  parentId: number,
+  children: ReadonlyArray<unknown>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) =>
+      replaceDirectChildren(entry, parentId, children),
+    )
+  }
+  if (typeof value !== `object` || value === null) return value
+
+  const isParent = isRelationshipNode(value) && value.id === parentId
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      key === `children` && isParent
+        ? children
+        : replaceDirectChildren(entry, parentId, children),
     ]),
   )
 }
@@ -1883,8 +1913,8 @@ function applyRouteLifecycleStep(
   step: FullRowBatchStep,
   roots: Map<number, RootRow>,
   levels: Array<Map<number, ChildRow>>,
-  seenRoutes: Set<number>,
-  retiredRouteOwners: Map<number, number>,
+  seenRoutes: Set<string>,
+  retiredRouteOwners: Map<string, number>,
 ): void {
   const rows = step.level === 0 ? roots : levels[step.level - 1]!
   const previousRouteOwners = new Map<number, Set<number>>()
@@ -1900,17 +1930,26 @@ function applyRouteLifecycleStep(
   updateFullRowBatchModels(step, roots, levels)
 
   for (const row of rows.values()) {
-    seenRoutes.add(row.group)
-    retiredRouteOwners.delete(row.group)
+    const route = routeIdentity(step.level, row.group)
+    seenRoutes.add(route)
+    retiredRouteOwners.delete(route)
   }
   for (const [route, previousOwners] of previousRouteOwners) {
     if ([...rows.values()].some((row) => row.group === route)) continue
+    const retiredRoute = routeIdentity(step.level, route)
     if (previousOwners.size === 1) {
-      retiredRouteOwners.set(route, [...previousOwners][0]!)
+      retiredRouteOwners.set(retiredRoute, [...previousOwners][0]!)
     } else {
-      retiredRouteOwners.delete(route)
+      retiredRouteOwners.delete(retiredRoute)
     }
   }
+}
+
+function routeIdentity(level: 0 | IncludeDepth, route: number): string {
+  // This oracle has one include edge per level, so level plus correlation value
+  // is the complete route identity. Equal values at different levels are not
+  // the same subscription lifecycle.
+  return `${level}:${route}`
 }
 
 function createRouteLifecycleScenario({
@@ -1920,8 +1959,8 @@ function createRouteLifecycleScenario({
   prefixSteps = createConnectedBatchBranches(depth, branches),
   trailingSteps = [],
 }: RouteLifecycleScenarioOptions): RouteLifecycleScenario {
-  const seenRoutes = new Set<number>()
-  const retiredRouteOwners = new Map<number, number>()
+  const seenRoutes = new Set<string>()
+  const retiredRouteOwners = new Map<string, number>()
 
   const steps = [...prefixSteps]
   const roots = new Map<number, RootRow>()
@@ -1974,11 +2013,15 @@ function createRouteLifecycleScenario({
         ? row.group === currentRoute
         : (row as ChildRow).parentGroup === currentRoute,
     ).length
-    const retiredOwner = retiredRouteOwners.get(descriptor.destination.route)
+    const destinationRoute = routeIdentity(
+      descriptor.level,
+      descriptor.destination.route,
+    )
+    const retiredOwner = retiredRouteOwners.get(destinationRoute)
 
     switch (descriptor.destination.strategy) {
       case `fresh`:
-        if (seenRoutes.has(descriptor.destination.route)) {
+        if (seenRoutes.has(destinationRoute)) {
           throw new Error(`fresh route must never have been used`)
         }
         break
@@ -1996,7 +2039,7 @@ function createRouteLifecycleScenario({
         }
         break
       case `split`:
-        if (seenRoutes.has(descriptor.destination.route)) {
+        if (seenRoutes.has(destinationRoute)) {
           throw new Error(`split destination must be unused`)
         }
         if (currentRouteUsers < 2) {
@@ -2492,6 +2535,69 @@ function createSnapshotOnResubscribeScenarios(
   }
 }
 
+function createInitiallySharedRouteResubscribeScenario(
+  parentLevel: 0 | 1 | 2,
+): ClassifiedHistoryScenario {
+  const depth = (parentLevel + 1) as IncludeDepth
+  const branches = transitionHistoryBranches
+  const childLevel = depth
+  const sharedRoute = branches[0].groupBase + parentLevel
+  const childId = rowAt(branches, 0, childLevel)
+  const child = {
+    ...batchChild(childId, sharedRoute, childId, 0),
+    group: branches[0].groupBase + childLevel,
+  }
+  const scenario = createRouteLifecycleScenario({
+    depth,
+    branches,
+    prefixSteps: createInitiallySharedRoutePrefix(depth, parentLevel, branches),
+    descriptors: [
+      {
+        kind: `rekey`,
+        level: parentLevel,
+        row: 0,
+        destination: { strategy: `split`, route: 2_100 + parentLevel },
+      },
+      {
+        kind: `rekey`,
+        level: parentLevel,
+        row: 1,
+        destination: { strategy: `fresh`, route: 2_200 + parentLevel },
+      },
+      {
+        kind: `rekey`,
+        level: parentLevel,
+        row: 1,
+        destination: { strategy: `restore`, route: sharedRoute },
+        stepsBefore: [
+          {
+            level: childLevel,
+            changes: [
+              {
+                type: `update`,
+                value: { ...child, value: child.value + 1 },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+  expectEveryRouteTransitionVisible(scenario)
+  return {
+    control: createSharedRouteLastSubscriberScenario(parentLevel),
+    candidate: scenario,
+    candidateCheckpoint: scenario.steps.length,
+    classify: (difference) =>
+      classifyUnexpectedSharedRoute(
+        difference,
+        rowAt(branches, 0, parentLevel),
+        rowAt(branches, 1, parentLevel),
+        childId,
+      ),
+  }
+}
+
 type ClassifiedHistoryScenario = {
   control: FullRowBatchScenario
   greenVariants?: ReadonlyArray<FullRowBatchScenario>
@@ -2568,7 +2674,7 @@ function createRekeyRouteReuseFixture({
     rekey,
     reuse: insertOldRoute,
     classify: (difference) =>
-      classifyUnexpectedSharedChild(
+      classifyUnexpectedSharedRoute(
         difference,
         retiredRowId,
         insertedId,
@@ -2858,7 +2964,7 @@ function createSharedRouteLifetimeScenarios(
       candidate: { depth: 1, steps: candidateSteps },
       candidateCheckpoint: candidateSteps.length,
       classify: (difference) =>
-        classifyUnexpectedSharedChild(
+        classifyUnexpectedSharedRoute(
           difference,
           departed.id,
           remaining.id,
@@ -2903,7 +3009,7 @@ function createSharedRouteLifetimeScenarios(
     candidate: { depth: 2, steps: candidateSteps },
     candidateCheckpoint: candidateSteps.length,
     classify: (difference) =>
-      classifyUnexpectedSharedChild(
+      classifyUnexpectedSharedRoute(
         difference,
         departed.id,
         remaining.id,
@@ -3508,6 +3614,39 @@ describe(`includes recompute oracle`, () => {
     },
   )
 
+  fcTest(
+    `unexpected shared-child classification rejects extra corruption`,
+    () => {
+      const expected = [
+        { id: 1, value: 10, children: [] },
+        { id: 2, value: 20, children: [{ id: 3, value: 30 }] },
+      ]
+      const actual = [
+        { id: 1, value: 11, children: [{ id: 3, value: 30 }] },
+        { id: 2, value: 20, children: [{ id: 3, value: 31 }] },
+      ]
+
+      expect(classifyUnexpectedSharedRoute({ actual, expected }, 1, 2, 3)).toBe(
+        false,
+      )
+    },
+  )
+
+  fcTest(`missing replacement classification rejects extra corruption`, () => {
+    const expected = [
+      { id: 1, value: 10, children: [{ id: 3, value: 30 }] },
+      { id: 2, value: 20, children: [] },
+    ]
+    const actual = [
+      { id: 1, value: 11, children: [] },
+      { id: 2, value: 21, children: [] },
+    ]
+
+    expect(classifyMissingReplacementChild({ actual, expected }, 1, 3)).toBe(
+      false,
+    )
+  })
+
   fcTest(`rejects subscriber lifecycle labels on reparent transitions`, () => {
     expect(() =>
       createRouteLifecycleScenario({
@@ -3523,6 +3662,29 @@ describe(`includes recompute oracle`, () => {
         ],
       }),
     ).toThrow(/reparent transitions only support live merge destinations/)
+  })
+
+  fcTest(`scopes rekey route histories to their include level`, () => {
+    expect(() =>
+      createRouteLifecycleScenario({
+        depth: 3,
+        branches: transitionHistoryBranches,
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 1,
+            row: 0,
+            destination: { strategy: `fresh`, route: 2_100 },
+          },
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `fresh`, route: 2_100 },
+          },
+        ],
+      }),
+    ).not.toThrow()
   })
 
   fcTest(`the sibling topology targets rows under one parent`, () => {
@@ -3685,6 +3847,18 @@ describe(`includes recompute oracle`, () => {
       () =>
         expectClassifiedHistoryMatches(
           createSnapshotOnResubscribeScenarios(parentLevel),
+        ),
+    )
+
+    fcTest(
+      parentLevel === 0
+        ? `discovered trace: an initially shared root route retires, changes, and resubscribes`
+        : `matches recomputation when an initially shared level-${parentLevel} route retires, changes, and resubscribes`,
+      () =>
+        (parentLevel === 0
+          ? expectClassifiedHistoryFailure
+          : expectClassifiedHistoryMatches)(
+          createInitiallySharedRouteResubscribeScenario(parentLevel),
         ),
     )
   }

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -206,55 +206,6 @@ function replaceDirectChildren(
   )
 }
 
-function removeDirectRelationshipChild(
-  value: unknown,
-  parentId: number,
-  childId: number,
-): unknown {
-  if (!Array.isArray(value)) return value
-
-  return value.map((entry) => {
-    if (!isRelationshipNode(entry) || !Array.isArray(entry.children)) {
-      return entry
-    }
-
-    return {
-      ...entry,
-      children:
-        entry.id === parentId
-          ? entry.children.filter(
-              (child) => !isRelationshipNode(child) || child.id !== childId,
-            )
-          : removeDirectRelationshipChild(entry.children, parentId, childId),
-    }
-  })
-}
-
-function classifyOnlyMissingReplacementChild(
-  difference: AssertionDifference,
-  replacementRowId: number,
-  childId: number,
-): boolean {
-  if (!classifyMissingReplacementChild(difference, replacementRowId, childId)) {
-    return false
-  }
-
-  try {
-    expect(difference.actual).toEqual(
-      removeDirectRelationshipChild(
-        difference.expected,
-        replacementRowId,
-        childId,
-      ),
-    )
-    return true
-  } catch {
-    // Reject a known missing-child difference if any second difference rides
-    // along with it; expected failures must not hide new regressions.
-    return false
-  }
-}
-
 type RelationshipProjectionNode = {
   id: number
   children?: Array<RelationshipProjectionNode>
@@ -3101,7 +3052,7 @@ function createRelationshipBatchShapeScenarios({
     },
     candidateCheckpoint: prefix.length + 1 + replacementSteps.length,
     classify: (difference) =>
-      classifyOnlyMissingReplacementChild(
+      classifyMissingReplacementChild(
         difference,
         replacementChild.id,
         source.idBase + depth,

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util'
 import { fc, test as fcTest } from '@fast-check/vitest'
 import { describe, expect } from 'vitest'
 import {
@@ -131,15 +132,47 @@ function classifyMissingSharedRouteSnapshot(
   { actual, expected }: AssertionDifference,
   enteringParentId: number,
   existingParentId: number,
-  childId: number,
+  childIds: number | ReadonlyArray<number>,
 ): boolean {
+  const expectedChildIds = Array.isArray(childIds) ? childIds : [childIds]
+  const expectedWithoutSnapshot = removeDirectChild(
+    expected,
+    enteringParentId,
+    expectedChildIds,
+  )
   return (
-    findRelationshipNode(actual, enteringParentId) !== undefined &&
-    findRelationshipNode(expected, enteringParentId) !== undefined &&
-    !hasDirectChild(actual, enteringParentId, childId) &&
-    hasDirectChild(expected, enteringParentId, childId) &&
-    hasDirectChild(actual, existingParentId, childId) &&
-    hasDirectChild(expected, existingParentId, childId)
+    expectedChildIds.every(
+      (childId) =>
+        hasDirectChild(expected, enteringParentId, childId) &&
+        hasDirectChild(actual, existingParentId, childId) &&
+        hasDirectChild(expected, existingParentId, childId),
+    ) && isDeepStrictEqual(actual, expectedWithoutSnapshot)
+  )
+}
+
+function removeDirectChild(
+  value: unknown,
+  parentId: number,
+  childIds: ReadonlyArray<number>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => removeDirectChild(entry, parentId, childIds))
+  }
+  if (typeof value !== `object` || value === null) return value
+
+  const isParent = isRelationshipNode(value) && value.id === parentId
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      key === `children` && isParent && Array.isArray(entry)
+        ? entry
+            .filter(
+              (child) =>
+                !isRelationshipNode(child) || !childIds.includes(child.id),
+            )
+            .map((child) => removeDirectChild(child, parentId, childIds))
+        : removeDirectChild(entry, parentId, childIds),
+    ]),
   )
 }
 
@@ -1812,11 +1845,18 @@ type RouteDestination = {
 
 type RouteTransitionDescriptor = {
   row: 0 | 1
-  destination: RouteDestination
   stepsBefore?: ReadonlyArray<FullRowBatchStep>
 } & (
-  | { kind: `reparent`; level: IncludeDepth }
-  | { kind: `rekey`; level: 0 | IncludeDepth }
+  | {
+      kind: `reparent`
+      level: IncludeDepth
+      destination: { strategy: `merge`; route: number }
+    }
+  | {
+      kind: `rekey`
+      level: 0 | IncludeDepth
+      destination: RouteDestination
+    }
 )
 
 type RouteLifecycleScenario = FullRowBatchScenario & {
@@ -1892,6 +1932,12 @@ function createRouteLifecycleScenario({
 
   const transitionStepIndexes: Array<number> = []
   for (const descriptor of descriptors) {
+    const destination = descriptor.destination as RouteDestination
+    if (descriptor.kind === `reparent` && destination.strategy !== `merge`) {
+      throw new Error(
+        `reparent transitions only support live merge destinations`,
+      )
+    }
     for (const step of descriptor.stepsBefore ?? []) {
       steps.push(step)
       applyRouteLifecycleStep(
@@ -2073,13 +2119,10 @@ function independentTransitionDescriptors(
     case `descendant-ancestor`:
       return [
         {
-          kind: `reparent`,
+          kind: `rekey`,
           level: 2,
           row: 0,
-          destination: {
-            strategy: `merge`,
-            route: branches[1].groupBase + 1,
-          },
+          destination: { strategy: `fresh`, route: freshRoutes[0] },
         },
         {
           kind: `reparent`,
@@ -2145,6 +2188,34 @@ function independentTransitionDescriptors(
   }
 }
 
+function independentTransitionPrefix(
+  shape: IndependentTransitionShape,
+  branches: readonly [ConnectedBranch, ConnectedBranch],
+): Array<FullRowBatchStep> {
+  const prefix = createConnectedBatchBranches(3, branches)
+  if (shape !== `sibling`) return prefix
+
+  const secondSiblingId = rowAt(branches, 1, 2)
+  return prefix.map((step) =>
+    step.level === 2
+      ? {
+          ...step,
+          changes: step.changes.map((change) =>
+            change.value.id === secondSiblingId
+              ? {
+                  ...change,
+                  value: {
+                    ...change.value,
+                    parentGroup: branches[0].groupBase + 1,
+                  },
+                }
+              : change,
+          ),
+        }
+      : step,
+  )
+}
+
 function independentTransitionScenarioArbitrary(
   shape: IndependentTransitionShape,
 ): fc.Arbitrary<RouteLifecycleScenario> {
@@ -2158,6 +2229,7 @@ function independentTransitionScenarioArbitrary(
       return createRouteLifecycleScenario({
         depth: 3,
         branches,
+        prefixSteps: independentTransitionPrefix(shape, branches),
         descriptors: independentTransitionDescriptors(
           shape,
           branches,
@@ -2245,24 +2317,6 @@ function destinationHistoryScenarioArbitrary(
         ),
       })
     })
-}
-
-function relationshipNodeValue(value: unknown, id: number): unknown {
-  return findRelationshipNode(value, id)?.value
-}
-
-function classifyMissingOrStaleChild(
-  { actual, expected }: AssertionDifference,
-  parentId: number,
-  childId: number,
-  expectedValue: number,
-): boolean {
-  return (
-    hasDirectChild(expected, parentId, childId) &&
-    relationshipNodeValue(expected, childId) === expectedValue &&
-    (!hasDirectChild(actual, parentId, childId) ||
-      relationshipNodeValue(actual, childId) !== expectedValue)
-  )
 }
 
 function createInitiallySharedRoutePrefix(
@@ -2391,11 +2445,10 @@ function createSharedRouteLastSubscriberScenario(
 
 function createSnapshotOnResubscribeScenarios(
   parentLevel: 0 | 1 | 2,
-): ClassifiedHistoryScenario {
+): Pick<ClassifiedHistoryScenario, `control` | `candidate`> {
   const depth = (parentLevel + 1) as IncludeDepth
   const branches = transitionHistoryBranches
   const childLevel = depth
-  const parentId = rowAt(branches, 0, parentLevel)
   const originalRoute = branches[0].groupBase + parentLevel
   const childId = rowAt(branches, 0, childLevel)
   const child = {
@@ -2436,14 +2489,6 @@ function createSnapshotOnResubscribeScenarios(
   return {
     control,
     candidate,
-    candidateCheckpoint: candidate.steps.length,
-    classify: (difference) =>
-      classifyMissingOrStaleChild(
-        difference,
-        parentId,
-        childId,
-        updatedChild.value,
-      ),
   }
 }
 
@@ -2899,7 +2944,10 @@ async function expectClassifiedHistoryMatches({
   control,
   greenVariants = [],
   candidate,
-}: ClassifiedHistoryScenario): Promise<void> {
+}: Pick<
+  ClassifiedHistoryScenario,
+  `control` | `greenVariants` | `candidate`
+>): Promise<void> {
   await expectFullRowBatchScenarioMatches(control)
   for (const greenVariant of greenVariants) {
     await expectFullRowBatchScenarioMatches(greenVariant)
@@ -3442,6 +3490,144 @@ const {
 })
 
 describe(`includes recompute oracle`, () => {
+  fcTest(
+    `shared-route snapshot classification rejects extra corruption`,
+    () => {
+      const expected = [
+        { id: 1, value: 10, children: [{ id: 3, value: 30 }] },
+        { id: 2, value: 20, children: [{ id: 3, value: 30 }] },
+      ]
+      const actual = [
+        { id: 1, value: 11, children: [] },
+        { id: 2, value: 20, children: [{ id: 3, value: 31 }] },
+      ]
+
+      expect(
+        classifyMissingSharedRouteSnapshot({ actual, expected }, 1, 2, 3),
+      ).toBe(false)
+    },
+  )
+
+  fcTest(`rejects subscriber lifecycle labels on reparent transitions`, () => {
+    expect(() =>
+      createRouteLifecycleScenario({
+        depth: 3,
+        branches: transitionHistoryBranches,
+        descriptors: [
+          {
+            kind: `reparent`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `fresh`, route: 2_100 },
+          } as unknown as RouteTransitionDescriptor,
+        ],
+      }),
+    ).toThrow(/reparent transitions only support live merge destinations/)
+  })
+
+  fcTest(`the sibling topology targets rows under one parent`, () => {
+    const branches = transitionHistoryBranches
+    const prefix = independentTransitionPrefix(`sibling`, branches)
+    const levelTwo = prefix.find((step) => step.level === 2)
+    if (!levelTwo || levelTwo.level !== 2) throw new Error(`Missing level 2`)
+    const first = levelTwo.changes.find(
+      (change) => change.value.id === rowAt(branches, 0, 2),
+    )
+    const second = levelTwo.changes.find(
+      (change) => change.value.id === rowAt(branches, 1, 2),
+    )
+    if (!first || !second) throw new Error(`Missing sibling targets`)
+
+    expect(first.value.parentGroup).toBe(second.value.parentGroup)
+  })
+
+  fcTest(`the descendant remains attached before its ancestor moves`, () => {
+    const branches = transitionHistoryBranches
+    const scenario = createRouteLifecycleScenario({
+      depth: 3,
+      branches,
+      descriptors: independentTransitionDescriptors(
+        `descendant-ancestor`,
+        branches,
+        [2_100, 2_500],
+      ),
+    })
+    const ancestorTransitionStep = scenario.transitionStepIndexes[1]
+    if (ancestorTransitionStep === undefined) {
+      throw new Error(`Missing ancestor transition`)
+    }
+    const beforeAncestorMove = recomputeFullRowBatchScenario(
+      scenario,
+      ancestorTransitionStep,
+    )
+
+    expect(
+      hasDirectChild(
+        beforeAncestorMove,
+        rowAt(branches, 0, 1),
+        rowAt(branches, 0, 2),
+      ),
+    ).toBe(true)
+  })
+
+  fcTest(
+    `discovered trace: a root entering a live route misses its ordered snapshot`,
+    async () => {
+      const branches = transitionHistoryBranches
+      const prefix = createConnectedBatchBranches(1, branches)
+      const childStep = prefix.find((step) => step.level === 1)
+      if (!childStep || childStep.level !== 1)
+        throw new Error(`Missing children`)
+      const scenario: FullRowBatchScenario = {
+        depth: 1,
+        steps: [
+          prefix[0]!,
+          {
+            level: 1,
+            changes: [
+              ...childStep.changes,
+              {
+                type: `insert`,
+                value: {
+                  ...batchChild(3_000, branches[0].groupBase, 3_000, -1),
+                  group: 2_500,
+                },
+              },
+            ],
+          },
+          {
+            level: 0,
+            changes: [
+              {
+                type: `update`,
+                value: batchRoot(
+                  branches[1].idBase,
+                  branches[0].groupBase,
+                  branches[1].idBase,
+                  0,
+                ),
+              },
+            ],
+          },
+        ],
+      }
+
+      await expectAssertionFailure(
+        () => expectFullRowBatchScenarioMatches(scenario),
+        {
+          checkpoint: 3,
+          classify: (difference) =>
+            classifyMissingSharedRouteSnapshot(
+              difference,
+              branches[1].idBase,
+              branches[0].idBase,
+              [3_000, branches[0].idBase + 1],
+            ),
+        },
+      )()
+    },
+  )
+
   for (const [shapeIndex, shape] of independentTransitionShapes.entries()) {
     fcTest.prop([independentTransitionScenarioArbitrary(shape)], {
       numRuns: 4,
@@ -3470,6 +3656,8 @@ describe(`includes recompute oracle`, () => {
 
   for (const parentLevel of [0, 1, 2] as const) {
     for (const enteringRow of [0, 1] as const) {
+      // Only roots currently miss an existing shared-route snapshot; nested
+      // subscribers receive the snapshot and remain green controls.
       const expectsFailure = parentLevel === 0
       fcTest(
         expectsFailure

--- a/packages/db/tests/query/includes-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-oracle.property.test.ts
@@ -62,6 +62,7 @@ type OracleNode = RootRow & {
 
 type RelationshipNode = {
   id: number
+  value?: unknown
   children?: unknown
 }
 
@@ -123,6 +124,22 @@ function classifyMissingReplacementChild(
     findRelationshipNode(expected, replacementRowId) !== undefined &&
     !hasDirectChild(actual, replacementRowId, childId) &&
     hasDirectChild(expected, replacementRowId, childId)
+  )
+}
+
+function classifyMissingSharedRouteSnapshot(
+  { actual, expected }: AssertionDifference,
+  enteringParentId: number,
+  existingParentId: number,
+  childId: number,
+): boolean {
+  return (
+    findRelationshipNode(actual, enteringParentId) !== undefined &&
+    findRelationshipNode(expected, enteringParentId) !== undefined &&
+    !hasDirectChild(actual, enteringParentId, childId) &&
+    hasDirectChild(expected, enteringParentId, childId) &&
+    hasDirectChild(actual, existingParentId, childId) &&
+    hasDirectChild(expected, existingParentId, childId)
   )
 }
 
@@ -1788,6 +1805,648 @@ function expectEveryHistoryStepVisible(
   }
 }
 
+type RouteDestination = {
+  strategy: `fresh` | `restore` | `merge` | `split` | `retired`
+  route: number
+}
+
+type RouteTransitionDescriptor = {
+  row: 0 | 1
+  destination: RouteDestination
+  stepsBefore?: ReadonlyArray<FullRowBatchStep>
+} & (
+  | { kind: `reparent`; level: IncludeDepth }
+  | { kind: `rekey`; level: 0 | IncludeDepth }
+)
+
+type RouteLifecycleScenario = FullRowBatchScenario & {
+  transitionStepIndexes: ReadonlyArray<number>
+}
+
+type RouteLifecycleScenarioOptions = {
+  depth: IncludeDepth
+  branches: readonly [ConnectedBranch, ConnectedBranch]
+  descriptors: ReadonlyArray<RouteTransitionDescriptor>
+  prefixSteps?: ReadonlyArray<FullRowBatchStep>
+  trailingSteps?: ReadonlyArray<FullRowBatchStep>
+}
+
+function rowAt(
+  branches: readonly [ConnectedBranch, ConnectedBranch],
+  row: 0 | 1,
+  level: 0 | IncludeDepth,
+): number {
+  return branches[row].idBase + level
+}
+
+function applyRouteLifecycleStep(
+  step: FullRowBatchStep,
+  roots: Map<number, RootRow>,
+  levels: Array<Map<number, ChildRow>>,
+  seenRoutes: Set<number>,
+  retiredRouteOwners: Map<number, number>,
+): void {
+  const rows = step.level === 0 ? roots : levels[step.level - 1]!
+  const previousRouteOwners = new Map<number, Set<number>>()
+
+  for (const change of step.changes) {
+    const previous = rows.get(change.value.id)
+    if (!previous) continue
+    const owners = previousRouteOwners.get(previous.group) ?? new Set<number>()
+    owners.add(previous.id)
+    previousRouteOwners.set(previous.group, owners)
+  }
+
+  updateFullRowBatchModels(step, roots, levels)
+
+  for (const row of rows.values()) {
+    seenRoutes.add(row.group)
+    retiredRouteOwners.delete(row.group)
+  }
+  for (const [route, previousOwners] of previousRouteOwners) {
+    if ([...rows.values()].some((row) => row.group === route)) continue
+    if (previousOwners.size === 1) {
+      retiredRouteOwners.set(route, [...previousOwners][0]!)
+    } else {
+      retiredRouteOwners.delete(route)
+    }
+  }
+}
+
+function createRouteLifecycleScenario({
+  depth,
+  branches,
+  descriptors,
+  prefixSteps = createConnectedBatchBranches(depth, branches),
+  trailingSteps = [],
+}: RouteLifecycleScenarioOptions): RouteLifecycleScenario {
+  const seenRoutes = new Set<number>()
+  const retiredRouteOwners = new Map<number, number>()
+
+  const steps = [...prefixSteps]
+  const roots = new Map<number, RootRow>()
+  const levels = Array.from({ length: 4 }, () => new Map<number, ChildRow>())
+  for (const step of steps) {
+    applyRouteLifecycleStep(step, roots, levels, seenRoutes, retiredRouteOwners)
+  }
+
+  const transitionStepIndexes: Array<number> = []
+  for (const descriptor of descriptors) {
+    for (const step of descriptor.stepsBefore ?? []) {
+      steps.push(step)
+      applyRouteLifecycleStep(
+        step,
+        roots,
+        levels,
+        seenRoutes,
+        retiredRouteOwners,
+      )
+    }
+
+    const id = rowAt(branches, descriptor.row, descriptor.level)
+    const rowsAtLevel =
+      descriptor.level === 0
+        ? [...roots.values()]
+        : [...levels[descriptor.level - 1]!.values()]
+    const current = rowsAtLevel.find((row) => row.id === id)
+    if (!current) throw new Error(`Missing transition row ${id}`)
+    const currentRoute =
+      descriptor.kind === `rekey`
+        ? current.group
+        : (current as ChildRow).parentGroup
+    const destinationRows =
+      descriptor.kind === `rekey`
+        ? rowsAtLevel
+        : descriptor.level === 1
+          ? [...roots.values()]
+          : [...levels[descriptor.level - 2]!.values()]
+    const destinationIsLive = destinationRows.some(
+      (row) => row.group === descriptor.destination.route,
+    )
+    const currentRouteUsers = rowsAtLevel.filter((row) =>
+      descriptor.kind === `rekey`
+        ? row.group === currentRoute
+        : (row as ChildRow).parentGroup === currentRoute,
+    ).length
+    const retiredOwner = retiredRouteOwners.get(descriptor.destination.route)
+
+    switch (descriptor.destination.strategy) {
+      case `fresh`:
+        if (seenRoutes.has(descriptor.destination.route)) {
+          throw new Error(`fresh route must never have been used`)
+        }
+        break
+      case `restore`:
+        if (destinationIsLive || retiredOwner !== id) {
+          throw new Error(`restore route must have been retired by this row`)
+        }
+        break
+      case `merge`:
+        if (
+          !destinationIsLive ||
+          descriptor.destination.route === currentRoute
+        ) {
+          throw new Error(`merge route must be live and different`)
+        }
+        break
+      case `split`:
+        if (seenRoutes.has(descriptor.destination.route)) {
+          throw new Error(`split destination must be unused`)
+        }
+        if (currentRouteUsers < 2) {
+          throw new Error(`split source route must be shared`)
+        }
+        break
+      case `retired`:
+        if (
+          destinationIsLive ||
+          retiredOwner === undefined ||
+          retiredOwner === id
+        ) {
+          throw new Error(`retired route must have been retired by another row`)
+        }
+        break
+    }
+
+    let step: FullRowBatchStep
+    if (descriptor.level === 0) {
+      const root = roots.get(id)
+      if (!root) throw new Error(`Missing transition root ${id}`)
+      step = {
+        level: 0,
+        changes: [
+          {
+            type: `update`,
+            value: { ...root, group: descriptor.destination.route },
+          },
+        ],
+      }
+    } else {
+      const child = levels[descriptor.level - 1]!.get(id)
+      if (!child) throw new Error(`Missing transition child ${id}`)
+      step = {
+        level: descriptor.level,
+        changes: [
+          {
+            type: `update`,
+            value:
+              descriptor.kind === `rekey`
+                ? { ...child, group: descriptor.destination.route }
+                : {
+                    ...child,
+                    parentGroup: descriptor.destination.route,
+                  },
+          },
+        ],
+      }
+    }
+    transitionStepIndexes.push(steps.length)
+    steps.push(step)
+    applyRouteLifecycleStep(step, roots, levels, seenRoutes, retiredRouteOwners)
+  }
+
+  steps.push(...trailingSteps)
+  return { depth, steps, transitionStepIndexes }
+}
+
+function expectEveryRouteTransitionVisible(
+  scenario: RouteLifecycleScenario,
+): void {
+  for (const stepIndex of scenario.transitionStepIndexes) {
+    const before = relationshipOnly(
+      recomputeFullRowBatchScenario(scenario, stepIndex),
+    )
+    const after = relationshipOnly(
+      recomputeFullRowBatchScenario(scenario, stepIndex + 1),
+    )
+    expect(after).not.toEqual(before)
+  }
+}
+
+const independentTransitionShapes = [
+  `ancestor-descendant`,
+  `descendant-ancestor`,
+  `sibling`,
+  `cross-branch`,
+  `root`,
+] as const
+
+type IndependentTransitionShape = (typeof independentTransitionShapes)[number]
+
+function independentFreshRoutesArbitrary(
+  shape: IndependentTransitionShape,
+): fc.Arbitrary<readonly [number, number]> {
+  const first = fc.integer({ min: 2_100, max: 2_400 })
+  if (shape === `sibling`) {
+    return fc.tuple(first, fc.integer({ min: 2_500, max: 2_800 }))
+  }
+  if (shape === `ancestor-descendant` || shape === `root`) {
+    return first.map((route) => [route, 2_500] as const)
+  }
+  return fc.constant([2_100, 2_500] as const)
+}
+
+function independentTransitionDescriptors(
+  shape: IndependentTransitionShape,
+  branches: readonly [ConnectedBranch, ConnectedBranch],
+  freshRoutes: readonly [number, number],
+): ReadonlyArray<RouteTransitionDescriptor> {
+  switch (shape) {
+    case `ancestor-descendant`:
+      return [
+        {
+          kind: `reparent`,
+          level: 1,
+          row: 0,
+          destination: {
+            strategy: `merge`,
+            route: branches[1].groupBase,
+          },
+        },
+        {
+          kind: `rekey`,
+          level: 2,
+          row: 0,
+          destination: { strategy: `fresh`, route: freshRoutes[0] },
+        },
+      ]
+    case `descendant-ancestor`:
+      return [
+        {
+          kind: `reparent`,
+          level: 2,
+          row: 0,
+          destination: {
+            strategy: `merge`,
+            route: branches[1].groupBase + 1,
+          },
+        },
+        {
+          kind: `reparent`,
+          level: 1,
+          row: 0,
+          destination: {
+            strategy: `merge`,
+            route: branches[1].groupBase,
+          },
+        },
+      ]
+    case `sibling`:
+      return [
+        {
+          kind: `rekey`,
+          level: 2,
+          row: 0,
+          destination: { strategy: `fresh`, route: freshRoutes[0] },
+        },
+        {
+          kind: `rekey`,
+          level: 2,
+          row: 1,
+          destination: { strategy: `fresh`, route: freshRoutes[1] },
+        },
+      ]
+    case `cross-branch`:
+      return [
+        {
+          kind: `reparent`,
+          level: 2,
+          row: 0,
+          destination: {
+            strategy: `merge`,
+            route: branches[1].groupBase + 1,
+          },
+        },
+        {
+          kind: `reparent`,
+          level: 2,
+          row: 1,
+          destination: {
+            strategy: `merge`,
+            route: branches[0].groupBase + 1,
+          },
+        },
+      ]
+    case `root`:
+      return [
+        {
+          kind: `rekey`,
+          level: 0,
+          row: 0,
+          destination: { strategy: `fresh`, route: freshRoutes[0] },
+        },
+        {
+          kind: `reparent`,
+          level: 1,
+          row: 1,
+          destination: { strategy: `merge`, route: freshRoutes[0] },
+        },
+      ]
+  }
+}
+
+function independentTransitionScenarioArbitrary(
+  shape: IndependentTransitionShape,
+): fc.Arbitrary<RouteLifecycleScenario> {
+  return fc
+    .record({
+      ...generatedBranchArbitraries,
+      freshRoutes: independentFreshRoutesArbitrary(shape),
+    })
+    .map(({ freshRoutes, ...branchOptions }) => {
+      const branches = createGeneratedBranches(branchOptions)
+      return createRouteLifecycleScenario({
+        depth: 3,
+        branches,
+        descriptors: independentTransitionDescriptors(
+          shape,
+          branches,
+          freshRoutes,
+        ),
+      })
+    })
+}
+
+const destinationHistories = [
+  `fresh`,
+  `restore`,
+  `merge-split`,
+  `retired`,
+] as const
+
+type DestinationHistory = (typeof destinationHistories)[number]
+
+function destinationHistoryDescriptors(
+  history: DestinationHistory,
+  branches: readonly [ConnectedBranch, ConnectedBranch],
+  freshRoute: number,
+): ReadonlyArray<RouteTransitionDescriptor> {
+  const originalRoute = branches[0].groupBase + 2
+  const sharedRoute = branches[1].groupBase + 2
+  const first: RouteTransitionDescriptor = {
+    kind: `rekey`,
+    level: 2,
+    row: 0,
+    destination: { strategy: `fresh`, route: freshRoute },
+  }
+
+  switch (history) {
+    case `fresh`:
+      return [first]
+    case `restore`:
+      return [
+        first,
+        {
+          ...first,
+          destination: { strategy: `restore`, route: originalRoute },
+        },
+      ]
+    case `merge-split`:
+      return [
+        {
+          ...first,
+          destination: { strategy: `merge`, route: sharedRoute },
+        },
+        {
+          ...first,
+          destination: { strategy: `split`, route: freshRoute },
+        },
+      ]
+    case `retired`:
+      return [
+        first,
+        {
+          kind: `rekey`,
+          level: 2,
+          row: 1,
+          destination: { strategy: `retired`, route: originalRoute },
+        },
+      ]
+  }
+}
+
+function destinationHistoryScenarioArbitrary(
+  history: DestinationHistory,
+): fc.Arbitrary<RouteLifecycleScenario> {
+  return fc
+    .record({
+      ...generatedBranchArbitraries,
+      freshRoute: fc.integer({ min: 2_100, max: 2_400 }),
+    })
+    .map(({ freshRoute, ...branchOptions }) => {
+      const branches = createGeneratedBranches(branchOptions)
+      return createRouteLifecycleScenario({
+        depth: 3,
+        branches,
+        descriptors: destinationHistoryDescriptors(
+          history,
+          branches,
+          freshRoute,
+        ),
+      })
+    })
+}
+
+function relationshipNodeValue(value: unknown, id: number): unknown {
+  return findRelationshipNode(value, id)?.value
+}
+
+function classifyMissingOrStaleChild(
+  { actual, expected }: AssertionDifference,
+  parentId: number,
+  childId: number,
+  expectedValue: number,
+): boolean {
+  return (
+    hasDirectChild(expected, parentId, childId) &&
+    relationshipNodeValue(expected, childId) === expectedValue &&
+    (!hasDirectChild(actual, parentId, childId) ||
+      relationshipNodeValue(actual, childId) !== expectedValue)
+  )
+}
+
+function createInitiallySharedRoutePrefix(
+  depth: IncludeDepth,
+  parentLevel: 0 | 1 | 2,
+  branches: readonly [ConnectedBranch, ConnectedBranch],
+  enteringRow: 0 | 1 = 1,
+): Array<FullRowBatchStep> {
+  const enteringId = rowAt(branches, enteringRow, parentLevel)
+  const sharedRoute = branches[otherBranch(enteringRow)].groupBase + parentLevel
+  return createConnectedBatchBranches(depth, branches).map((step) => {
+    if (step.level !== parentLevel) return step
+
+    if (step.level === 0) {
+      return {
+        level: 0,
+        changes: step.changes.map((change) =>
+          change.value.id === enteringId
+            ? { ...change, value: { ...change.value, group: sharedRoute } }
+            : change,
+        ),
+      }
+    }
+
+    return {
+      level: step.level,
+      changes: step.changes.map((change) =>
+        change.value.id === enteringId
+          ? { ...change, value: { ...change.value, group: sharedRoute } }
+          : change,
+      ),
+    }
+  })
+}
+
+function createMergeIntoSharedRouteScenarios(
+  parentLevel: 0 | 1 | 2,
+  enteringRow: 0 | 1,
+): ClassifiedHistoryScenario {
+  const depth = (parentLevel + 1) as IncludeDepth
+  const branches = transitionHistoryBranches
+  const childLevel = depth
+  const existingRow = otherBranch(enteringRow)
+  const sharedRoute = branches[existingRow].groupBase + parentLevel
+  const enteringParentId = rowAt(branches, enteringRow, parentLevel)
+  const childId = rowAt(branches, existingRow, childLevel)
+  const candidate = createRouteLifecycleScenario({
+    depth,
+    branches,
+    descriptors: [
+      {
+        kind: `rekey`,
+        level: parentLevel,
+        row: enteringRow,
+        destination: { strategy: `merge`, route: sharedRoute },
+      },
+    ],
+  })
+  expectEveryRouteTransitionVisible(candidate)
+
+  return {
+    control: {
+      depth,
+      steps: createInitiallySharedRoutePrefix(
+        depth,
+        parentLevel,
+        branches,
+        enteringRow,
+      ),
+    },
+    candidate,
+    candidateCheckpoint: candidate.steps.length,
+    classify: (difference) =>
+      classifyMissingSharedRouteSnapshot(
+        difference,
+        enteringParentId,
+        rowAt(branches, existingRow, parentLevel),
+        childId,
+      ),
+  }
+}
+
+function createSharedRouteLastSubscriberScenario(
+  parentLevel: 0 | 1 | 2,
+): FullRowBatchScenario {
+  const depth = (parentLevel + 1) as IncludeDepth
+  const branches = transitionHistoryBranches
+  const childLevel = depth
+  const sharedRoute = branches[0].groupBase + parentLevel
+  const childId = rowAt(branches, 0, childLevel)
+  const child = {
+    ...batchChild(childId, sharedRoute, childId, 0),
+    group: branches[0].groupBase + childLevel,
+  }
+  const descriptors: ReadonlyArray<RouteTransitionDescriptor> = [
+    {
+      kind: `rekey`,
+      level: parentLevel,
+      row: 0,
+      destination: { strategy: `split`, route: 2_100 + parentLevel },
+    },
+    {
+      kind: `rekey`,
+      level: parentLevel,
+      row: 1,
+      destination: { strategy: `fresh`, route: 2_200 + parentLevel },
+    },
+  ]
+  const scenario = createRouteLifecycleScenario({
+    depth,
+    branches,
+    descriptors,
+    prefixSteps: createInitiallySharedRoutePrefix(depth, parentLevel, branches),
+    trailingSteps: [
+      {
+        level: childLevel,
+        changes: [
+          { type: `update`, value: { ...child, value: child.value + 1 } },
+        ],
+      },
+    ],
+  })
+  expectEveryRouteTransitionVisible(scenario)
+  return scenario
+}
+
+function createSnapshotOnResubscribeScenarios(
+  parentLevel: 0 | 1 | 2,
+): ClassifiedHistoryScenario {
+  const depth = (parentLevel + 1) as IncludeDepth
+  const branches = transitionHistoryBranches
+  const childLevel = depth
+  const parentId = rowAt(branches, 0, parentLevel)
+  const originalRoute = branches[0].groupBase + parentLevel
+  const childId = rowAt(branches, 0, childLevel)
+  const child = {
+    ...batchChild(childId, originalRoute, childId, 0),
+    group: branches[0].groupBase + childLevel,
+  }
+  const updatedChild = { ...child, value: child.value + 1 }
+  const prefix = createConnectedBatchBranches(depth, branches)
+  const childUpdate: FullRowBatchStep = {
+    level: childLevel,
+    changes: [{ type: `update`, value: updatedChild }],
+  }
+  const candidate = createRouteLifecycleScenario({
+    depth,
+    branches,
+    descriptors: [
+      {
+        kind: `rekey`,
+        level: parentLevel,
+        row: 0,
+        destination: { strategy: `fresh`, route: 2_300 + parentLevel },
+      },
+      {
+        kind: `rekey`,
+        level: parentLevel,
+        row: 0,
+        destination: { strategy: `restore`, route: originalRoute },
+        stepsBefore: [childUpdate],
+      },
+    ],
+  })
+  expectEveryRouteTransitionVisible(candidate)
+  const control: FullRowBatchScenario = {
+    depth,
+    steps: [...prefix, childUpdate],
+  }
+
+  return {
+    control,
+    candidate,
+    candidateCheckpoint: candidate.steps.length,
+    classify: (difference) =>
+      classifyMissingOrStaleChild(
+        difference,
+        parentId,
+        childId,
+        updatedChild.value,
+      ),
+  }
+}
+
 type ClassifiedHistoryScenario = {
   control: FullRowBatchScenario
   greenVariants?: ReadonlyArray<FullRowBatchScenario>
@@ -2783,6 +3442,204 @@ const {
 })
 
 describe(`includes recompute oracle`, () => {
+  for (const [shapeIndex, shape] of independentTransitionShapes.entries()) {
+    fcTest.prop([independentTransitionScenarioArbitrary(shape)], {
+      numRuns: 4,
+      seed: 1734 + shapeIndex,
+    })(
+      `matches recomputation for independent ${shape} relationship targets`,
+      async (scenario) => {
+        expectEveryRouteTransitionVisible(scenario)
+        await expectFullRowBatchScenarioMatches(scenario)
+      },
+    )
+  }
+
+  for (const [historyIndex, history] of destinationHistories.entries()) {
+    fcTest.prop([destinationHistoryScenarioArbitrary(history)], {
+      numRuns: 4,
+      seed: 1740 + historyIndex,
+    })(
+      `matches recomputation for the ${history} route destination history`,
+      async (scenario) => {
+        expectEveryRouteTransitionVisible(scenario)
+        await expectFullRowBatchScenarioMatches(scenario)
+      },
+    )
+  }
+
+  for (const parentLevel of [0, 1, 2] as const) {
+    for (const enteringRow of [0, 1] as const) {
+      const expectsFailure = parentLevel === 0
+      fcTest(
+        expectsFailure
+          ? `discovered trace: root ${enteringRow} entering a live shared route receives its snapshot`
+          : `matches recomputation when level-${parentLevel} row ${enteringRow} enters a live shared route`,
+        () =>
+          (expectsFailure
+            ? expectClassifiedHistoryFailure
+            : expectClassifiedHistoryMatches)(
+            createMergeIntoSharedRouteScenarios(parentLevel, enteringRow),
+          ),
+      )
+    }
+
+    fcTest(
+      `matches recomputation when the last level-${parentLevel} shared-route subscriber leaves`,
+      () =>
+        expectFullRowBatchScenarioMatches(
+          createSharedRouteLastSubscriberScenario(parentLevel),
+        ),
+    )
+
+    fcTest(
+      `matches recomputation after a level-${parentLevel} route resubscribes`,
+      () =>
+        expectClassifiedHistoryMatches(
+          createSnapshotOnResubscribeScenarios(parentLevel),
+        ),
+    )
+  }
+
+  fcTest(`rejects invalid route destination strategies`, () => {
+    const branches = transitionHistoryBranches
+    const ownRoute = branches[0].groupBase + 2
+    const otherRoute = branches[1].groupBase + 2
+    const freshRoute = 2_100
+    const invalidCases: ReadonlyArray<{
+      descriptors: ReadonlyArray<RouteTransitionDescriptor>
+      message: RegExp
+    }> = [
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `fresh`, route: otherRoute },
+          },
+        ],
+        message: /fresh route must never have been used/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `restore`, route: ownRoute },
+          },
+        ],
+        message: /restore route must have been retired by this row/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `fresh`, route: freshRoute },
+          },
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 1,
+            destination: { strategy: `restore`, route: ownRoute },
+          },
+        ],
+        message: /restore route must have been retired by this row/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `merge`, route: freshRoute },
+          },
+        ],
+        message: /merge route must be live and different/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `merge`, route: ownRoute },
+          },
+        ],
+        message: /merge route must be live and different/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `split`, route: freshRoute },
+          },
+        ],
+        message: /split source route must be shared/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `merge`, route: otherRoute },
+          },
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `split`, route: ownRoute },
+          },
+        ],
+        message: /split destination must be unused/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `retired`, route: otherRoute },
+          },
+        ],
+        message: /retired route must have been retired by another row/,
+      },
+      {
+        descriptors: [
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `fresh`, route: freshRoute },
+          },
+          {
+            kind: `rekey`,
+            level: 2,
+            row: 0,
+            destination: { strategy: `retired`, route: ownRoute },
+          },
+        ],
+        message: /retired route must have been retired by another row/,
+      },
+    ]
+
+    for (const invalidCase of invalidCases) {
+      expect(() =>
+        createRouteLifecycleScenario({
+          depth: 3,
+          branches,
+          descriptors: invalidCase.descriptors,
+        }),
+      ).toThrow(invalidCase.message)
+    }
+  })
+
   fcTest(`rejects overlapping visible relationship keys`, () => {
     const base = {
       depth: 4,


### PR DESCRIPTION
This extends the includes recompute oracle with validated route-lifecycle histories across topology, destination reuse, unsubscribe, and resubscribe cases. It also pins two root-only bugs: entering an already-live shared route can miss its existing ordered snapshot, while restoring a retired shared route can leak its updated snapshot to a root that remains departed.

## Approach

The scenario builder uses explicit transition descriptors. Rekeys may target `fresh`, `restore`, `merge`, `split`, or `retired` routes; reparents are restricted to moving a contribution into a different live route. The builder replays model state while assembling each trace and validates every lifecycle label against live routes, seen routes, retired owners, and current subscribers.

Two bounded FastCheck matrices cover:

- **Transition topology:** ancestor→descendant, descendant→ancestor, true siblings under one parent, cross-branch, and root transitions.
- **Destination lifecycle:** fresh, restore, merge→split, and retired-route reuse.

Every transition must change the recomputed relationship projection. Negative tests also reject mislabeled descriptors, including subscriber-lifecycle labels on reparent transitions.

## Newly classified failure

The merge-into-live-route matrix tests both entering rows at parent levels 0, 1, and 2. Only roots currently fail; nested subscribers receive the existing snapshot and serve as green controls.

The expected-failure classifier compares the complete actual result with recomputation minus exactly the missing subtree. It therefore rejects unrelated scalar, ordering, descendant, or sibling corruption. A separate ordered two-child case proves the root misses the entire route snapshot, not merely one child.

## Lifecycle controls

- The last subscriber can leave a shared route without corrupting later child updates at parent levels 0–2.
- A row can retire a route, allow its child to update while unsubscribed, and restore the current snapshot at parent levels 0–2. Root restoration is an exact expected failure because it also publishes that snapshot to the departed root; nested levels are green controls.
- The topology fixtures prove that sibling targets share a parent and that the descendant remains attached before a descendant→ancestor sequence moves its ancestor.

## Key invariants

- Descriptor labels match the route state at the transition.
- Subscriber lifecycle strategies cannot be applied to contribution-only reparent transitions.
- Generated transitions visibly change the recomputed relationship tree.
- Expected failures accept only the exact missing-snapshot shape at the exact checkpoint.
- Source rows and the recompute model remain independent.
- Fixed seeds and bounded values keep failures reproducible and CI cost small.

## Non-goals

- Fixing the newly found runtime bug.
- Changing query execution, subscription ownership, or publication code.
- Expanding destination histories across every parent level or adding the broader batch-shape matrix in this PR.

## Trade-offs

The descriptor builder tracks more model metadata than hand-written traces, but it makes lifecycle labels enforceable and exposes invalid matrix cells early. The property runs stay small because the explicit matrices provide structural coverage while fixed seeds preserve reproducibility.

## Verification

```bash
pnpm exec vitest run packages/db/tests/query/includes-oracle.property.test.ts --maxWorkers=2
pnpm exec tsc --noEmit -p packages/db/tsconfig.json
pnpm exec eslint packages/db/tests/query/includes-oracle.property.test.ts
pnpm exec prettier --check packages/db/tests/query/includes-oracle.property.test.ts
git diff --check origin/main...HEAD
```

The merged targeted oracle suite passes all 136 tests, including exact expected-failure classifiers.

## Files changed

- `packages/db/tests/query/includes-oracle.property.test.ts` — adds route descriptors and validation, topology and lifecycle matrices, exact snapshot-failure classifiers, and adjacent green controls.

---

Refs #1658


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for relationship queries and shared-route behavior.
  - Added scenarios for route creation, merging, splitting, retirement, reuse, resubscription, and subscriber departure.
  - Added validation for topology changes, ordering, materialization, transition visibility, and invalid strategies.
  - Added regression checks to detect corrupted or unexpected query results and verify route lifecycle consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->