### PR TITLE
fix(db): reject query values from fn.select

### DIFF
--- a/.changeset/reject-fn-select-query-values.md
+++ b/.changeset/reject-fn-select-query-values.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Reject child query builders and query-construction helpers returned from `fn.select()` with type and runtime errors instead of exposing internal query objects.

--- a/docs/guides/live-queries.md
+++ b/docs/guides/live-queries.md
@@ -1330,6 +1330,8 @@ The singleton vs. array result type is inferred from whether the wrapped query e
 
 Like `toArray()`, `materialize()` is only valid as a top-level value in `.select()` — it cannot be nested inside expression helpers such as `coalesce()` or `eq()`.
 
+Do not return child queries, `toArray()`, `materialize()`, or query expressions such as `eq()` and `caseWhen()` from `.fn.select()`. Functional select callbacks run after the compiler builds the query graph, so they cannot add query operations to it.
+
 ### Aggregates
 
 You can use aggregate functions in child queries. Aggregates are computed per parent:

--- a/packages/db/src/errors.ts
+++ b/packages/db/src/errors.ts
@@ -481,6 +481,16 @@ export class FnSelectWithGroupByError extends QueryCompilationError {
   }
 }
 
+export class UnsupportedFnSelectResultError extends QueryCompilationError {
+  constructor(valueDescription: string) {
+    super(
+      `fn.select() cannot return ${valueDescription}. ` +
+        `Child query builders, query expressions, and helpers such as eq(), toArray(), materialize(), concat(toArray()), and caseWhen() are query-construction values. ` +
+        `Use them as direct fields in .select() instead.`,
+    )
+  }
+}
+
 export class UnsupportedRootScalarSelectError extends QueryCompilationError {
   constructor() {
     super(

--- a/packages/db/src/query/builder/index.ts
+++ b/packages/db/src/query/builder/index.ts
@@ -81,6 +81,57 @@ type CollectionResolver = (
   options: CollectionOptionsIdentity<any, string | number, any, any, any>,
 ) => CollectionImpl<any, string | number, any, any, any>
 
+type FnSelectQueryConstructionValue =
+  | QueryBuilder<any>
+  | InitialQueryBuilder
+  | BasicExpression
+  | Aggregate
+  | ToArrayWrapper<any>
+  | ConcatToArrayWrapper<any>
+  | MaterializeWrapper<any, boolean>
+  | CaseWhenWrapper<any>
+
+type IsAnyType<T> = 0 extends 1 & T ? true : false
+
+// Bound recursive inspection so deeply recursive result types do not exceed
+// TypeScript's instantiation limit. The runtime check has no depth limit.
+type ContainsFnSelectQueryConstructionValue<
+  T,
+  TDepth extends ReadonlyArray<unknown> = [],
+> =
+  IsAnyType<T> extends true
+    ? false
+    : T extends FnSelectQueryConstructionValue
+      ? true
+      : TDepth[`length`] extends 8
+        ? false
+        : T extends (...args: Array<any>) => any
+          ? false
+          : T extends ReadonlyArray<infer TItem>
+            ? ContainsFnSelectQueryConstructionValue<
+                TItem,
+                [...TDepth, unknown]
+              >
+            : T extends object
+              ? true extends {
+                  [K in keyof T]-?: ContainsFnSelectQueryConstructionValue<
+                    T[K],
+                    [...TDepth, unknown]
+                  >
+                }[keyof T]
+                ? true
+                : false
+              : false
+
+type InvalidFnSelectResult = {
+  readonly __tanstackDbFnSelectResultError__: `fn.select() cannot return child query builders, query expressions, or query helpers. Use them as direct fields in .select() instead.`
+}
+
+type FnSelectQueryResult<TContext extends Context, TResult> =
+  true extends ContainsFnSelectQueryConstructionValue<TResult>
+    ? InvalidFnSelectResult
+    : QueryBuilder<WithResult<TContext, TResult>>
+
 export class BaseQueryBuilder<TContext extends Context = Context> {
   private readonly query: Partial<QueryIR> = {}
 
@@ -889,10 +940,15 @@ export class BaseQueryBuilder<TContext extends Context = Context> {
        *     age: row.users.age + 1,
        *   }))
        * ```
+       *
+       * Child query builders, query expressions, and helpers such as eq(),
+       * toArray(), and materialize() cannot be returned from fn.select(). Use
+       * them as fields in select() so the compiler can add them to the query
+       * graph.
        */
       select<TFuncSelectResult>(
         callback: (row: TContext[`schema`]) => TFuncSelectResult,
-      ): QueryBuilder<WithResult<TContext, TFuncSelectResult>> {
+      ): FnSelectQueryResult<TContext, TFuncSelectResult> {
         return builder._clone({
           ...builder.query,
           select: undefined, // remove the select clause if it exists

--- a/packages/db/src/query/compiler/index.ts
+++ b/packages/db/src/query/compiler/index.ts
@@ -16,9 +16,17 @@ import {
   FnSelectWithGroupByError,
   HavingRequiresGroupByError,
   LimitOffsetRequireOrderByError,
+  UnsupportedFnSelectResultError,
   UnsupportedFromTypeError,
 } from '../../errors.js'
 import { VIRTUAL_PROP_NAMES } from '../../virtual-props.js'
+import { BaseQueryBuilder } from '../builder/index.js'
+import {
+  CaseWhenWrapper,
+  ConcatToArrayWrapper,
+  MaterializeWrapper,
+  ToArrayWrapper,
+} from '../builder/functions.js'
 import {
   ConditionalSelect,
   IncludesSubquery,
@@ -68,6 +76,52 @@ export const INCLUDES_ROUTING = Symbol(`includesRouting`)
 export const INCLUDES_PUBLIC_KEY = Symbol(`includesPublicKey`)
 export const FN_SELECT_STATE = Symbol(`fnSelectState`)
 const SKIP_INCLUDE = Symbol(`skipInclude`)
+
+function getUnsupportedFnSelectResultDescription(
+  value: unknown,
+  seen: Set<object> = new Set(),
+): string | undefined {
+  if (value instanceof BaseQueryBuilder) return `a child query builder`
+  if (value instanceof ToArrayWrapper) return `toArray()`
+  if (value instanceof ConcatToArrayWrapper) return `concat(toArray())`
+  if (value instanceof MaterializeWrapper) return `materialize()`
+  if (value instanceof CaseWhenWrapper) return `caseWhen()`
+  if (isExpressionLike(value)) {
+    return value &&
+      typeof value === `object` &&
+      `name` in value &&
+      typeof value.name === `string`
+      ? `${value.name}()`
+      : `a query expression`
+  }
+  if (value === null || typeof value !== `object` || seen.has(value)) {
+    return undefined
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (
+    !Array.isArray(value) &&
+    prototype !== Object.prototype &&
+    prototype !== null
+  ) {
+    return undefined
+  }
+
+  seen.add(value)
+  for (const entry of Object.values(value)) {
+    const unsupported = getUnsupportedFnSelectResultDescription(entry, seen)
+    if (unsupported) return unsupported
+  }
+  return undefined
+}
+
+export function validateFnSelectResult(value: unknown): void {
+  const unsupportedValueDescription =
+    getUnsupportedFnSelectResultDescription(value)
+  if (unsupportedValueDescription) {
+    throw new UnsupportedFnSelectResultError(unsupportedValueDescription)
+  }
+}
 
 type ConditionalSelectGuard = {
   condition: BasicExpression
@@ -785,6 +839,7 @@ export function compileQuery(
     pipeline = pipeline.pipe(
       map(([key, namespacedRow]) => {
         const selectResults = query.fnSelect!(namespacedRow)
+        validateFnSelectResult(selectResults)
         let selected = selectResults
         if (selectResults && typeof selectResults === `object`) {
           selected = Array.isArray(selectResults)

--- a/packages/db/src/query/compiler/index.ts
+++ b/packages/db/src/query/compiler/index.ts
@@ -98,17 +98,15 @@ function getUnsupportedFnSelectResultDescription(
     return undefined
   }
 
-  const prototype = Object.getPrototypeOf(value)
-  if (
-    !Array.isArray(value) &&
-    prototype !== Object.prototype &&
-    prototype !== null
-  ) {
-    return undefined
-  }
-
   seen.add(value)
-  for (const entry of Object.values(value)) {
+  const keys = [
+    ...Object.keys(value),
+    ...Object.getOwnPropertySymbols(value).filter((key) =>
+      Object.prototype.propertyIsEnumerable.call(value, key),
+    ),
+  ]
+  for (const key of keys) {
+    const entry = (value as Record<PropertyKey, unknown>)[key]
     const unsupported = getUnsupportedFnSelectResultDescription(entry, seen)
     if (unsupported) return unsupported
   }

--- a/packages/db/src/query/live/materialized-pipeline.ts
+++ b/packages/db/src/query/live/materialized-pipeline.ts
@@ -7,7 +7,11 @@ import {
   reduce,
   serializeValue,
 } from '@tanstack/db-ivm'
-import { FN_SELECT_STATE, INCLUDES_ROUTING } from '../compiler/index.js'
+import {
+  FN_SELECT_STATE,
+  INCLUDES_ROUTING,
+  validateFnSelectResult,
+} from '../compiler/index.js'
 import { VIRTUAL_PROP_NAMES } from '../../virtual-props.js'
 import { deepEquals } from '../../utils.js'
 import type {
@@ -492,6 +496,7 @@ function setMaterializedInclude(
 
   const sourceRow = setNestedValue(state.sourceRow, path, materialized)
   const selectedValue = state.fnSelect(sourceRow)
+  validateFnSelectResult(selectedValue)
   if (!selectedValue || typeof selectedValue !== `object`) {
     throw new Error(`fn.select must return an object when it projects includes`)
   }

--- a/packages/db/tests/query/functional-variants.test-d.ts
+++ b/packages/db/tests/query/functional-variants.test-d.ts
@@ -1,9 +1,13 @@
 import { describe, expectTypeOf, test } from 'vitest'
 import {
+  Query,
+  caseWhen,
   count,
   createLiveQueryCollection,
   eq,
   gt,
+  materialize,
+  toArray,
 } from '../../src/query/index.js'
 import { createCollection } from '../../src/collection/index.js'
 import { mockSyncCollectionOptions } from '../utils.js'
@@ -142,6 +146,60 @@ describe(`Functional Variants Types`, () => {
         }>
       >
     >()
+  })
+
+  test(`fn.select rejects child queries and materialization helpers`, () => {
+    // @ts-expect-error query helpers are only supported in select()
+    createLiveQueryCollection((q) =>
+      q.from({ user: usersCollection }).fn.select((row) => ({
+        id: row.user.id,
+        nested: {
+          departments: toArray(q.from({ department: departmentsCollection })),
+        },
+      })),
+    )
+
+    // @ts-expect-error materialize() is only supported in select()
+    createLiveQueryCollection((q) =>
+      q.from({ user: usersCollection }).fn.select((row) => ({
+        id: row.user.id,
+        departments: materialize(q.from({ department: departmentsCollection })),
+      })),
+    )
+
+    // @ts-expect-error child query builders are only supported in select()
+    createLiveQueryCollection((q) =>
+      q.from({ user: usersCollection }).fn.select((row) => ({
+        id: row.user.id,
+        departments: q.from({ department: departmentsCollection }),
+      })),
+    )
+
+    // @ts-expect-error query expressions are only supported in select()
+    createLiveQueryCollection((q) =>
+      q.from({ user: usersCollection }).fn.select((row) => ({
+        id: row.user.id,
+        active: eq(row.user.active, true),
+      })),
+    )
+
+    // @ts-expect-error caseWhen() is only supported in select()
+    createLiveQueryCollection((q) =>
+      q.from({ user: usersCollection }).fn.select((row) => ({
+        id: row.user.id,
+        label: caseWhen(eq(row.user.active, true), `active`, `inactive`),
+      })),
+    )
+  })
+
+  test(`fn.select accepts unresolved generic result types`, () => {
+    const query = new Query().from({ user: usersCollection })
+
+    function selectValue<T>(value: T) {
+      return query.fn.select(() => value)
+    }
+
+    selectValue({ label: `active` })
   })
 
   test(`fn.where with filtered original type`, () => {

--- a/packages/db/tests/query/functional-variants.test.ts
+++ b/packages/db/tests/query/functional-variants.test.ts
@@ -285,6 +285,40 @@ describe(`Functional Variants Query`, () => {
         }),
       ).toThrow(`fn.select() cannot return a child query builder`)
 
+      class Wrapper {
+        constructor(readonly departments: unknown) {}
+      }
+
+      expect(() =>
+        createLiveQueryCollection({
+          startSync: true,
+          query: (q) =>
+            q
+              .from({ user: usersCollection })
+              .fn.select(
+                () =>
+                  new Wrapper(
+                    q.from({ department: departmentsCollection }),
+                  ) as any,
+              ),
+        }),
+      ).toThrow(`fn.select() cannot return a child query builder`)
+
+      const departments = Symbol(`departments`)
+      expect(() =>
+        createLiveQueryCollection({
+          startSync: true,
+          query: (q) =>
+            q.from({ user: usersCollection }).fn.select(
+              (row) =>
+                ({
+                  id: row.user.id,
+                  [departments]: q.from({ department: departmentsCollection }),
+                }) as any,
+            ),
+        }),
+      ).toThrow(`fn.select() cannot return a child query builder`)
+
       expect(() =>
         createLiveQueryCollection({
           startSync: true,

--- a/packages/db/tests/query/functional-variants.test.ts
+++ b/packages/db/tests/query/functional-variants.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, test } from 'vitest'
 import {
+  caseWhen,
   count,
   createLiveQueryCollection,
   eq,
   gt,
+  materialize,
+  toArray,
 } from '../../src/query/index.js'
 import { createCollection } from '../../src/collection/index.js'
 import { mockSyncCollectionOptions, stripVirtualProps } from '../utils.js'
@@ -218,6 +221,101 @@ describe(`Functional Variants Query`, () => {
         isHighEarner: false,
         yearsToRetirement: 37,
       })
+    })
+
+    test(`rejects query-construction values returned from fn.select`, () => {
+      const departmentsCollection = createDepartmentsCollection()
+
+      expect(() =>
+        createLiveQueryCollection({
+          startSync: true,
+          query: (q) => {
+            const users = q.from({ user: usersCollection })
+            const departments = q.from({ department: departmentsCollection })
+
+            return users.fn.select(
+              (row) =>
+                ({
+                  id: row.user.id,
+                  nested: {
+                    departments: toArray(
+                      q.from({
+                        department: departments.fn.where(
+                          ({ department }) =>
+                            row.user.department_id === department.id,
+                        ),
+                      }),
+                    ),
+                  },
+                }) as any,
+            )
+          },
+        }),
+      ).toThrow(
+        `fn.select() cannot return toArray(). Child query builders, query expressions, and helpers`,
+      )
+
+      expect(() =>
+        createLiveQueryCollection({
+          startSync: true,
+          query: (q) =>
+            q.from({ user: usersCollection }).fn.select(
+              (row) =>
+                ({
+                  id: row.user.id,
+                  departments: materialize(
+                    q.from({ department: departmentsCollection }),
+                  ),
+                }) as any,
+            ),
+        }),
+      ).toThrow(`fn.select() cannot return materialize()`)
+
+      expect(() =>
+        createLiveQueryCollection({
+          startSync: true,
+          query: (q) =>
+            q.from({ user: usersCollection }).fn.select(
+              (row) =>
+                ({
+                  id: row.user.id,
+                  departments: q.from({ department: departmentsCollection }),
+                }) as any,
+            ),
+        }),
+      ).toThrow(`fn.select() cannot return a child query builder`)
+
+      expect(() =>
+        createLiveQueryCollection({
+          startSync: true,
+          query: (q) =>
+            q.from({ user: usersCollection }).fn.select(
+              (row) =>
+                ({
+                  id: row.user.id,
+                  active: eq(row.user.active, true),
+                }) as any,
+            ),
+        }),
+      ).toThrow(`fn.select() cannot return eq()`)
+
+      expect(() =>
+        createLiveQueryCollection({
+          startSync: true,
+          query: (q) =>
+            q.from({ user: usersCollection }).fn.select(
+              (row) =>
+                ({
+                  id: row.user.id,
+                  label: caseWhen(
+                    eq(row.user.active, true),
+                    `active`,
+                    `inactive`,
+                  ),
+                }) as any,
+            ),
+        }),
+      ).toThrow(`fn.select() cannot return caseWhen()`)
     })
   })
 

--- a/packages/db/tests/query/group-by.test.ts
+++ b/packages/db/tests/query/group-by.test.ts
@@ -2224,11 +2224,14 @@ function createGroupByTests(autoIndex: `off` | `eager`): void {
               q
                 .from({ orders: ordersCollection })
                 .groupBy(({ orders }) => orders.customer_id)
-                .fn.select((row) => ({
-                  customerId: row.orders.customer_id,
-                  totalAmount: sum(row.orders.amount),
-                  orderCount: count(row.orders.id),
-                })),
+                .fn.select(
+                  (row) =>
+                    ({
+                      customerId: row.orders.customer_id,
+                      totalAmount: sum(row.orders.amount),
+                      orderCount: count(row.orders.id),
+                    }) as any,
+                ),
           }),
         ).toThrow(`fn.select() cannot be used with groupBy()`)
       })

--- a/packages/db/tests/query/includes-collection-oracle.property.test.ts
+++ b/packages/db/tests/query/includes-collection-oracle.property.test.ts
@@ -858,6 +858,77 @@ describe(`Collection-valued includes oracle`, () => {
   )
 
   fcTest(
+    `fn.select rejects query values returned during include rematerialization`,
+    async () => {
+      const messages = createControlledCollection(`fn-select-reject-messages`, [
+        { id: 1, group: 1 },
+      ])
+      const tools = createControlledCollection(`fn-select-reject-tools`, [
+        { id: 2, group: 2 },
+      ])
+      const children = createControlledCollection(`fn-select-reject-children`, [
+        { id: 10, parentGroup: 1, value: 1 },
+      ])
+      const live = createLiveQueryCollection((q) => {
+        const messageRows = q
+          .from({ message: messages.collection })
+          .select(({ message }) => ({
+            kind: `message` as const,
+            id: message.id,
+            children: toArray(
+              q
+                .from({ messageChild: children.collection })
+                .where(({ messageChild }) =>
+                  eq(messageChild.parentGroup, message.group),
+                ),
+            ),
+          }))
+        const toolRows = q
+          .from({ tool: tools.collection })
+          .select(({ tool }) => ({
+            kind: `tool` as const,
+            id: tool.id,
+          }))
+
+        return q.unionAll(messageRows, toolRows).fn.select((row) => {
+          const includedChildren =
+            row.kind === `message`
+              ? (row.children as typeof row.children | null)
+              : null
+
+          return {
+            kind: row.kind,
+            id: row.id,
+            leakedQuery:
+              includedChildren?.[0]?.value === 2
+                ? q.from({ child: children.collection })
+                : null,
+          } as any
+        })
+      })
+
+      try {
+        await live.preload()
+
+        expect(() =>
+          children.write(`update`, {
+            id: 10,
+            parentGroup: 1,
+            value: 2,
+          }),
+        ).toThrow(`fn.select() cannot return a child query builder`)
+      } finally {
+        await Promise.all([
+          live.cleanup(),
+          messages.collection.cleanup(),
+          tools.collection.cleanup(),
+          children.collection.cleanup(),
+        ])
+      }
+    },
+  )
+
+  fcTest(
     `rejects collapsed contributors that disagree by value, order, or outgoing route`,
     async () => {
       type CommentRow = {


### PR DESCRIPTION
Returning a child query, query expression, or materialization helper from `.fn.select()` now fails with a clear type or runtime error instead of exposing TanStack DB internal query objects as row data. The error directs users to declarative `.select()`, where the compiler can add those values to the query graph.

## Root Cause

`.fn.select()` is an opaque callback that runs after the compiler has built the query graph. Query builders and helpers such as `eq()`, `toArray()`, `materialize()`, and `caseWhen()` describe graph construction; they are not materialized data. The functional projection path shallow-copied callback results without validating them, so these objects could reach public live-query rows. Functional projections can also run again when a union branch rematerializes an include, which created a second leak path.

## Approach

- Classify query builders, expressions, aggregates, and materialization wrappers as invalid functional-select results at the type level.
- Preserve generic `.fn.select()` helpers by placing the diagnostic in the returned type instead of constraining the callback parameter.
- Add a cycle-safe runtime validator for JavaScript and explicitly widened results. Apply it both during normal functional projection and include rematerialization.
- Add a dedicated `UnsupportedFnSelectResultError` with the detected helper name when available.
- Document the boundary between `.select()` and `.fn.select()` and add a patch changeset.

## Key Invariants

- Query-construction values never become public row data through `.fn.select()`.
- Every runtime invocation of the functional projection uses the same validation, including include rematerialization.
- Concrete invalid return types surface a useful TypeScript diagnostic, while unresolved generic result types remain valid.
- The fix does not alter the compiled materialization graph or valid functional projection results.

## Non-goals

- This does not add nested-query or materialization support to `.fn.select()`.
- This does not expand correlated include semantics. Callers must express child queries as direct fields in declarative `.select()`.

## Trade-offs

The runtime validator recursively inspects arrays and plain objects so JavaScript callers and values widened through `any` receive the same error. Type-level recursion is capped at eight levels to avoid TypeScript instantiation-limit failures; runtime validation remains unbounded and cycle-safe.

## Verification

Run from `packages/db`:

```bash
pnpm vitest run --pool-options.threads.maxThreads=2 tests/query/functional-variants.test.ts tests/query/group-by.test.ts tests/query/includes-collection-oracle.property.test.ts
pnpm vitest run --pool-options.threads.maxThreads=2 --typecheck.only tests/query/functional-variants.test-d.ts
pnpm exec eslint src/errors.ts src/query/builder/index.ts src/query/compiler/index.ts src/query/live/materialized-pipeline.ts tests/query/functional-variants.test-d.ts tests/query/functional-variants.test.ts tests/query/group-by.test.ts tests/query/includes-collection-oracle.property.test.ts
```

The runtime suite passed 139 tests. The type suite passed 19 tests. ESLint, the focused rematerialization regression, `git diff --check`, and `pnpm changeset status --since=origin/main` also passed.

## Files changed

- `.changeset/reject-fn-select-query-values.md` records the `@tanstack/db` patch.
- `docs/guides/live-queries.md` documents unsupported `.fn.select()` return values.
- `packages/db/src/errors.ts` adds the targeted public error.
- `packages/db/src/query/builder/index.ts` adds type-level detection while preserving generic callbacks.
- `packages/db/src/query/compiler/index.ts` validates runtime functional projection results.
- `packages/db/src/query/live/materialized-pipeline.ts` applies the same validation during include rematerialization.
- `packages/db/tests/query/functional-variants.test-d.ts` covers invalid values and generic compatibility.
- `packages/db/tests/query/functional-variants.test.ts` covers runtime query builders, expressions, and helpers.
- `packages/db/tests/query/group-by.test.ts` preserves the existing runtime group-by diagnostic test under the stricter types.
- `packages/db/tests/query/includes-collection-oracle.property.test.ts` covers the rematerialization path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `fn.select()` now rejects unsupported query builders, query expressions, and query helpers with clear type and runtime errors.
  * Added validation for nested and materialized query results, including during live-query updates.
  * Improved error handling for unsupported values returned by functional selections.

* **Documentation**
  * Clarified supported and unsupported values for `.fn.select()` callbacks and where query-building helpers should be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->