### PR TITLE
fix(react-db): support conditional query configs

### DIFF
--- a/.changeset/support-conditional-live-query-configs.md
+++ b/.changeset/support-conditional-live-query-configs.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/db': patch
+'@tanstack/react-db': patch
+---
+
+Support disabling live queries declared with the `{ query }` config syntax by returning `undefined` or `null` from the query callback.

--- a/docs/guides/live-queries.md
+++ b/docs/guides/live-queries.md
@@ -454,11 +454,26 @@ function TodoList({ userId }: { userId: string }) {
 }
 ```
 
-The callback form can also return `undefined` or `null` to disable a query. This still uses derived identity, so captured structured values do not need a dependency array. When the query is disabled:
+The `query` callback can return `undefined` or `null` to disable a query. This still uses derived identity, so captured structured values do not need a dependency array:
+
+```tsx
+const { data, isEnabled, status } = useLiveQuery({
+  query: (q) => {
+    if (!userId) return undefined
+
+    return q
+      .from({ todos: todosCollection })
+      .where(({ todos }) => eq(todos.userId, userId))
+  },
+})
+```
+
+The top-level callback form supports the same behavior. When the query is disabled:
 - `status` is `'disabled'`
 - `data`, `state`, and `collection` are `undefined`
 - `isEnabled` is `false`
-- `isLoading`, `isReady`, `isIdle`, and `isError` are all `false`
+- `isReady` is `true`
+- `isLoading`, `isIdle`, `isError`, and `isCleanedUp` are all `false`
 
 ### Alternative Input Forms
 

--- a/packages/db/src/live-query-options.ts
+++ b/packages/db/src/live-query-options.ts
@@ -8,8 +8,10 @@ import type { CollectionImpl } from './collection/index.js'
 import type { CollectionOptionsIdentity } from './collection-options.js'
 import type { CollectionOptions, DbClient } from './client.js'
 import type {
+  Context,
   InitialQueryBuilder,
   LiveQueryCollectionConfig,
+  QueryBuilder,
 } from './query/index.js'
 
 export type LiveQueryKey = ReadonlyArray<unknown>
@@ -21,6 +23,17 @@ export type LiveQueryOptions = LiveQueryCollectionConfig<any> & {
 export type DeferredLiveQueryCollections = Set<
   CollectionImpl<any, string | number, any, any, any>
 >
+
+type PreparedLiveQueryConfigInput = Omit<
+  LiveQueryCollectionConfig<Context>,
+  `query`
+> & {
+  query:
+    | QueryBuilder<Context>
+    | ((q: InitialQueryBuilder) => QueryBuilder<Context> | undefined | null)
+  queryKey?: LiveQueryKey
+  client?: DbClient
+}
 
 function createInitialQueryBuilder(
   dbClient: DbClient | undefined,
@@ -73,17 +86,20 @@ export function prepareLiveQueryValue(
       queryKey: _queryKey,
       client: _client,
       ...config
-    } = value as LiveQueryCollectionConfig<any> & {
-      queryKey?: LiveQueryKey
-      client?: DbClient
+    } = value as PreparedLiveQueryConfigInput
+
+    const preparedQuery =
+      typeof query === `function`
+        ? query(createInitialQueryBuilder(dbClient, deferredCollections))
+        : query
+
+    if (preparedQuery === undefined || preparedQuery === null) {
+      return preparedQuery
     }
 
     return {
       ...config,
-      query:
-        typeof query === `function`
-          ? query(createInitialQueryBuilder(dbClient, deferredCollections))
-          : query,
+      query: preparedQuery,
     }
   }
 

--- a/packages/db/tests/live-query-options.test.ts
+++ b/packages/db/tests/live-query-options.test.ts
@@ -3,8 +3,24 @@ import { createCollection } from '../src/collection/index.js'
 import {
   getLiveQueryHash,
   getPreparedLiveQueryIdentity,
+  prepareLiveQueryValue,
 } from '../src/live-query-options.js'
 import { BaseQueryBuilder } from '../src/query/builder/index.js'
+
+describe(`live query preparation`, () => {
+  it.each([undefined, null])(
+    `promotes a nullish config query result to a disabled query`,
+    (disabled) => {
+      const prepared = prepareLiveQueryValue(
+        { query: () => disabled },
+        undefined,
+        new Set(),
+      )
+
+      expect(prepared).toBe(disabled)
+    },
+  )
+})
 
 describe(`live query identity`, () => {
   it(`hashes Map values in an explicit queryKey deterministically`, () => {

--- a/packages/react-db/skills/react-db/SKILL.md
+++ b/packages/react-db/skills/react-db/SKILL.md
@@ -89,11 +89,13 @@ const { data } = useLiveQuery({
 const { data } = useLiveQuery(preloadedCollection)
 
 // Conditional query — derived identity handles enabled/disabled transitions
-const { data, status } = useLiveQuery((q) => {
-  if (!userId) return undefined
-  return q
-    .from({ todo: todoCollection })
-    .where(({ todo }) => eq(todo.userId, userId))
+const { data, status } = useLiveQuery({
+  query: (q) => {
+    if (!userId) return undefined
+    return q
+      .from({ todo: todoCollection })
+      .where(({ todo }) => eq(todo.userId, userId))
+  },
 })
 // When disabled: status='disabled', data=undefined
 ```

