### PR TITLE
fix: drive inner joins from a correlation-bounded lazy side inside includes

### DIFF
--- a/.changeset/include-join-where-pushdown.md
+++ b/.changeset/include-join-where-pushdown.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/db": patch
+---
+
+Fix a join inside a correlated include ignoring the subquery's where filter and scanning the whole source collection. The inner-join active/lazy side selection now prefers a side that is already lazily loaded (bounded by the include's correlation) as the driving side, so the joined side loads keyed by the bounded rows instead of the bounded side being flooded with join keys from a full scan of the other side. Mount cost of the reported shape drops from linear in the source collection size (~290ms at 200k rows) to flat (~1ms), with identical results.

--- a/packages/db/src/query/compiler/joins.ts
+++ b/packages/db/src/query/compiler/joins.ts
@@ -171,6 +171,8 @@ function processJoin(
     joinClause.type,
     mainCollection,
     joinedCollection,
+    lazySources.has(mainSource),
+    lazySources.has(joinedSource),
   )
 
   // Analyze which source each expression refers to and swap if necessary
@@ -663,6 +665,8 @@ function getActiveAndLazySources(
   joinType: JoinClause[`type`],
   leftCollection: Collection,
   rightCollection: Collection,
+  mainIsLazy: boolean,
+  joinedIsLazy: boolean,
 ):
   | { activeSource: `main` | `joined`; lazySource: Collection }
   | { activeSource: undefined; lazySource: undefined } {
@@ -675,6 +679,18 @@ function getActiveAndLazySources(
     case `right`:
       return { activeSource: `joined`, lazySource: leftCollection }
     case `inner`:
+      // A main side that is already lazy is bounded: it never does an initial
+      // full load — its rows arrive on demand (keyed by an includes
+      // correlation, see #1709). The join must drive from that side so the
+      // joined side loads keyed by the bounded row set. Letting the size
+      // heuristic override this would load the joined side in full and drive
+      // the bounded side with join keys drawn from that full scan.
+      // (Deliberately asymmetric: a lazy JOINED side only arises today via
+      // correlation-alias shapes whose subscriptions are not actually lazy,
+      // where forcing the flip could regress; those keep the size heuristic.)
+      if (mainIsLazy && !joinedIsLazy) {
+        return { activeSource: `main`, lazySource: rightCollection }
+      }
       // The smallest collection should be the active collection
       // and the biggest collection should be lazy
       return leftCollection.size < rightCollection.size

--- a/packages/db/tests/query/includes-work-counter-oracle.test.ts
+++ b/packages/db/tests/query/includes-work-counter-oracle.test.ts
@@ -8,8 +8,6 @@ import {
   eq,
   materialize,
 } from '../../src/query/index.js'
-import { expectAssertionFailure } from '../expected-failure.js'
-import { TraceAssertionError } from '../trace-runner.js'
 import type { Collection } from '../../src/collection/index.js'
 
 let nextCollectionId = 0
@@ -33,9 +31,17 @@ type FillerCounts = {
   links: number
 }
 
+type SourceCollections = {
+  terms: Collection<TermRow>
+  meanings: Collection<MeaningRow>
+  groups: Collection<GroupRow>
+  links: Collection<LinkRow>
+}
+
 type WorkScenario = {
   filler: FillerCounts
   joinTargets: boolean
+  afterMount?: (sources: SourceCollections) => Promise<void> | void
 }
 
 type WorkCount = {
@@ -197,6 +203,7 @@ function observeLink(link: LinkObservation): LinkObservation {
 async function observeWork({
   filler,
   joinTargets,
+  afterMount,
 }: WorkScenario): Promise<WorkObservation> {
   const rows = createFixtureRows(filler)
   const sources = {
@@ -283,6 +290,11 @@ async function observeWork({
     cleanupLive = () => live.cleanup()
 
     await live.preload()
+    if (afterMount) {
+      await afterMount(sources)
+      // Let the change propagate through the dataflow graph
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
     const root = live.toArray[0]!
     return {
       result: [
@@ -346,44 +358,6 @@ function expectedResult({
   ]
 }
 
-function assertEqualSourceWork(
-  actual: SourceWork,
-  expected: SourceWork,
-): Promise<void> {
-  try {
-    expect(actual).toEqual(expected)
-    return Promise.resolve()
-  } catch (error) {
-    return Promise.reject(new TraceAssertionError(1, error))
-  }
-}
-
-function isExactWorkCount(value: unknown, expected: WorkCount): boolean {
-  return (
-    typeof value === `object` &&
-    value !== null &&
-    `delivered` in value &&
-    value.delivered === expected.delivered &&
-    `examined` in value &&
-    value.examined === expected.examined
-  )
-}
-
-function isExactSourceWork(value: unknown, expected: SourceWork): boolean {
-  return (
-    typeof value === `object` &&
-    value !== null &&
-    `terms` in value &&
-    isExactWorkCount(value.terms, expected.terms) &&
-    `meanings` in value &&
-    isExactWorkCount(value.meanings, expected.meanings) &&
-    `groups` in value &&
-    isExactWorkCount(value.groups, expected.groups) &&
-    `links` in value &&
-    isExactWorkCount(value.links, expected.links)
-  )
-}
-
 const joinedBaselineWork: SourceWork = {
   terms: { delivered: 3, examined: 3 },
   meanings: { delivered: 1, examined: 1 },
@@ -401,7 +375,10 @@ const joinFreeBaselineWork: SourceWork = {
 let joinedBaselineObservation: WorkObservation
 let joinFreeBaselineObservation: WorkObservation
 
-async function expectKnownCorrelatedJoinDefect(
+// The correlated where bounds the join's left side, so irrelevant left-side
+// rows must not add source work: the join drives from the correlation-bounded
+// side and lazily loads targets keyed by its rows (#1709).
+async function expectBoundedCorrelatedJoinWork(
   fillerCount: number,
 ): Promise<void> {
   const baseline = joinedBaselineObservation
@@ -417,26 +394,7 @@ async function expectKnownCorrelatedJoinDefect(
   expect(baseline.result).toEqual(expectedResult({ joinTargets: true }))
   expect(scaled.result).toEqual(baseline.result)
   expect(baseline.sourceWork).toEqual(joinedBaselineWork)
-
-  const knownLinkWork = {
-    delivered: baseline.sourceWork.links.delivered + fillerCount,
-    // Once irrelevant rows exist, the defective route scans the whole
-    // collection and then reads the two selected rows through the index.
-    examined: baseline.sourceWork.links.examined + fillerCount + 2,
-  }
-  const knownScaledWork: SourceWork = {
-    // The full left scan also activates one extra indexed target route.
-    terms: { delivered: 4, examined: 4 },
-    meanings: baseline.sourceWork.meanings,
-    groups: baseline.sourceWork.groups,
-    links: knownLinkWork,
-  }
-  await expectAssertionFailure(assertEqualSourceWork, {
-    checkpoint: 1,
-    classify: ({ actual, expected }) =>
-      isExactSourceWork(actual, knownScaledWork) &&
-      isExactSourceWork(expected, baseline.sourceWork),
-  })(scaled.sourceWork, baseline.sourceWork)
+  expect(scaled.sourceWork).toEqual(baseline.sourceWork)
 }
 
 describe(`includes deterministic work-counter oracle`, () => {
@@ -450,17 +408,48 @@ describe(`includes deterministic work-counter oracle`, () => {
   })
 
   it.each([1, 2, 3])(
-    `pins the #1709 defect formula at the small filler boundary (%i)`,
-    expectKnownCorrelatedJoinDefect,
+    `keeps left-side source work flat at the small filler boundary (#1709) (%i)`,
+    expectBoundedCorrelatedJoinWork,
   )
 
   fcTest.prop([fc.integer({ min: 1, max: 24 })], {
     numRuns: 6,
     seed: 1709,
   })(
-    `known work defect: a join defeats correlated source pushdown (#1709)`,
-    expectKnownCorrelatedJoinDefect,
+    `a join no longer defeats correlated source pushdown (#1709)`,
+    expectBoundedCorrelatedJoinWork,
   )
+
+  it(`joins a late insert into the bounded side lazily without rescanning (#1709 incremental)`, async () => {
+    const observed = await observeWork({
+      filler: { terms: 5, meanings: 0, groups: 0, links: 12 },
+      joinTargets: true,
+      afterMount: (sources) => {
+        // New link in the selected group pointing at a target that was never
+        // loaded: the join must lazily load exactly that target, not rescan.
+        sources.links.insert({
+          id: `link-late`,
+          groupId: `group-0`,
+          targetId: `term-filler-3`,
+        })
+      },
+    })
+
+    const links = observed.result[0]!.meanings[0]!.groups[0]!.links
+    expect(links).toHaveLength(3)
+    expect(links).toContainEqual({
+      id: `link-late`,
+      text: `irrelevant target 3`,
+    })
+    expect(observed.sourceWork).toEqual({
+      // Mount work plus exactly one lazily loaded join target for the insert
+      terms: { delivered: 4, examined: 4 },
+      meanings: { delivered: 1, examined: 1 },
+      groups: { delivered: 1, examined: 1 },
+      // The inserted row arrives as a live update, not an indexed re-read
+      links: { delivered: 3, examined: 2 },
+    })
+  })
 
   fcTest.prop([fc.integer({ min: 1, max: 24 })], {
     numRuns: 6,


### PR DESCRIPTION
Fixes #1709

## Root cause

`materialize()` strips the correlation `eq()` out of the child query's WHERE at build time (`buildIncludesSubquery`) and re-encodes it as `IncludesSubquery` metadata, so the child query the compiler sees has no `where` at all. The includes compiler then correctly bounds the child's FROM side: it marks the alias lazy and drives its subscription per parent correlation key (`requestSnapshot({ where: inArray(l.groupId, parentKeys) })`) — which is why the no-join control in the issue stays flat.

When the child also has an inner `.join()`, `processJoin` picks the join's active/lazy sides in `getActiveAndLazySources` purely by **collection size**. With `links` (200k) larger than `terms` (50k), `terms` becomes the active side — a full eager subscription with no `where` — and the join's lazy-load driver then pushes `requestSnapshot({ where: inArray(l.targetId, <every term id from that full scan>) })` into `links`. Unlike a top-level query, the include's correlation bound lives out-of-band (not as a `whereExpression` on the subscription), so nothing intersects that request: nearly the whole `links` collection is materialized into the dataflow graph. That is the `currentStateAsChanges` + `wrapInputWithAlias` signature in the issue's CPU profile.

## Fix

`getActiveAndLazySources` now receives whether each side is already lazy (`lazySources.has(alias)` at decision time). For an **inner** join, a main side that is already lazy is bounded — its rows only ever arrive on demand, keyed by the includes correlation — so the join drives from it and the joined side becomes the lazy one, loading keyed by the bounded rows (`inArray(tgt.id, <targetIds of the 6 selected links>)`). The size heuristic remains the fallback when the main side is not bounded.

This reuses the exact machinery that already works: for `left` joins the active side is always `main`, and the issue's repro with the join type switched to `left` is already flat on `main` today. The fix makes the bounded inner join take that same path.

The flip is deliberately asymmetric (`mainIsLazy && !joinedIsLazy` only). A lazy **joined** side can currently only arise through correlation-alias shapes whose real subscriptions are not actually lazy (see follow-ups), where forcing the flip could regress against the size heuristic, so those keep the existing behavior.

## Measurements

Issue repro (`links` grows with filler rows that the query never selects, identical 6-row result):

| `links` size | before | after | control (no join) |
| --- | --- | --- | --- |
| 6 | 6.2 ms | 6.4 ms | 5.3 ms |
| 50,006 | 90.5 ms | 1.5 ms | 1.0 ms |
| 200,006 | **289.5 ms** | **1.0 ms** | 0.9 ms |

Subscription trace after the fix: `links` receives only `in(groupId, [g0])` (as in the control), `terms` receives `in(id, [t1…t6])` instead of a full eager load.

## Tests

`tests/query/includes-work-counter-oracle.test.ts` (from #1738) already pinned this defect with an exact work formula and `expectAssertionFailure`. This PR flips it to the bounded expectation:

- the `it.each` boundary cases and the seeded property test now assert `scaled.sourceWork == baseline.sourceWork` (flat delivered/examined work as the left side grows) — 4 of these fail on `main`, all pass with the fix;
- both direction controls (join-target growth, join-free includes) are unchanged and still pass;
- new incremental test: after mount, inserting a link that points at a **never-loaded** join target must lazily load exactly that one target and join it (`terms` +1 delivered, no rescan of `links`), asserted with exact work counts via a new optional `afterMount` phase in the oracle's `observeWork`.

Also verified manually on the issue's shape: post-mount link insert with a never-loaded target appears with the joined text, target renames propagate, deletes remove the row, and inserts into never-selected groups do not surface.

Validation: `@tanstack/db` 2862 passed / type-clean; all consumer package suites green (query-db-collection 294, electric 477, react 170, vue 94, svelte 99, solid 67, angular 52, trailbase, rxdb); full monorepo build clean.

## Known adjacent gaps (pre-existing, unchanged by this PR)

Reviewing this fix surfaced two shapes where the includes lazy machinery never engages at all (the child source eagerly full-loads exactly as in #1709, before and after this change):

1. **Correlation on a join-to-subquery alias** — `getLazyLoadTargets` resolves the lazy target to the outer join alias while the real subscription is registered under the remapped inner alias, so the lazy mark lands on a phantom alias and the includes-level snapshot tap silently no-ops (`subscriptions[alias]` missing → `continue`, unlike the throwing check in `joins.ts`).
2. **Includes child whose own FROM is a subquery or `unionAll`** — no lazy target resolves, so the child loads eagerly and this fix's boundedness flag never sets.

Happy to file these as separate issues if useful.

---

*This PR was developed with AI assistance (Claude); all changes were reviewed and validated by me.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correlated include joins to avoid unnecessary full source scans.
  * Reduced join-key loading and mount work for lazily loaded data.
  * Preserved query results while keeping work stable as related records increase.
  * Ensured late-added related records load incrementally without rescanning existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->