### PR TITLE
fix: support nested optional property access in SingleRowRefProxy

### DIFF
--- a/.changeset/single-row-ref-proxy-optional-access.md
+++ b/.changeset/single-row-ref-proxy-optional-access.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Fix `SingleRowRefProxy` collapsing optional and nullable nested objects to opaque leaves. `createIndex()` and single-row `where` callbacks can now traverse them with optional chaining (`row.updatedAt?.seconds`), matching the query builder's `Ref` behavior; runtime behavior is unchanged.

--- a/packages/db/src/query/builder/ref-proxy.ts
+++ b/packages/db/src/query/builder/ref-proxy.ts
@@ -23,6 +23,24 @@ export type VirtualPropsRefProxy<
 }
 
 /**
+ * Resolves the ref type for a single field of a row. Optionality and
+ * nullability are hoisted out of the field type before the object check, so
+ * an optional nested object (`Foo | undefined`) still produces a traversable
+ * branch proxy instead of collapsing to an opaque leaf. The nullish part is
+ * re-added to the union so optional chaining (`row.a?.b`) type-checks the
+ * same way it does on the query builder's `Ref` type.
+ */
+type SingleRowField<V, TKey extends string | number> = [
+  NonNullable<V>,
+] extends [never]
+  ? RefLeaf<V>
+  : NonNullable<V> extends Record<string, any>
+    ?
+        | (SingleRowRefProxy<NonNullable<V>, TKey> & RefProxy<NonNullable<V>>)
+        | Extract<V, null | undefined>
+    : RefLeaf<V>
+
+/**
  * Type for creating a RefProxy for a single row/type without namespacing
  * Used in collection indexes and where clauses
  *
@@ -35,9 +53,7 @@ export type SingleRowRefProxy<
 > =
   T extends Record<string, any>
     ? {
-        [K in keyof T]: T[K] extends Record<string, any>
-          ? SingleRowRefProxy<T[K], TKey> & RefProxy<T[K]>
-          : RefLeaf<T[K]>
+        [K in keyof T]: SingleRowField<T[K], TKey>
       } & RefProxy<T> &
         VirtualPropsRefProxy<TKey>
     : RefProxy<T> & VirtualPropsRefProxy<TKey>

--- a/packages/db/tests/single-row-ref-proxy.test-d.ts
+++ b/packages/db/tests/single-row-ref-proxy.test-d.ts
@@ -1,0 +1,80 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { createCollection } from '../src/collection/index.js'
+import { eq } from '../src/query/builder/functions.js'
+import type { RefLeaf } from '../src/query/builder/types.js'
+
+describe(`SingleRowRefProxy nested optional property access`, () => {
+  type Doc = {
+    id: string
+    name: string
+    updatedAt?: { seconds: number; nanoseconds: number }
+    author: { name: string; contact?: { email: string } }
+    deletedAt: { seconds: number } | null
+  }
+
+  const collection = createCollection<Doc, string>({
+    getKey: (doc) => doc.id,
+    sync: { sync: () => {} },
+  })
+
+  it(`allows optional chaining into an optional nested object`, () => {
+    collection.createIndex((row) => {
+      expectTypeOf(row.updatedAt?.seconds).toEqualTypeOf<
+        RefLeaf<number> | undefined
+      >()
+      return row.updatedAt?.seconds
+    })
+  })
+
+  it(`requires optional chaining for an optional nested object`, () => {
+    collection.createIndex((row) => {
+      // @ts-expect-error - updatedAt may be undefined, plain access must error
+      return row.updatedAt.seconds
+    })
+  })
+
+  it(`allows optional chaining into a nullable nested object`, () => {
+    collection.createIndex((row) => {
+      expectTypeOf(row.deletedAt?.seconds).toEqualTypeOf<
+        RefLeaf<number> | undefined
+      >()
+      return row.deletedAt?.seconds
+    })
+  })
+
+  it(`keeps required nested objects traversable without optional chaining`, () => {
+    collection.createIndex((row) => {
+      expectTypeOf(row.author.name).toEqualTypeOf<RefLeaf<string>>()
+      return row.author.name
+    })
+  })
+
+  it(`supports optional objects nested below a required object`, () => {
+    collection.createIndex((row) => {
+      expectTypeOf(row.author.contact?.email).toEqualTypeOf<
+        RefLeaf<string> | undefined
+      >()
+      return row.author.contact?.email
+    })
+  })
+
+  it(`keeps scalar fields as plain leaves`, () => {
+    collection.createIndex((row) => {
+      expectTypeOf(row.name).toEqualTypeOf<RefLeaf<string>>()
+      return row.name
+    })
+  })
+
+  it(`rejects properties that do not exist on the nested object`, () => {
+    collection.createIndex((row) => {
+      // @ts-expect-error - millis is not a property of updatedAt
+      return row.updatedAt?.millis
+    })
+  })
+
+  it(`accepts nested optional refs in the subscribeChanges where callback`, () => {
+    collection.subscribeChanges(() => {}, {
+      where: (row) => eq(row.updatedAt?.seconds, 5),
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1726

## Problem

`SingleRowRefProxy` maps each field with `T[K] extends Record<string, any>` to decide between a traversable branch proxy and an opaque `RefLeaf`. For an optional (`Foo | undefined`) or nullable (`Foo | null`) nested object that conditional fails, so the field collapses to `RefLeaf<Foo | undefined>` and nested access fails to type-check:

```ts
collection.createIndex((row) => row.updatedAt?.seconds)
// TS2339: Property 'seconds' does not exist on type 'RefLeaf<{ seconds: number; ... } | undefined>'
```

The runtime proxy records the path fine — this was purely a type-level gap. The query builder's `Ref` type already solves the same problem by hoisting nullability before the object check (`RefBranch` in `query/builder/types.ts`).

## Fix

A `SingleRowField` helper applies the same pattern to `SingleRowRefProxy`:

- `NonNullable<V>` is checked against `Record<string, any>`, so optional/nullable objects still produce a branch proxy.
- `Extract<V, null | undefined>` is re-added to the union, so optional chaining is required exactly where the schema says the value may be absent (`row.updatedAt?.seconds` type-checks; `row.updatedAt.seconds` errors).
- A `[NonNullable<V>] extends [never]` guard keeps exactly-`undefined`/`null` fields as leaves (`never extends Record<string, any>` would otherwise be true).

Required objects, scalar leaves, and virtual props resolve to identical types as before — the change only affects fields whose type unions an object with `null`/`undefined`. This covers every `SingleRowRefProxy` consumer: `createIndex()` callbacks, `subscribeChanges`/`currentStateAsChanges` `where` callbacks, and `getKey` introspection.

## Tests

`tests/single-row-ref-proxy.test-d.ts` (8 type tests): optional and nullable nested objects traversable via `?.`, plain access on them rejected, optional-below-required nesting, required objects still traversable without `?.`, scalars stay leaves, unknown nested properties rejected, and the `subscribeChanges` `where` callback accepting a nested optional ref. Verified red against `main`: 4 of 8 fail there.

Validation: `@tanstack/db` suite 122 files / 2869 passed with `vitest --typecheck`, `tsc --noEmit` clean, full monorepo `pnpm build` clean.

---

*This PR was developed with AI assistance (Claude); all changes were reviewed and validated by me.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested-field access for optional and nullable objects in collection indexes and single-row filters.
  * Optional chaining now works consistently when traversing nested data.
  * Preserved correct handling and type checking for required fields, scalar values, and invalid properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->