--- a/packages/react-db/src/index.ts
+++ b/packages/react-db/src/index.ts
@@ -1,6 +1,7 @@
 // Re-export all public APIs
 export { useLiveQuery } from './useLiveQuery'
 export type {
+  ConditionalUseLiveQueryConfig,
   LiveQueryKey,
   UseLiveQueryConfig,
   UseLiveQueryStatus,

--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -67,11 +67,11 @@ type ConfiguredQueryBuilder<TContext extends Context> = Extract<
   QueryBuilder<TContext>
 >
 
-export type EnabledUseLiveQueryConfig<TContext extends Context> =
+export type UseLiveQueryConfig<TContext extends Context> =
   UseLiveQueryConfigOptions<TContext> &
     Pick<LiveQueryCollectionConfig<TContext>, `query`>
 
-export type UseLiveQueryConfig<TContext extends Context> =
+export type ConditionalUseLiveQueryConfig<TContext extends Context> =
   UseLiveQueryConfigOptions<TContext> & {
     query:
       | ConfiguredQueryBuilder<TContext>
@@ -506,7 +506,7 @@ export function useLiveQuery<
  */
 // Overload 6: Accept config object
 export function useLiveQuery<TContext extends Context>(
-  config: EnabledUseLiveQueryConfig<TContext>,
+  config: UseLiveQueryConfig<TContext>,
 ): {
   state: Map<string | number, GetResult<TContext>>
   data: InferResultType<TContext>
@@ -522,7 +522,7 @@ export function useLiveQuery<TContext extends Context>(
 
 // Overload 7: Accept config object with a query that can return undefined/null
 export function useLiveQuery<TContext extends Context>(
-  config: UseLiveQueryConfig<TContext>,
+  config: ConditionalUseLiveQueryConfig<TContext>,
 ): {
   state: Map<string | number, GetResult<TContext>> | undefined
   data: InferResultType<TContext> | undefined
@@ -551,6 +551,23 @@ export function useLiveQuery<TContext extends Context>(
   isError: boolean
   isCleanedUp: boolean
   isEnabled: true // Always true when query always returns a builder
+}
+
+// Overload 9: Accept config object with legacy deps and a query that can return undefined/null
+export function useLiveQuery<TContext extends Context>(
+  config: ConditionalUseLiveQueryConfig<TContext>,
+  deps: Array<unknown>,
+): {
+  state: Map<string | number, GetResult<TContext>> | undefined
+  data: InferResultType<TContext> | undefined
+  collection: Collection<GetResult<TContext>, string | number, {}> | undefined
+  status: UseLiveQueryStatus
+  isLoading: boolean
+  isReady: boolean
+  isIdle: boolean
+  isError: boolean
+  isCleanedUp: boolean
+  isEnabled: boolean
 }
 
 /**
@@ -582,7 +599,7 @@ export function useLiveQuery<TContext extends Context>(
  *
  * return <div>{data.map(item => <Item key={item.id} {...item} />)}</div>
  */
-// Overload 9: Accept pre-created live query collection
+// Overload 10: Accept pre-created live query collection
 export function useLiveQuery<
   TResult extends object,
   TKey extends string | number,

--- a/packages/react-db/src/useLiveQuery.ts
+++ b/packages/react-db/src/useLiveQuery.ts
@@ -48,16 +48,36 @@ export type DerivedIdentityProfiler = {
 
 export type UseLiveQueryStatus = CollectionStatus | `disabled`
 export type LiveQueryKey = ReadonlyArray<unknown>
+type UseLiveQueryConfigOptions<TContext extends Context> = Omit<
+  LiveQueryCollectionConfig<TContext>,
+  `query`
+> & {
+  /**
+   * Explicit identity for queries that contain opaque functional variants or
+   * are hot enough that deriving identity from structured IR is too expensive.
+   * Structured queries should omit this so DB can derive identity directly.
+   */
+  queryKey?: LiveQueryKey
+  /** Override the nearest DbProvider for this query. */
+  client?: DbClient
+}
+
+type ConfiguredQueryBuilder<TContext extends Context> = Extract<
+  LiveQueryCollectionConfig<TContext>[`query`],
+  QueryBuilder<TContext>
+>
+
+export type EnabledUseLiveQueryConfig<TContext extends Context> =
+  UseLiveQueryConfigOptions<TContext> &
+    Pick<LiveQueryCollectionConfig<TContext>, `query`>
+
 export type UseLiveQueryConfig<TContext extends Context> =
-  LiveQueryCollectionConfig<TContext> & {
-    /**
-     * Explicit identity for queries that contain opaque functional variants or
-     * are hot enough that deriving identity from structured IR is too expensive.
-     * Structured queries should omit this so DB can derive identity directly.
-     */
-    queryKey?: LiveQueryKey
-    /** Override the nearest DbProvider for this query. */
-    client?: DbClient
+  UseLiveQueryConfigOptions<TContext> & {
+    query:
+      | ConfiguredQueryBuilder<TContext>
+      | ((
+          q: InitialQueryBuilder,
+        ) => ConfiguredQueryBuilder<TContext> | undefined | null)
   }
 
 export function warnDeprecatedDepsArray(
@@ -297,6 +317,16 @@ function createCollectionFromPreparedQuery(value: unknown) {
  * })
  *
  * @example
+ * // Return undefined or null to disable a query
+ * const { data, isEnabled } = useLiveQuery({
+ *   query: (q) => {
+ *     if (!userId) return undefined
+ *     return q.from({ todos: todosCollection })
+ *             .where(({ todos }) => eq(todos.userId, userId))
+ *   },
+ * })
+ *
+ * @example
  * // Join pattern
  * const { data } = useLiveQuery({
  *   query: (q) =>
@@ -476,21 +506,37 @@ export function useLiveQuery<
  */
 // Overload 6: Accept config object
 export function useLiveQuery<TContext extends Context>(
-  config: UseLiveQueryConfig<TContext>,
+  config: EnabledUseLiveQueryConfig<TContext>,
 ): {
   state: Map<string | number, GetResult<TContext>>
   data: InferResultType<TContext>
   collection: Collection<GetResult<TContext>, string | number, {}>
-  status: CollectionStatus // Can't be disabled for config objects
+  status: CollectionStatus // Can't be disabled when query always returns a builder
   isLoading: boolean
   isReady: boolean
   isIdle: boolean
   isError: boolean
   isCleanedUp: boolean
-  isEnabled: true // Always true for config objects
+  isEnabled: true // Always true when query always returns a builder
 }
 
-// Overload 7: Accept config object with legacy deps
+// Overload 7: Accept config object with a query that can return undefined/null
+export function useLiveQuery<TContext extends Context>(
+  config: UseLiveQueryConfig<TContext>,
+): {
+  state: Map<string | number, GetResult<TContext>> | undefined
+  data: InferResultType<TContext> | undefined
+  collection: Collection<GetResult<TContext>, string | number, {}> | undefined
+  status: UseLiveQueryStatus
+  isLoading: boolean
+  isReady: boolean
+  isIdle: boolean
+  isError: boolean
+  isCleanedUp: boolean
+  isEnabled: boolean
+}
+
+// Overload 8: Accept config object with legacy deps
 export function useLiveQuery<TContext extends Context>(
   config: LiveQueryCollectionConfig<TContext>,
   deps?: Array<unknown>,
@@ -498,13 +544,13 @@ export function useLiveQuery<TContext extends Context>(
   state: Map<string | number, GetResult<TContext>>
   data: InferResultType<TContext>
   collection: Collection<GetResult<TContext>, string | number, {}>
-  status: CollectionStatus // Can't be disabled for config objects
+  status: CollectionStatus // Can't be disabled when query always returns a builder
   isLoading: boolean
   isReady: boolean
   isIdle: boolean
   isError: boolean
   isCleanedUp: boolean
-  isEnabled: true // Always true for config objects
+  isEnabled: true // Always true when query always returns a builder
 }
 
 /**
@@ -536,7 +582,7 @@ export function useLiveQuery<TContext extends Context>(
  *
  * return <div>{data.map(item => <Item key={item.id} {...item} />)}</div>
  */
-// Overload 8: Accept pre-created live query collection
+// Overload 9: Accept pre-created live query collection
 export function useLiveQuery<
   TResult extends object,
   TKey extends string | number,
@@ -556,7 +602,7 @@ export function useLiveQuery<
   isEnabled: true // Always true for pre-created live query collections
 }
 
-// Overload 9: Accept pre-created live query collection with singleResult: true
+// Overload 10: Accept pre-created live query collection with singleResult: true
 export function useLiveQuery<
   TResult extends object,
   TKey extends string | number,

--- a/packages/react-db/src/useLiveSuspenseQuery.ts
+++ b/packages/react-db/src/useLiveSuspenseQuery.ts
@@ -3,7 +3,7 @@
 import { useRef } from 'react'
 import { useLiveQuery } from './useLiveQuery'
 import { getLiveQueryResultInfo } from './live-query-internals'
-import type { UseLiveQueryConfig } from './useLiveQuery'
+import type { EnabledUseLiveQueryConfig } from './useLiveQuery'
 import type {
   Collection,
   Context,
@@ -118,7 +118,7 @@ export function useLiveSuspenseQuery<TContext extends Context>(
 
 // Overload 2: Accept config object
 export function useLiveSuspenseQuery<TContext extends Context>(
-  config: UseLiveQueryConfig<TContext>,
+  config: EnabledUseLiveQueryConfig<TContext>,
 ): {
   state: Map<string | number, GetResult<TContext>>
   data: InferResultType<TContext>

--- a/packages/react-db/src/useLiveSuspenseQuery.ts
+++ b/packages/react-db/src/useLiveSuspenseQuery.ts
@@ -3,7 +3,7 @@
 import { useRef } from 'react'
 import { useLiveQuery } from './useLiveQuery'
 import { getLiveQueryResultInfo } from './live-query-internals'
-import type { EnabledUseLiveQueryConfig } from './useLiveQuery'
+import type { UseLiveQueryConfig } from './useLiveQuery'
 import type {
   Collection,
   Context,
@@ -118,7 +118,7 @@ export function useLiveSuspenseQuery<TContext extends Context>(
 
 // Overload 2: Accept config object
 export function useLiveSuspenseQuery<TContext extends Context>(
-  config: EnabledUseLiveQueryConfig<TContext>,
+  config: UseLiveQueryConfig<TContext>,
 ): {
   state: Map<string | number, GetResult<TContext>>
   data: InferResultType<TContext>

--- a/packages/react-db/tests/useLiveQuery.test-d.tsx
+++ b/packages/react-db/tests/useLiveQuery.test-d.tsx
@@ -4,6 +4,7 @@ import { createCollection } from '../../db/src/collection/index'
 import { collectionOptions } from '../../db/src/index'
 import { mockSyncCollectionOptions } from '../../db/tests/utils'
 import {
+  Query,
   createLiveQueryCollection,
   eq,
   liveQueryCollectionOptions,
@@ -17,6 +18,11 @@ import type { DbClient, DehydratedDbState } from '../../db/src/index'
 import type { JSX } from 'react'
 import type { OutputWithVirtual } from '../../db/tests/utils'
 import type { SingleResult } from '../../db/src/types'
+import type { QueryBuilder } from '../../db/src/query/index'
+import type {
+  UseLiveQueryConfig,
+  UseLiveQueryStatus,
+} from '../src/useLiveQuery'
 
 type Person = {
   id: string
@@ -89,6 +95,56 @@ describe(`useLiveQuery type assertions`, () => {
     expectTypeOf(result.current.data).toMatchTypeOf<
       OutputWithVirtual<Person> | undefined
     >()
+  })
+
+  it(`types a conditional findOne config object as disabled-capable`, () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `test-conditional-person-config`,
+        getKey: (person: Person) => person.id,
+        initialData: [],
+      }),
+    )
+    const enabled = null as unknown as boolean
+    const query = new Query()
+      .from({ collection })
+      .where(({ collection: c }) => eq(c.id, `3`))
+      .findOne()
+    type QueryContext =
+      typeof query extends QueryBuilder<infer TContext> ? TContext : never
+    const config: UseLiveQueryConfig<QueryContext> = {
+      queryKey: [collection.id, enabled],
+      query: () => (enabled ? query : undefined),
+    }
+
+    const { result } = renderHook(() => {
+      return useLiveQuery(config)
+    })
+
+    expectTypeOf(result.current.data).toMatchTypeOf<
+      OutputWithVirtual<Person> | undefined
+    >()
+    expectTypeOf(result.current.status).toEqualTypeOf<UseLiveQueryStatus>()
+    expectTypeOf(result.current.isEnabled).toEqualTypeOf<boolean>()
+  })
+
+  it(`rejects a conditional config with a top-level scalar result`, () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `test-conditional-scalar-config`,
+        getKey: (person: Person) => person.id,
+        initialData: [],
+      }),
+    )
+    const enabled = null as unknown as boolean
+
+    useLiveQuery({
+      // @ts-expect-error - top-level scalar results are not supported
+      query: (q) => {
+        if (!enabled) return undefined
+        return q.from({ collection }).select(({ collection: c }) => c.name)
+      },
+    })
   })
 
   it(`should type config object to return query rows without queryKey`, () => {

--- a/packages/react-db/tests/useLiveQuery.test-d.tsx
+++ b/packages/react-db/tests/useLiveQuery.test-d.tsx
@@ -20,9 +20,10 @@ import type { OutputWithVirtual } from '../../db/tests/utils'
 import type { SingleResult } from '../../db/src/types'
 import type { QueryBuilder } from '../../db/src/query/index'
 import type {
+  ConditionalUseLiveQueryConfig,
   UseLiveQueryConfig,
   UseLiveQueryStatus,
-} from '../src/useLiveQuery'
+} from '../src/index'
 
 type Person = {
   id: string
@@ -112,7 +113,7 @@ describe(`useLiveQuery type assertions`, () => {
       .findOne()
     type QueryContext =
       typeof query extends QueryBuilder<infer TContext> ? TContext : never
-    const config: UseLiveQueryConfig<QueryContext> = {
+    const config: ConditionalUseLiveQueryConfig<QueryContext> = {
       queryKey: [collection.id, enabled],
       query: () => (enabled ? query : undefined),
     }
@@ -120,6 +121,55 @@ describe(`useLiveQuery type assertions`, () => {
     const { result } = renderHook(() => {
       return useLiveQuery(config)
     })
+
+    expectTypeOf(result.current.data).toMatchTypeOf<
+      OutputWithVirtual<Person> | undefined
+    >()
+    expectTypeOf(result.current.status).toEqualTypeOf<UseLiveQueryStatus>()
+    expectTypeOf(result.current.isEnabled).toEqualTypeOf<boolean>()
+  })
+
+  it(`accepts an annotated enabled config in useLiveSuspenseQuery`, () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `test-annotated-suspense-config`,
+        getKey: (person: Person) => person.id,
+        initialData: [],
+      }),
+    )
+    const query = new Query().from({ collection })
+    type QueryContext =
+      typeof query extends QueryBuilder<infer TContext> ? TContext : never
+    const config: UseLiveQueryConfig<QueryContext> = {
+      query: () => query,
+    }
+
+    const { result } = renderHook(() => useLiveSuspenseQuery(config))
+
+    expectTypeOf(result.current.data).toMatchTypeOf<
+      Array<OutputWithVirtual<Person>>
+    >()
+  })
+
+  it(`types a conditional config with deprecated dependencies`, () => {
+    const collection = createCollection(
+      mockSyncCollectionOptions<Person>({
+        id: `test-conditional-config-deps`,
+        getKey: (person: Person) => person.id,
+        initialData: [],
+      }),
+    )
+    const enabled = null as unknown as boolean
+
+    const { result } = renderHook(() =>
+      useLiveQuery(
+        {
+          query: (q) =>
+            enabled ? q.from({ collection }).findOne() : undefined,
+        },
+        [enabled],
+      ),
+    )
 
     expectTypeOf(result.current.data).toMatchTypeOf<
       OutputWithVirtual<Person> | undefined

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -1981,7 +1981,76 @@ describe(`Query Collections`, () => {
     })
   })
 
-  describe(`callback variants with conditional returns`, () => {
+  describe(`conditional returns`, () => {
+    it(`disables a config query that returns undefined`, async () => {
+      const collection = createCollection(
+        mockSyncCollectionOptions<Person>({
+          id: `undefined-config-query-test`,
+          getKey: (person: Person) => person.id,
+          initialData: initialPersons,
+        }),
+      )
+
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          useLiveQuery({
+            query: (q) => {
+              if (!enabled) return undefined
+              return q
+                .from({ persons: collection })
+                .where(({ persons }) => gt(persons.age, 30))
+            },
+          }),
+        { initialProps: { enabled: false } },
+      )
+
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.collection).toBeUndefined()
+      expect(result.current.status).toBe(`disabled`)
+      expect(result.current.isEnabled).toBe(false)
+      expect(result.current.isReady).toBe(true)
+
+      rerender({ enabled: true })
+
+      await waitFor(() => expect(result.current.data).toHaveLength(1))
+      expect(result.current.status).toBe(`ready`)
+      expect(result.current.isEnabled).toBe(true)
+
+      rerender({ enabled: false })
+
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.collection).toBeUndefined()
+      expect(result.current.status).toBe(`disabled`)
+      expect(result.current.isEnabled).toBe(false)
+      expect(result.current.isReady).toBe(true)
+    })
+
+    it(`disables a config query that returns null`, () => {
+      const collection = createCollection(
+        mockSyncCollectionOptions<Person>({
+          id: `null-config-query-test`,
+          getKey: (person: Person) => person.id,
+          initialData: initialPersons,
+        }),
+      )
+
+      const { result } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          useLiveQuery({
+            query: (q) => {
+              if (!enabled) return null
+              return q.from({ persons: collection })
+            },
+          }),
+        { initialProps: { enabled: false } },
+      )
+
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.collection).toBeUndefined()
+      expect(result.current.status).toBe(`disabled`)
+      expect(result.current.isEnabled).toBe(false)
+    })
+
     it(`should handle callback returning undefined without a dependency array`, async () => {
       const collection = createCollection(
         mockSyncCollectionOptions<Person>({

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -2051,6 +2051,48 @@ describe(`Query Collections`, () => {
       expect(result.current.isEnabled).toBe(false)
     })
 
+    it(`disables a config query with deprecated dependencies`, async () => {
+      const warnSpy = vi.spyOn(console, `warn`).mockImplementation(() => {})
+      const collection = createCollection(
+        mockSyncCollectionOptions<Person>({
+          id: `conditional-config-deps-test`,
+          getKey: (person: Person) => person.id,
+          initialData: initialPersons,
+        }),
+      )
+
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          useLiveQuery(
+            {
+              query: (q) => {
+                if (!enabled) return undefined
+                return q
+                  .from({ persons: collection })
+                  .where(({ persons }) => gt(persons.age, 30))
+              },
+            },
+            [enabled],
+          ),
+        { initialProps: { enabled: false } },
+      )
+
+      expect(result.current.status).toBe(`disabled`)
+      expect(result.current.isEnabled).toBe(false)
+
+      rerender({ enabled: true })
+
+      await waitFor(() => expect(result.current.data).toHaveLength(1))
+      expect(result.current.status).toBe(`ready`)
+      expect(result.current.isEnabled).toBe(true)
+
+      rerender({ enabled: false })
+
+      expect(result.current.status).toBe(`disabled`)
+      expect(result.current.isEnabled).toBe(false)
+      warnSpy.mockRestore()
+    })
+
     it(`should handle callback returning undefined without a dependency array`, async () => {
       const collection = createCollection(
         mockSyncCollectionOptions<Person>({

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -2093,6 +2093,57 @@ describe(`Query Collections`, () => {
       warnSpy.mockRestore()
     })
 
+    it(`stays disabled when the prior query becomes ready`, async () => {
+      let finishSync: (() => void) | undefined
+      const collection = createCollection<Person>({
+        id: `conditional-config-pending-sync-test`,
+        getKey: (person) => person.id,
+        sync: {
+          sync: ({ begin, write, commit, markReady }) => {
+            finishSync = () => {
+              begin()
+              write({ type: `insert`, value: initialPersons[2]! })
+              commit()
+              markReady()
+            }
+          },
+        },
+        onInsert: async () => {},
+        onUpdate: async () => {},
+        onDelete: async () => {},
+      })
+
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          useLiveQuery({
+            query: (q) => {
+              if (!enabled) return undefined
+              return q
+                .from({ persons: collection })
+                .where(({ persons }) => gt(persons.age, 30))
+            },
+          }),
+        { initialProps: { enabled: true } },
+      )
+
+      await waitFor(() => expect(finishSync).toBeDefined())
+      expect(result.current.isLoading).toBe(true)
+
+      rerender({ enabled: false })
+      expect(result.current.status).toBe(`disabled`)
+
+      await act(async () => {
+        finishSync!()
+        await Promise.resolve()
+      })
+
+      expect(collection.status).toBe(`ready`)
+      expect(collection.state.size).toBe(1)
+      expect(result.current.status).toBe(`disabled`)
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.collection).toBeUndefined()
+    })
+
     it(`should handle callback returning undefined without a dependency array`, async () => {
       const collection = createCollection(
         mockSyncCollectionOptions<Person>({


### PR DESCRIPTION
Allow `useLiveQuery({ query })` callbacks to return `undefined` or `null`. Config-based queries can now use the same enabled/disabled pattern as the top-level callback form, with correct runtime state and TypeScript inference.

## Root cause

The config-object path invoked its `query` callback but always returned the surrounding config object. A nullish callback result therefore became `{ query: undefined }` or `{ query: null }` instead of the top-level nullish value used to mark a query as disabled. The React overloads also required config callbacks to return a builder, so valid conditional configs failed type checking before they reached that runtime path.

## Approach

- Promote a nullish result from a config `query` callback to the prepared query value itself.
- Add and export `ConditionalUseLiveQueryConfig` for disabled-capable configs while preserving the existing enabled-only meaning of `UseLiveQueryConfig`.
- Add conditional config overloads for both the standard call and the retained dependency-array form.
- Keep precise non-optional results for enabled configs and `useLiveSuspenseQuery`.
- Preserve the query builder's root-object result constraint.
- Document the config syntax and its disabled snapshot state.

## Key invariants

- Each config callback is evaluated once during preparation.
- `undefined` and `null` both disable the query.
- A callback that always returns a builder keeps the existing enabled-only return type.
- A separately annotated `UseLiveQueryConfig` remains accepted by `useLiveSuspenseQuery`.
- Conditional configs work with the retained dependency-array overload until it is removed in 1.0.
- Conditional configs retain derived identity across disable, enable, and disable transitions when no `queryKey` is supplied.
- Top-level scalar query results remain rejected by TypeScript.

## Non-goals

- This does not remove or change the top-level callback form.
- This does not add conditional queries to `useLiveSuspenseQuery`; suspense keeps the enabled-only config type.
- This does not change explicit `queryKey` behavior.

## Trade-offs

Preserving `UseLiveQueryConfig` as enabled-only avoids a source-breaking change for reusable suspense configs. Conditional wrappers can use the new exported `ConditionalUseLiveQueryConfig` type. This adds a public type and an overload, but keeps the patch release compatible and preserves precise enabled results.

## Verification

```bash
cd packages/db
../../node_modules/.bin/vitest run tests/live-query-options.test.ts --coverage.enabled=false --pool-options.threads.maxThreads=2

cd ../react-db
../../node_modules/.bin/vitest run tests/useLiveQuery.test.tsx --coverage.enabled=false --pool-options.threads.maxThreads=2
../../node_modules/.bin/vitest typecheck tests/useLiveQuery.test-d.tsx --run --coverage.enabled=false --pool-options.threads.maxThreads=2
pnpm build
```

The React hook test file passes 54/54, the public type suite passes 16/16, and the affected package build and lint checks pass.

## Files changed

- `packages/db/src/live-query-options.ts`: propagate nullish config callback results as disabled queries.
- `packages/db/tests/live-query-options.test.ts`: cover config query preparation for `undefined` and `null`.
- `packages/react-db/src/useLiveQuery.ts`: add the conditional config type and standard/legacy overloads while preserving enabled config compatibility.
- `packages/react-db/src/useLiveSuspenseQuery.ts`: retain the public enabled-only config contract.
- `packages/react-db/src/index.ts`: export `ConditionalUseLiveQueryConfig`.
- `packages/react-db/tests/useLiveQuery.test.tsx`: cover disabled configs, derived-identity transitions, and the dependency-array compatibility path.
- `packages/react-db/tests/useLiveQuery.test-d.tsx`: cover conditional `findOne` inference, annotated suspense configs, dependency-array configs, and scalar rejection.
- `docs/guides/live-queries.md` and `packages/react-db/skills/react-db/SKILL.md`: document conditional config syntax and state.
- `.changeset/support-conditional-live-query-configs.md`: publish patch releases for `@tanstack/db` and `@tanstack/react-db`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live queries can now be conditionally disabled by returning `undefined` or `null` from a query callback.
  * Disabled queries report `disabled` status, undefined data, and appropriate readiness and enabled-state values.
  * Added public typing support for conditional live-query configurations.
* **Documentation**
  * Updated live-query guides and examples to demonstrate conditional configuration and disabled-query behavior.
* **Bug Fixes**
  * Improved support for enabling and disabling queries across current and legacy configuration styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
