### PR TITLE
test(db): add includes work and shape oracles

### DIFF
--- a/packages/db/tests/query/includes-work-counter-oracle.test.ts
+++ b/packages/db/tests/query/includes-work-counter-oracle.test.ts
@@ -1,5 +1,5 @@
 import { fc, test as fcTest } from '@fast-check/vitest'
-import { describe, expect } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { createCollection } from '../../src/collection/index.js'
 import { BTreeIndex } from '../../src/indexes/btree-index.js'
 import { localOnlyCollectionOptions } from '../../src/local-only.js'
@@ -50,6 +50,10 @@ type SourceWork = {
   links: WorkCount
 }
 
+type LinkObservation =
+  | { id: string; text: string }
+  | { id: string; targetId: string }
+
 type WorkObservation = {
   result: Array<{
     id: string
@@ -57,11 +61,23 @@ type WorkObservation = {
       id: string
       groups: Array<{
         id: string
-        links: Array<{ id: string; text?: string; targetId?: string }>
+        links: Array<LinkObservation>
       }>
     }>
   }>
   sourceWork: SourceWork
+}
+
+async function runCleanups(
+  cleanups: ReadonlyArray<() => void | Promise<void>>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    cleanups.map(async (cleanup) => cleanup()),
+  )
+  const firstRejection = results.find(
+    (result): result is PromiseRejectedResult => result.status === `rejected`,
+  )
+  if (firstRejection !== undefined) throw firstRejection.reason
 }
 
 const noFillers: FillerCounts = {
@@ -170,6 +186,14 @@ function createFixtureRows(filler: FillerCounts): SourceRows {
   }
 }
 
+function observeLink(link: LinkObservation): LinkObservation {
+  if (`text` in link) return { id: link.id, text: link.text }
+  if (`targetId` in link) return { id: link.id, targetId: link.targetId }
+
+  const exhaustive: never = link
+  return exhaustive
+}
+
 async function observeWork({
   filler,
   joinTargets,
@@ -268,11 +292,7 @@ async function observeWork({
             id: meaning.id,
             groups: meaning.groups.map((group) => ({
               id: group.id,
-              links: group.links.map((link) =>
-                `text` in link
-                  ? { id: link.id, text: link.text }
-                  : { id: link.id, targetId: link.targetId },
-              ),
+              links: group.links.map(observeLink),
             })),
           })),
         },
@@ -285,8 +305,10 @@ async function observeWork({
       },
     }
   } finally {
-    await cleanupLive?.()
-    await Promise.all(Object.values(sources).map((source) => source.cleanup()))
+    await runCleanups([
+      async () => cleanupLive?.(),
+      ...Object.values(sources).map((source) => async () => source.cleanup()),
+    ])
   }
 }
 
@@ -376,62 +398,77 @@ const joinFreeBaselineWork: SourceWork = {
   links: { delivered: 2, examined: 2 },
 }
 
+let joinedBaselineObservation: WorkObservation
+let joinFreeBaselineObservation: WorkObservation
+
+async function expectKnownCorrelatedJoinDefect(
+  fillerCount: number,
+): Promise<void> {
+  const baseline = joinedBaselineObservation
+  const scaled = await observeWork({
+    filler: {
+      terms: 0,
+      meanings: 0,
+      groups: 0,
+      links: fillerCount,
+    },
+    joinTargets: true,
+  })
+  expect(baseline.result).toEqual(expectedResult({ joinTargets: true }))
+  expect(scaled.result).toEqual(baseline.result)
+  expect(baseline.sourceWork).toEqual(joinedBaselineWork)
+
+  const knownLinkWork = {
+    delivered: baseline.sourceWork.links.delivered + fillerCount,
+    // Once irrelevant rows exist, the defective route scans the whole
+    // collection and then reads the two selected rows through the index.
+    examined: baseline.sourceWork.links.examined + fillerCount + 2,
+  }
+  const knownScaledWork: SourceWork = {
+    // The full left scan also activates one extra indexed target route.
+    terms: { delivered: 4, examined: 4 },
+    meanings: baseline.sourceWork.meanings,
+    groups: baseline.sourceWork.groups,
+    links: knownLinkWork,
+  }
+  await expectAssertionFailure(assertEqualSourceWork, {
+    checkpoint: 1,
+    classify: ({ actual, expected }) =>
+      isExactSourceWork(actual, knownScaledWork) &&
+      isExactSourceWork(expected, baseline.sourceWork),
+  })(scaled.sourceWork, baseline.sourceWork)
+}
+
 describe(`includes deterministic work-counter oracle`, () => {
-  fcTest.prop([fc.integer({ min: 4, max: 24 })], {
+  beforeAll(async () => {
+    const [joinedBaseline, joinFreeBaseline] = await Promise.all([
+      observeWork({ filler: noFillers, joinTargets: true }),
+      observeWork({ filler: noFillers, joinTargets: false }),
+    ])
+    joinedBaselineObservation = joinedBaseline
+    joinFreeBaselineObservation = joinFreeBaseline
+  })
+
+  it.each([1, 2, 3])(
+    `pins the #1709 defect formula at the small filler boundary (%i)`,
+    expectKnownCorrelatedJoinDefect,
+  )
+
+  fcTest.prop([fc.integer({ min: 1, max: 24 })], {
     numRuns: 6,
     seed: 1709,
   })(
     `known work defect: a join defeats correlated source pushdown (#1709)`,
-    async (fillerCount) => {
-      const baseline = await observeWork({
-        filler: noFillers,
-        joinTargets: true,
-      })
-      const scaled = await observeWork({
-        filler: {
-          terms: 0,
-          meanings: 0,
-          groups: 0,
-          links: fillerCount,
-        },
-        joinTargets: true,
-      })
-      expect(baseline.result).toEqual(expectedResult({ joinTargets: true }))
-      expect(scaled.result).toEqual(baseline.result)
-      expect(baseline.sourceWork).toEqual(joinedBaselineWork)
-
-      const knownLinkWork = {
-        delivered: baseline.sourceWork.links.delivered + fillerCount,
-        // Once irrelevant rows exist, the defective route scans the whole
-        // collection and then reads the two selected rows through the index.
-        examined: baseline.sourceWork.links.examined + fillerCount + 2,
-      }
-      const knownScaledWork: SourceWork = {
-        // The full left scan also activates one extra indexed target route.
-        terms: { delivered: 4, examined: 4 },
-        meanings: baseline.sourceWork.meanings,
-        groups: baseline.sourceWork.groups,
-        links: knownLinkWork,
-      }
-      await expectAssertionFailure(assertEqualSourceWork, {
-        checkpoint: 1,
-        classify: ({ actual, expected }) =>
-          isExactSourceWork(actual, knownScaledWork) &&
-          isExactSourceWork(expected, baseline.sourceWork),
-      })(scaled.sourceWork, baseline.sourceWork)
-    },
+    expectKnownCorrelatedJoinDefect,
   )
 
-  fcTest.prop([fc.integer({ min: 4, max: 24 })], {
+  fcTest.prop([fc.integer({ min: 1, max: 24 })], {
     numRuns: 6,
     seed: 170_900,
   })(
     `indexed join-target growth keeps source work flat (#1709 direction control)`,
     async (fillerCount) => {
-      const baseline = await observeWork({
-        filler: noFillers,
-        joinTargets: true,
-      })
+      const baseline = joinedBaselineObservation
       const scaled = await observeWork({
         filler: {
           terms: fillerCount,
@@ -449,16 +486,13 @@ describe(`includes deterministic work-counter oracle`, () => {
     },
   )
 
-  fcTest.prop([fc.integer({ min: 4, max: 24 })], {
+  fcTest.prop([fc.integer({ min: 1, max: 24 })], {
     numRuns: 6,
     seed: 17_090,
   })(
     `join-free correlated includes keep source work flat (#1709 control)`,
     async (fillerCount) => {
-      const baseline = await observeWork({
-        filler: noFillers,
-        joinTargets: false,
-      })
+      const baseline = joinFreeBaselineObservation
       const scaled = await observeWork({
         filler: {
           terms: fillerCount,

--- a/packages/db/tests/query/includes-work-counter-oracle.test.ts
+++ b/packages/db/tests/query/includes-work-counter-oracle.test.ts
@@ -1,0 +1,478 @@
+import { fc, test as fcTest } from '@fast-check/vitest'
+import { describe, expect } from 'vitest'
+import { createCollection } from '../../src/collection/index.js'
+import { BTreeIndex } from '../../src/indexes/btree-index.js'
+import { localOnlyCollectionOptions } from '../../src/local-only.js'
+import {
+  createLiveQueryCollection,
+  eq,
+  materialize,
+} from '../../src/query/index.js'
+import { expectAssertionFailure } from '../expected-failure.js'
+import { TraceAssertionError } from '../trace-runner.js'
+import type { Collection } from '../../src/collection/index.js'
+
+let nextCollectionId = 0
+
+type TermRow = { id: string; text: string }
+type MeaningRow = { id: string; termId: string }
+type GroupRow = { id: string; meaningId: string }
+type LinkRow = { id: string; groupId: string; targetId: string }
+
+type SourceRows = {
+  terms: Array<TermRow>
+  meanings: Array<MeaningRow>
+  groups: Array<GroupRow>
+  links: Array<LinkRow>
+}
+
+type FillerCounts = {
+  terms: number
+  meanings: number
+  groups: number
+  links: number
+}
+
+type WorkScenario = {
+  filler: FillerCounts
+  joinTargets: boolean
+}
+
+type WorkCount = {
+  delivered: number
+  examined: number
+}
+
+type SourceWork = {
+  terms: WorkCount
+  meanings: WorkCount
+  groups: WorkCount
+  links: WorkCount
+}
+
+type WorkObservation = {
+  result: Array<{
+    id: string
+    meanings: Array<{
+      id: string
+      groups: Array<{
+        id: string
+        links: Array<{ id: string; text?: string; targetId?: string }>
+      }>
+    }>
+  }>
+  sourceWork: SourceWork
+}
+
+const noFillers: FillerCounts = {
+  terms: 0,
+  meanings: 0,
+  groups: 0,
+  links: 0,
+}
+
+function createSourceCollection<T extends { id: string }>(
+  name: string,
+  initialData: Array<T>,
+) {
+  return createCollection(
+    localOnlyCollectionOptions<T>({
+      id: `${name}-${nextCollectionId++}`,
+      getKey: (row) => row.id,
+      initialData,
+    }),
+  )
+}
+
+// Count both sides of the source boundary named in #1709's profile. Delivered
+// rows show what enters the dataflow graph. entries() visits capture scans and
+// get() calls capture keyed reads, so examined work cannot hide behind a filter.
+function countSourceWork<T extends object>(collection: Collection<T>) {
+  let deliveredRows = 0
+  let examinedRows = 0
+  let readingEntry = false
+  const originalSubscribeChanges = collection.subscribeChanges.bind(collection)
+  const originalEntries = collection.entries.bind(collection)
+  const originalGet = collection.get.bind(collection)
+
+  collection.subscribeChanges = (callback, options) => {
+    return originalSubscribeChanges((changes) => {
+      deliveredRows += changes.length
+      callback(changes)
+    }, options)
+  }
+
+  collection.get = (key) => {
+    if (!readingEntry) examinedRows++
+    return originalGet(key)
+  }
+
+  collection.entries = function* () {
+    const entries = originalEntries()
+    const readNext = () => {
+      readingEntry = true
+      try {
+        return entries.next()
+      } finally {
+        readingEntry = false
+      }
+    }
+
+    for (let next = readNext(); !next.done; next = readNext()) {
+      examinedRows++
+      yield next.value
+    }
+  }
+
+  return (): WorkCount => ({ delivered: deliveredRows, examined: examinedRows })
+}
+
+function createFixtureRows(filler: FillerCounts): SourceRows {
+  return {
+    terms: [
+      { id: `term-0`, text: `selected term` },
+      { id: `term-1`, text: `first target` },
+      { id: `term-2`, text: `second target` },
+      ...Array.from({ length: filler.terms }, (_, index) => ({
+        id: `term-filler-${index}`,
+        text: `irrelevant target ${index}`,
+      })),
+    ],
+    meanings: [
+      { id: `meaning-0`, termId: `term-0` },
+      ...Array.from({ length: filler.meanings }, (_, index) => ({
+        id: `meaning-filler-${index}`,
+        termId: `term-never-selected`,
+      })),
+    ],
+    groups: [
+      { id: `group-0`, meaningId: `meaning-0` },
+      ...Array.from({ length: filler.groups }, (_, index) => ({
+        id: `group-filler-${index}`,
+        meaningId: `meaning-never-selected`,
+      })),
+    ],
+    links: [
+      // Keep filler links on one existing target key. Only the left-side input
+      // grows; the term-filler control probes right-side input growth separately.
+      { id: `link-0`, groupId: `group-0`, targetId: `term-1` },
+      {
+        id: `link-1`,
+        groupId: `group-0`,
+        targetId: `term-2`,
+      },
+      ...Array.from({ length: filler.links }, (_, index) => ({
+        id: `link-filler-${index}`,
+        groupId: `group-never-selected`,
+        targetId: `term-1`,
+      })),
+    ],
+  }
+}
+
+async function observeWork({
+  filler,
+  joinTargets,
+}: WorkScenario): Promise<WorkObservation> {
+  const rows = createFixtureRows(filler)
+  const sources = {
+    terms: createSourceCollection(`work-terms`, rows.terms),
+    meanings: createSourceCollection(`work-meanings`, rows.meanings),
+    groups: createSourceCollection(`work-groups`, rows.groups),
+    links: createSourceCollection(`work-links`, rows.links),
+  }
+  let cleanupLive: (() => Promise<void>) | undefined
+
+  try {
+    await Promise.all(Object.values(sources).map((source) => source.preload()))
+
+    // Match #1709's reproduction: load first, then add a B-tree index on each
+    // correlation and join column before constructing the live query.
+    sources.terms.createIndex((row) => row.id, { indexType: BTreeIndex })
+    sources.meanings.createIndex((row) => row.termId, {
+      indexType: BTreeIndex,
+    })
+    sources.groups.createIndex((row) => row.meaningId, {
+      indexType: BTreeIndex,
+    })
+    sources.links.createIndex((row) => row.groupId, { indexType: BTreeIndex })
+    sources.links.createIndex((row) => row.targetId, {
+      indexType: BTreeIndex,
+    })
+
+    const counters = {
+      terms: countSourceWork(sources.terms),
+      meanings: countSourceWork(sources.meanings),
+      groups: countSourceWork(sources.groups),
+      links: countSourceWork(sources.links),
+    }
+
+    const live = createLiveQueryCollection((q) =>
+      q
+        .from({ term: sources.terms })
+        .where(({ term }) => eq(term.id, `term-0`))
+        .select(({ term }) => ({
+          id: term.id,
+          meanings: materialize(
+            q
+              .from({ meaning: sources.meanings })
+              .where(({ meaning }) => eq(meaning.termId, term.id))
+              .select(({ meaning }) => ({
+                id: meaning.id,
+                groups: materialize(
+                  q
+                    .from({ group: sources.groups })
+                    .where(({ group }) => eq(group.meaningId, meaning.id))
+                    .select(({ group }) => {
+                      const selectedLinks = q
+                        .from({ link: sources.links })
+                        .where(({ link }) => eq(link.groupId, group.id))
+
+                      return {
+                        id: group.id,
+                        links: joinTargets
+                          ? materialize(
+                              selectedLinks
+                                .innerJoin(
+                                  { target: sources.terms },
+                                  ({ link, target }) =>
+                                    eq(link.targetId, target.id),
+                                )
+                                .select(({ link, target }) => ({
+                                  id: link.id,
+                                  text: target.text,
+                                })),
+                            )
+                          : materialize(
+                              selectedLinks.select(({ link }) => ({
+                                id: link.id,
+                                targetId: link.targetId,
+                              })),
+                            ),
+                      }
+                    }),
+                ),
+              })),
+          ),
+        })),
+    )
+    cleanupLive = () => live.cleanup()
+
+    await live.preload()
+    const root = live.toArray[0]!
+    return {
+      result: [
+        {
+          id: root.id,
+          meanings: root.meanings.map((meaning) => ({
+            id: meaning.id,
+            groups: meaning.groups.map((group) => ({
+              id: group.id,
+              links: group.links.map((link) =>
+                `text` in link
+                  ? { id: link.id, text: link.text }
+                  : { id: link.id, targetId: link.targetId },
+              ),
+            })),
+          })),
+        },
+      ],
+      sourceWork: {
+        terms: counters.terms(),
+        meanings: counters.meanings(),
+        groups: counters.groups(),
+        links: counters.links(),
+      },
+    }
+  } finally {
+    await cleanupLive?.()
+    await Promise.all(Object.values(sources).map((source) => source.cleanup()))
+  }
+}
+
+function expectedResult({
+  joinTargets,
+}: Pick<WorkScenario, 'joinTargets'>): WorkObservation[`result`] {
+  return [
+    {
+      id: `term-0`,
+      meanings: [
+        {
+          id: `meaning-0`,
+          groups: [
+            {
+              id: `group-0`,
+              links: [
+                joinTargets
+                  ? { id: `link-0`, text: `first target` }
+                  : { id: `link-0`, targetId: `term-1` },
+                joinTargets
+                  ? {
+                      id: `link-1`,
+                      text: `second target`,
+                    }
+                  : {
+                      id: `link-1`,
+                      targetId: `term-2`,
+                    },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]
+}
+
+function assertEqualSourceWork(
+  actual: SourceWork,
+  expected: SourceWork,
+): Promise<void> {
+  try {
+    expect(actual).toEqual(expected)
+    return Promise.resolve()
+  } catch (error) {
+    return Promise.reject(new TraceAssertionError(1, error))
+  }
+}
+
+function isExactWorkCount(value: unknown, expected: WorkCount): boolean {
+  return (
+    typeof value === `object` &&
+    value !== null &&
+    `delivered` in value &&
+    value.delivered === expected.delivered &&
+    `examined` in value &&
+    value.examined === expected.examined
+  )
+}
+
+function isExactSourceWork(value: unknown, expected: SourceWork): boolean {
+  return (
+    typeof value === `object` &&
+    value !== null &&
+    `terms` in value &&
+    isExactWorkCount(value.terms, expected.terms) &&
+    `meanings` in value &&
+    isExactWorkCount(value.meanings, expected.meanings) &&
+    `groups` in value &&
+    isExactWorkCount(value.groups, expected.groups) &&
+    `links` in value &&
+    isExactWorkCount(value.links, expected.links)
+  )
+}
+
+const joinedBaselineWork: SourceWork = {
+  terms: { delivered: 3, examined: 3 },
+  meanings: { delivered: 1, examined: 1 },
+  groups: { delivered: 1, examined: 1 },
+  links: { delivered: 2, examined: 2 },
+}
+
+const joinFreeBaselineWork: SourceWork = {
+  terms: { delivered: 1, examined: 1 },
+  meanings: { delivered: 1, examined: 1 },
+  groups: { delivered: 1, examined: 1 },
+  links: { delivered: 2, examined: 2 },
+}
+
+describe(`includes deterministic work-counter oracle`, () => {
+  fcTest.prop([fc.integer({ min: 4, max: 24 })], {
+    numRuns: 6,
+    seed: 1709,
+  })(
+    `known work defect: a join defeats correlated source pushdown (#1709)`,
+    async (fillerCount) => {
+      const baseline = await observeWork({
+        filler: noFillers,
+        joinTargets: true,
+      })
+      const scaled = await observeWork({
+        filler: {
+          terms: 0,
+          meanings: 0,
+          groups: 0,
+          links: fillerCount,
+        },
+        joinTargets: true,
+      })
+      expect(baseline.result).toEqual(expectedResult({ joinTargets: true }))
+      expect(scaled.result).toEqual(baseline.result)
+      expect(baseline.sourceWork).toEqual(joinedBaselineWork)
+
+      const knownLinkWork = {
+        delivered: baseline.sourceWork.links.delivered + fillerCount,
+        // Once irrelevant rows exist, the defective route scans the whole
+        // collection and then reads the two selected rows through the index.
+        examined: baseline.sourceWork.links.examined + fillerCount + 2,
+      }
+      const knownScaledWork: SourceWork = {
+        // The full left scan also activates one extra indexed target route.
+        terms: { delivered: 4, examined: 4 },
+        meanings: baseline.sourceWork.meanings,
+        groups: baseline.sourceWork.groups,
+        links: knownLinkWork,
+      }
+      await expectAssertionFailure(assertEqualSourceWork, {
+        checkpoint: 1,
+        classify: ({ actual, expected }) =>
+          isExactSourceWork(actual, knownScaledWork) &&
+          isExactSourceWork(expected, baseline.sourceWork),
+      })(scaled.sourceWork, baseline.sourceWork)
+    },
+  )
+
+  fcTest.prop([fc.integer({ min: 4, max: 24 })], {
+    numRuns: 6,
+    seed: 170_900,
+  })(
+    `indexed join-target growth keeps source work flat (#1709 direction control)`,
+    async (fillerCount) => {
+      const baseline = await observeWork({
+        filler: noFillers,
+        joinTargets: true,
+      })
+      const scaled = await observeWork({
+        filler: {
+          terms: fillerCount,
+          meanings: 0,
+          groups: 0,
+          links: 0,
+        },
+        joinTargets: true,
+      })
+
+      expect(baseline.result).toEqual(expectedResult({ joinTargets: true }))
+      expect(scaled.result).toEqual(baseline.result)
+      expect(baseline.sourceWork).toEqual(joinedBaselineWork)
+      expect(scaled.sourceWork).toEqual(baseline.sourceWork)
+    },
+  )
+
+  fcTest.prop([fc.integer({ min: 4, max: 24 })], {
+    numRuns: 6,
+    seed: 17_090,
+  })(
+    `join-free correlated includes keep source work flat (#1709 control)`,
+    async (fillerCount) => {
+      const baseline = await observeWork({
+        filler: noFillers,
+        joinTargets: false,
+      })
+      const scaled = await observeWork({
+        filler: {
+          terms: fillerCount,
+          meanings: fillerCount,
+          groups: fillerCount,
+          links: fillerCount,
+        },
+        joinTargets: false,
+      })
+
+      expect(baseline.result).toEqual(expectedResult({ joinTargets: false }))
+      expect(scaled.result).toEqual(baseline.result)
+      expect(baseline.sourceWork).toEqual(joinFreeBaselineWork)
+      expect(scaled.sourceWork).toEqual(baseline.sourceWork)
+    },
+  )
+})

--- a/packages/query-db-collection/tests/includes-work-counter-oracle.test.ts
+++ b/packages/query-db-collection/tests/includes-work-counter-oracle.test.ts
@@ -37,11 +37,12 @@ type NodeCollection = Pick<
   'cleanup' | 'preload' | 'size' | 'toArray'
 >
 
-type NestedTreeWork = {
-  treeRowsConstructed: number
-  sourceRowsDelivered: TreeCounts
-  childCollectionsCreated: Record<ChildLevel, number>
-  childCollectionRows: Record<ChildLevel, number>
+type NestedTreeShape = {
+  reachableTreeRows: number
+  sourceRowsDeliveredAtPreload: TreeCounts
+  sourceRowsDeliveredAfterTraversal: TreeCounts
+  reachableChildCollections: Record<ChildLevel, number>
+  reachableChildRows: Record<ChildLevel, number>
 }
 
 const branchesPerRoot = 2
@@ -129,6 +130,47 @@ function requireChildren(row: NodeRow, level: string): NodeCollection {
   return row.children
 }
 
+function observeReachableTreeShape(roots: NodeCollection) {
+  const reachableChildCollections = { branches: 0, twigs: 0, leaves: 0 }
+  const reachableChildRows = { branches: 0, twigs: 0, leaves: 0 }
+  let reachableTreeRows = roots.size
+
+  const countChildren = (
+    collection: NodeCollection,
+    level: ChildLevel,
+  ): void => {
+    const children = collection.toArray
+    reachableChildCollections[level]++
+    reachableChildRows[level] += children.length
+    reachableTreeRows += children.length
+
+    const nextLevel =
+      level === `branches` ? `twigs` : level === `twigs` ? `leaves` : undefined
+    if (nextLevel === undefined) return
+
+    for (const child of children) {
+      countChildren(requireChildren(child, level), nextLevel)
+    }
+  }
+
+  for (const root of roots.toArray) {
+    countChildren(requireChildren(root, `root`), `branches`)
+  }
+
+  return { reachableTreeRows, reachableChildCollections, reachableChildRows }
+}
+
+function snapshotSourceRowsDelivered(
+  sourceCounters: Record<keyof TreeCounts, () => number>,
+): TreeCounts {
+  return {
+    roots: sourceCounters.roots(),
+    branches: sourceCounters.branches(),
+    twigs: sourceCounters.twigs(),
+    leaves: sourceCounters.leaves(),
+  }
+}
+
 async function runCleanups(
   cleanups: ReadonlyArray<() => void | Promise<void>>,
 ): Promise<void> {
@@ -148,9 +190,9 @@ function rethrowFirstCleanupError(
   if (firstRejection !== undefined) throw firstRejection.error
 }
 
-async function observeNestedTreeWork(
+async function observeNestedTreeShape(
   rootCount: number,
-): Promise<NestedTreeWork> {
+): Promise<NestedTreeShape> {
   const rows = createNestedTreeRows(rootCount)
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -171,10 +213,10 @@ async function observeNestedTreeWork(
       leaves: countDeliveredRows(sources.leaves),
     }
 
-    // This is the root useLiveQuery shape timed by #1634. Each children property
-    // remains a live Collection. The timer in the report stops before React's
-    // virtualizer mounts any recursive Level consumers, so this oracle measures
-    // only the nested collections and rows constructed by the root query.
+    // This matches the nested result shape in #1634. Each children property
+    // remains a live Collection. The public result API exposes the reachable
+    // tree, not internal allocation counts, so this oracle constrains reachable
+    // cardinality and source delivery rather than claiming to count allocations.
     const roots: NodeCollection = createLiveQueryCollection({
       startSync: true,
       query: (q) =>
@@ -207,46 +249,18 @@ async function observeNestedTreeWork(
     rootCollection = roots
     await roots.preload()
 
-    const childCollectionsCreated = { branches: 0, twigs: 0, leaves: 0 }
-    const childCollectionRows = { branches: 0, twigs: 0, leaves: 0 }
-    let treeRowsConstructed = roots.size
-
-    const countChildren = (
-      collection: NodeCollection,
-      level: ChildLevel,
-    ): void => {
-      const children = collection.toArray
-      childCollectionsCreated[level]++
-      childCollectionRows[level] += children.length
-      treeRowsConstructed += children.length
-
-      const nextLevel =
-        level === `branches`
-          ? `twigs`
-          : level === `twigs`
-            ? `leaves`
-            : undefined
-      if (nextLevel === undefined) return
-
-      for (const child of children) {
-        countChildren(requireChildren(child, level), nextLevel)
-      }
-    }
-
-    for (const root of roots.toArray) {
-      countChildren(requireChildren(root, `root`), `branches`)
-    }
+    const sourceRowsDeliveredAtPreload =
+      snapshotSourceRowsDelivered(sourceCounters)
+    const { reachableTreeRows, reachableChildCollections, reachableChildRows } =
+      observeReachableTreeShape(roots)
 
     return {
-      treeRowsConstructed,
-      sourceRowsDelivered: {
-        roots: sourceCounters.roots(),
-        branches: sourceCounters.branches(),
-        twigs: sourceCounters.twigs(),
-        leaves: sourceCounters.leaves(),
-      },
-      childCollectionsCreated,
-      childCollectionRows,
+      reachableTreeRows,
+      sourceRowsDeliveredAtPreload,
+      sourceRowsDeliveredAfterTraversal:
+        snapshotSourceRowsDelivered(sourceCounters),
+      reachableChildCollections,
+      reachableChildRows,
     }
   } finally {
     let cleanupRejected = false
@@ -277,45 +291,55 @@ async function observeNestedTreeWork(
   }
 }
 
-function expectNestedTreeWork(
-  observation: NestedTreeWork,
+function expectNestedTreeShape(
+  observation: NestedTreeShape,
   rootCount: number,
 ): void {
   const expected = expectedTreeCounts(rootCount)
-  expect(observation.treeRowsConstructed).toBe(
+  expect(observation.reachableTreeRows).toBe(
     Object.values(expected).reduce((sum, count) => sum + count, 0),
   )
-  expect(observation.sourceRowsDelivered).toEqual(expected)
-  expect(observation.childCollectionsCreated).toEqual({
+  expect(observation.sourceRowsDeliveredAtPreload).toEqual(expected)
+  expect(observation.sourceRowsDeliveredAfterTraversal).toEqual(
+    observation.sourceRowsDeliveredAtPreload,
+  )
+  expect(observation.reachableChildCollections).toEqual({
     branches: expected.roots,
     twigs: expected.branches,
     leaves: expected.twigs,
   })
-  expect(observation.childCollectionRows).toEqual({
+  expect(observation.reachableChildRows).toEqual({
     branches: expected.branches,
     twigs: expected.twigs,
     leaves: expected.leaves,
   })
 }
 
-describe(`nested includes setup counter oracle`, () => {
+describe(`nested includes reachable-shape oracle`, () => {
   fcTest.prop([fc.integer({ min: 0, max: 20 })], {
     numRuns: 6,
     seed: 1634,
   })(
-    `constructs each nested collection inside the root query (#1634)`,
+    `preserves the complete reachable nested tree shape (#1634)`,
     async (rootCount) => {
-      expectNestedTreeWork(await observeNestedTreeWork(rootCount), rootCount)
+      expectNestedTreeShape(await observeNestedTreeShape(rootCount), rootCount)
     },
   )
 
-  it(`constructs no nested collections for an empty root query`, async () => {
-    expectNestedTreeWork(await observeNestedTreeWork(0), 0)
+  it(`exposes no nested collections for an empty root query`, async () => {
+    expectNestedTreeShape(await observeNestedTreeShape(0), 0)
   })
 
   it(`pins #1634's reported 20-by-2-by-5-by-10 tree`, async () => {
-    // These semantic counters do not claim to measure elapsed time. They pin
-    // source delivery and nested collection construction at the timed seam.
-    expectNestedTreeWork(await observeNestedTreeWork(20), 20)
+    // These semantic counters do not claim to measure elapsed time or internal
+    // allocations. They pin source delivery at preload and reachable shape.
+    expectNestedTreeShape(await observeNestedTreeShape(20), 20)
+  })
+
+  it(`does not deliver more source rows while traversing the result`, async () => {
+    const observation = await observeNestedTreeShape(20)
+    expect(observation.sourceRowsDeliveredAfterTraversal).toEqual(
+      observation.sourceRowsDeliveredAtPreload,
+    )
   })
 })

--- a/packages/query-db-collection/tests/includes-work-counter-oracle.test.ts
+++ b/packages/query-db-collection/tests/includes-work-counter-oracle.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@tanstack/db'
 import { describe, expect, it } from 'vitest'
 import { queryCollectionOptions } from '../src/query'
-import type { Collection, WithVirtualProps } from '@tanstack/db'
+import type { Collection } from '@tanstack/db'
 
 let nextCollectionId = 0
 
@@ -32,9 +32,9 @@ type NodeRow = {
   children?: NodeCollection
 }
 
-type NodeCollection = Collection<
-  WithVirtualProps<NodeRow, string | number>,
-  string | number
+type NodeCollection = Pick<
+  Collection<NodeRow, string | number>,
+  'cleanup' | 'preload' | 'size' | 'toArray'
 >
 
 type NestedTreeWork = {
@@ -129,6 +129,25 @@ function requireChildren(row: NodeRow, level: string): NodeCollection {
   return row.children
 }
 
+async function runCleanups(
+  cleanups: ReadonlyArray<() => void | Promise<void>>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    cleanups.map(async (cleanup) => cleanup()),
+  )
+  const firstRejection = results.find(
+    (result): result is PromiseRejectedResult => result.status === `rejected`,
+  )
+  if (firstRejection !== undefined) throw firstRejection.reason
+}
+
+function rethrowFirstCleanupError(
+  results: ReadonlyArray<{ rejected: boolean; error: unknown }>,
+): void {
+  const firstRejection = results.find((result) => result.rejected)
+  if (firstRejection !== undefined) throw firstRejection.error
+}
+
 async function observeNestedTreeWork(
   rootCount: number,
 ): Promise<NestedTreeWork> {
@@ -142,7 +161,7 @@ async function observeNestedTreeWork(
     twigs: createQuerySource(`tree-twigs`, rows.twigs, queryClient),
     leaves: createQuerySource(`tree-leaves`, rows.leaves, queryClient),
   }
-  let roots: ReturnType<typeof createLiveQueryCollection> | undefined
+  let rootCollection: NodeCollection | undefined
 
   try {
     const sourceCounters = {
@@ -156,7 +175,7 @@ async function observeNestedTreeWork(
     // remains a live Collection. The timer in the report stops before React's
     // virtualizer mounts any recursive Level consumers, so this oracle measures
     // only the nested collections and rows constructed by the root query.
-    roots = createLiveQueryCollection({
+    const roots: NodeCollection = createLiveQueryCollection({
       startSync: true,
       query: (q) =>
         q.from({ root: sources.roots }).select(({ root }) => ({
@@ -185,6 +204,7 @@ async function observeNestedTreeWork(
             })),
         })),
     })
+    rootCollection = roots
     await roots.preload()
 
     const childCollectionsCreated = { branches: 0, twigs: 0, leaves: 0 }
@@ -195,7 +215,7 @@ async function observeNestedTreeWork(
       collection: NodeCollection,
       level: ChildLevel,
     ): void => {
-      const children = collection.toArray as unknown as ReadonlyArray<NodeRow>
+      const children = collection.toArray
       childCollectionsCreated[level]++
       childCollectionRows[level] += children.length
       treeRowsConstructed += children.length
@@ -213,7 +233,7 @@ async function observeNestedTreeWork(
       }
     }
 
-    for (const root of roots.toArray as unknown as ReadonlyArray<NodeRow>) {
+    for (const root of roots.toArray) {
       countChildren(requireChildren(root, `root`), `branches`)
     }
 
@@ -229,9 +249,31 @@ async function observeNestedTreeWork(
       childCollectionRows,
     }
   } finally {
-    await roots?.cleanup()
-    await Promise.all(Object.values(sources).map((source) => source.cleanup()))
-    queryClient.clear()
+    let cleanupRejected = false
+    let cleanupError: unknown
+    try {
+      await runCleanups([
+        async () => rootCollection?.cleanup(),
+        ...Object.values(sources).map((source) => async () => source.cleanup()),
+      ])
+    } catch (error) {
+      cleanupRejected = true
+      cleanupError = error
+    }
+
+    let clearRejected = false
+    let clearError: unknown
+    try {
+      queryClient.clear()
+    } catch (error) {
+      clearRejected = true
+      clearError = error
+    }
+
+    rethrowFirstCleanupError([
+      { rejected: cleanupRejected, error: cleanupError },
+      { rejected: clearRejected, error: clearError },
+    ])
   }
 }
 
@@ -257,7 +299,7 @@ function expectNestedTreeWork(
 }
 
 describe(`nested includes setup counter oracle`, () => {
-  fcTest.prop([fc.integer({ min: 1, max: 20 })], {
+  fcTest.prop([fc.integer({ min: 0, max: 20 })], {
     numRuns: 6,
     seed: 1634,
   })(
@@ -266,6 +308,10 @@ describe(`nested includes setup counter oracle`, () => {
       expectNestedTreeWork(await observeNestedTreeWork(rootCount), rootCount)
     },
   )
+
+  it(`constructs no nested collections for an empty root query`, async () => {
+    expectNestedTreeWork(await observeNestedTreeWork(0), 0)
+  })
 
   it(`pins #1634's reported 20-by-2-by-5-by-10 tree`, async () => {
     // These semantic counters do not claim to measure elapsed time. They pin

--- a/packages/query-db-collection/tests/includes-work-counter-oracle.test.ts
+++ b/packages/query-db-collection/tests/includes-work-counter-oracle.test.ts
@@ -1,0 +1,275 @@
+import { fc, test as fcTest } from '@fast-check/vitest'
+import { QueryClient } from '@tanstack/query-core'
+import {
+  BasicIndex,
+  createCollection,
+  createLiveQueryCollection,
+  eq,
+} from '@tanstack/db'
+import { describe, expect, it } from 'vitest'
+import { queryCollectionOptions } from '../src/query'
+import type { Collection, WithVirtualProps } from '@tanstack/db'
+
+let nextCollectionId = 0
+
+type RootRow = { id: string; value: string }
+type BranchRow = { id: string; parentId: string; value: string }
+type TwigRow = { id: string; parentId: string; value: string }
+type LeafRow = { id: string; parentId: string; value: string }
+
+type TreeCounts = {
+  roots: number
+  branches: number
+  twigs: number
+  leaves: number
+}
+
+type ChildLevel = Exclude<keyof TreeCounts, 'roots'>
+
+type NodeRow = {
+  id: string
+  value: string
+  children?: NodeCollection
+}
+
+type NodeCollection = Collection<
+  WithVirtualProps<NodeRow, string | number>,
+  string | number
+>
+
+type NestedTreeWork = {
+  treeRowsConstructed: number
+  sourceRowsDelivered: TreeCounts
+  childCollectionsCreated: Record<ChildLevel, number>
+  childCollectionRows: Record<ChildLevel, number>
+}
+
+const branchesPerRoot = 2
+const twigsPerBranch = 5
+const leavesPerTwig = 10
+
+function createNestedTreeRows(rootCount: number) {
+  const roots: Array<RootRow> = []
+  const branches: Array<BranchRow> = []
+  const twigs: Array<TwigRow> = []
+  const leaves: Array<LeafRow> = []
+
+  for (let rootIndex = 0; rootIndex < rootCount; rootIndex++) {
+    const rootId = `root-${rootIndex}`
+    roots.push({ id: rootId, value: rootId })
+
+    for (let branchIndex = 0; branchIndex < branchesPerRoot; branchIndex++) {
+      const branchId = `branch-${rootIndex}-${branchIndex}`
+      branches.push({ id: branchId, parentId: rootId, value: branchId })
+
+      for (let twigIndex = 0; twigIndex < twigsPerBranch; twigIndex++) {
+        const twigId = `twig-${rootIndex}-${branchIndex}-${twigIndex}`
+        twigs.push({ id: twigId, parentId: branchId, value: twigId })
+
+        for (let leafIndex = 0; leafIndex < leavesPerTwig; leafIndex++) {
+          const leafId = `leaf-${rootIndex}-${branchIndex}-${twigIndex}-${leafIndex}`
+          leaves.push({ id: leafId, parentId: twigId, value: leafId })
+        }
+      }
+    }
+  }
+
+  return { roots, branches, twigs, leaves }
+}
+
+function createQuerySource<T extends { id: string }>(
+  name: string,
+  rows: Array<T>,
+  queryClient: QueryClient,
+) {
+  const id = `${name}-${nextCollectionId++}`
+  return createCollection(
+    queryCollectionOptions<T>({
+      id,
+      queryClient,
+      autoIndex: `eager`,
+      defaultIndexType: BasicIndex,
+      queryKey: [id],
+      queryFn: () => Promise.resolve(rows),
+      getKey: (row) => row.id,
+    }),
+  )
+}
+
+function countDeliveredRows<T extends object>(collection: Collection<T>) {
+  let deliveredRows = 0
+  const originalSubscribeChanges = collection.subscribeChanges.bind(collection)
+
+  collection.subscribeChanges = (callback, options) => {
+    return originalSubscribeChanges((changes) => {
+      deliveredRows += changes.length
+      callback(changes)
+    }, options)
+  }
+
+  return () => deliveredRows
+}
+
+function expectedTreeCounts(rootCount: number): TreeCounts {
+  const branches = rootCount * branchesPerRoot
+  const twigs = branches * twigsPerBranch
+
+  return {
+    roots: rootCount,
+    branches,
+    twigs,
+    leaves: twigs * leavesPerTwig,
+  }
+}
+
+function requireChildren(row: NodeRow, level: string): NodeCollection {
+  if (row.children === undefined) {
+    throw new Error(`Expected ${level} row ${row.id} to have children`)
+  }
+  return row.children
+}
+
+async function observeNestedTreeWork(
+  rootCount: number,
+): Promise<NestedTreeWork> {
+  const rows = createNestedTreeRows(rootCount)
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const sources = {
+    roots: createQuerySource(`tree-roots`, rows.roots, queryClient),
+    branches: createQuerySource(`tree-branches`, rows.branches, queryClient),
+    twigs: createQuerySource(`tree-twigs`, rows.twigs, queryClient),
+    leaves: createQuerySource(`tree-leaves`, rows.leaves, queryClient),
+  }
+  let roots: ReturnType<typeof createLiveQueryCollection> | undefined
+
+  try {
+    const sourceCounters = {
+      roots: countDeliveredRows(sources.roots),
+      branches: countDeliveredRows(sources.branches),
+      twigs: countDeliveredRows(sources.twigs),
+      leaves: countDeliveredRows(sources.leaves),
+    }
+
+    // This is the root useLiveQuery shape timed by #1634. Each children property
+    // remains a live Collection. The timer in the report stops before React's
+    // virtualizer mounts any recursive Level consumers, so this oracle measures
+    // only the nested collections and rows constructed by the root query.
+    roots = createLiveQueryCollection({
+      startSync: true,
+      query: (q) =>
+        q.from({ root: sources.roots }).select(({ root }) => ({
+          id: root.id,
+          value: root.value,
+          children: q
+            .from({ branch: sources.branches })
+            .where(({ branch }) => eq(branch.parentId, root.id))
+            .select(({ branch }) => ({
+              id: branch.id,
+              value: branch.value,
+              children: q
+                .from({ twig: sources.twigs })
+                .where(({ twig }) => eq(twig.parentId, branch.id))
+                .select(({ twig }) => ({
+                  id: twig.id,
+                  value: twig.value,
+                  children: q
+                    .from({ leaf: sources.leaves })
+                    .where(({ leaf }) => eq(leaf.parentId, twig.id))
+                    .select(({ leaf }) => ({
+                      id: leaf.id,
+                      value: leaf.value,
+                    })),
+                })),
+            })),
+        })),
+    })
+    await roots.preload()
+
+    const childCollectionsCreated = { branches: 0, twigs: 0, leaves: 0 }
+    const childCollectionRows = { branches: 0, twigs: 0, leaves: 0 }
+    let treeRowsConstructed = roots.size
+
+    const countChildren = (
+      collection: NodeCollection,
+      level: ChildLevel,
+    ): void => {
+      const children = collection.toArray as unknown as ReadonlyArray<NodeRow>
+      childCollectionsCreated[level]++
+      childCollectionRows[level] += children.length
+      treeRowsConstructed += children.length
+
+      const nextLevel =
+        level === `branches`
+          ? `twigs`
+          : level === `twigs`
+            ? `leaves`
+            : undefined
+      if (nextLevel === undefined) return
+
+      for (const child of children) {
+        countChildren(requireChildren(child, level), nextLevel)
+      }
+    }
+
+    for (const root of roots.toArray as unknown as ReadonlyArray<NodeRow>) {
+      countChildren(requireChildren(root, `root`), `branches`)
+    }
+
+    return {
+      treeRowsConstructed,
+      sourceRowsDelivered: {
+        roots: sourceCounters.roots(),
+        branches: sourceCounters.branches(),
+        twigs: sourceCounters.twigs(),
+        leaves: sourceCounters.leaves(),
+      },
+      childCollectionsCreated,
+      childCollectionRows,
+    }
+  } finally {
+    await roots?.cleanup()
+    await Promise.all(Object.values(sources).map((source) => source.cleanup()))
+    queryClient.clear()
+  }
+}
+
+function expectNestedTreeWork(
+  observation: NestedTreeWork,
+  rootCount: number,
+): void {
+  const expected = expectedTreeCounts(rootCount)
+  expect(observation.treeRowsConstructed).toBe(
+    Object.values(expected).reduce((sum, count) => sum + count, 0),
+  )
+  expect(observation.sourceRowsDelivered).toEqual(expected)
+  expect(observation.childCollectionsCreated).toEqual({
+    branches: expected.roots,
+    twigs: expected.branches,
+    leaves: expected.twigs,
+  })
+  expect(observation.childCollectionRows).toEqual({
+    branches: expected.branches,
+    twigs: expected.twigs,
+    leaves: expected.leaves,
+  })
+}
+
+describe(`nested includes setup counter oracle`, () => {
+  fcTest.prop([fc.integer({ min: 1, max: 20 })], {
+    numRuns: 6,
+    seed: 1634,
+  })(
+    `constructs each nested collection inside the root query (#1634)`,
+    async (rootCount) => {
+      expectNestedTreeWork(await observeNestedTreeWork(rootCount), rootCount)
+    },
+  )
+
+  it(`pins #1634's reported 20-by-2-by-5-by-10 tree`, async () => {
+    // These semantic counters do not claim to measure elapsed time. They pin
+    // source delivery and nested collection construction at the timed seam.
+    expectNestedTreeWork(await observeNestedTreeWork(20), 20)
+  })
+})


### PR DESCRIPTION
This adds deterministic source-work and reachable-shape oracles for the includes reports in #1709 and #1634. It changes tests only: runtime behavior is unchanged, and the reported signatures now have stable regression coverage that does not depend on wall-clock timing.

## Approach

For #1709, the oracle recreates the reported load-first, then-add-`BTreeIndex` setup and counts work at both sides of each source boundary:

- rows delivered into the dataflow graph
- rows examined through scans and keyed reads
- irrelevant rows added to the correlated link source
- indexed target-growth and join-free controls that must remain flat

The known defect is classified narrowly: adding irrelevant link rows preserves the result but increases link work and activates one extra target route. Any other failure shape remains a test failure.

For #1634, the oracle recreates the report's 20-by-2-by-5-by-10 query-backed tree. It snapshots source delivery immediately after `roots.preload()`, traverses the public result to count reachable child collections and rows, then proves that traversal caused no further source delivery. The public API cannot reveal internal allocations, so this test deliberately constrains source work at preload and reachable output cardinality. It does not claim to count collections or rows allocated and later discarded inside the engine.

## Key invariants

- Filler rows never change query results.
- The #1709 expected failure matches exact delivered and examined counts.
- Indexed target growth and join-free nested includes keep source work flat.
- The #1634 source rows are delivered by the preload boundary.
- Traversing the #1634 result does not trigger more source delivery.
- The complete 20/40/200/2,000 reachable tree shape is preserved.

## Non-goals

- Fixing either runtime path.
- Adding timing thresholds or machine-dependent benchmarks.
- Measuring internal allocation counts that the public result API cannot expose.
- Closing the linked issues before runtime fixes land.

## Verification

```bash
pnpm exec vitest run packages/db/tests/query/includes-work-counter-oracle.test.ts --maxWorkers=2
pnpm exec vitest run --config packages/query-db-collection/vitest.config.ts packages/query-db-collection/tests/includes-work-counter-oracle.test.ts --maxWorkers=2
```

All 10 focused tests pass (6 core DB and 4 query-db). Focused Vitest typechecking reports no errors. ESLint, Prettier, and `git diff --check` are clean.

## Files changed

- `packages/db/tests/query/includes-work-counter-oracle.test.ts` adds the #1709 source-work oracle and controls.
- `packages/query-db-collection/tests/includes-work-counter-oracle.test.ts` adds the #1634 preload source-delivery and reachable-tree-shape oracle.

---

Refs #1658, #1709, #1634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added deterministic and property-based coverage for nested live-query includes.
  * Added validation of query results, row delivery, source work counts, and reachable-row traversal.
  * Covered indexed targets, correlated includes, joined queries, empty trees, boundary cases, and larger generated datasets.
  * Improved cleanup verification for live queries and source collections, including failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->