### PR TITLE
fix(db): reuse collection descriptors by id

### DIFF
--- a/.changeset/fix-db-client-descriptor-identity.md
+++ b/.changeset/fix-db-client-descriptor-identity.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Reuse materialized collections when new collection descriptors have the same id. This lets callers recreate dynamic descriptors without creating duplicate collections.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -138,33 +138,19 @@ function createProjectTodosDescriptor(
 }
 ```
 
-The scope is part of the descriptor identity. Memoize descriptors by a stable
-scope key; `DbClient` handles collection memoization and QueryClient ownership:
+The scope is part of the descriptor identity. `DbClient` resolves separately
+created descriptors with the same id to the same collection, so a React hook
+can create the descriptor from its current parameters:
 
 ```typescript
-type ProjectTodosDescriptor = ReturnType<typeof createProjectTodosDescriptor>
-
-const projectDescriptors = new Map<string, ProjectTodosDescriptor>()
-
-export function getProjectTodosDescriptor(
-  projectId: string,
-): ProjectTodosDescriptor {
-  let descriptor = projectDescriptors.get(projectId)
-  if (!descriptor) {
-    descriptor = createProjectTodosDescriptor(projectId)
-    projectDescriptors.set(projectId, descriptor)
-  }
-  return descriptor
+export function useProjectTodos(projectId: string) {
+  return useDbClient().collection(createProjectTodosDescriptor(projectId))
 }
-
-const todos = dbClient.collection(getProjectTodosDescriptor(projectId))
 ```
 
-For multiple scope values, use nested maps or a collision-safe stable key that
-includes every value. Do not create a descriptor on each render. In a
-long-lived app, user-selected scopes can make the map grow without bound; remove
-unused descriptors and call `await dbClient.cleanup()` when the client scope
-ends. Request-local maps can be discarded with the request.
+Only the first descriptor for an id is materialized. Include every scope value
+that changes the collection in both its descriptor id and Query key. Call
+`await dbClient.cleanup()` when the client scope ends.
 
 A business scope is separate from a **relational subset** requested by a live query. With `syncMode: "on-demand"`, `LoadSubsetOptions` describes predicates, ordering, limits, and offsets within one business-scoped collection. These options reach `queryFn` through `ctx.meta.loadSubsetOptions` and determine the subset Query keys. See [QueryFn and Predicate Push-Down](#queryfn-and-predicate-push-down).
 

--- a/docs/guides/ssr.md
+++ b/docs/guides/ssr.md
@@ -149,6 +149,10 @@ const todoCollection = collectionOptions(
 )
 ```
 
+Within one `DbClient`, descriptors with the same `id` resolve to the same
+collection. Only the first descriptor is materialized. Include every dynamic
+parameter that changes the collection in its `id`.
+
 A descriptor created from an arbitrary concrete config can be materialized by
 one `DbClient` only. Use the explicit factory form for custom adapters and
 request-scoped dependencies.

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -305,7 +305,6 @@ export function isCollectionOptions(
 }
 
 export class DbClient {
-  private collectionsByOptions = new WeakMap<object, AnyCollection>()
   private collectionsById = new Map<string, CollectionRecord>()
   private pendingHydration = new Map<string, Array<DehydratedCollectionChunk>>()
   private liveQueries = new Map<string, LiveQueryRecord>()
@@ -451,24 +450,20 @@ export class DbClient {
     materializeOptions: CollectionMaterializeOptions<any> | undefined,
     deferSyncStart: boolean,
   ): AnyCollection {
-    const existing = this.collectionsByOptions.get(options)
+    const existing = this.collectionsById.get(options.id)
     if (existing) {
-      if (!deferSyncStart) {
-        this.collectionsById.get(existing.id)!.shouldDehydrate = true
-      }
-      if (deferSyncStart) {
-        existing._deferSyncStart()
-      }
-      return existing
-    }
-
-    if (this.collectionsById.has(options.id)) {
-      throw new Error(
-        `Cannot materialize collection "${options.id}" because this DbClient already has a different collection with that id. SSR hydration requires collection ids to be unique per DbClient.`,
-      )
+      return this.reuseMaterializedCollection(existing, deferSyncStart)
     }
 
     const config = options[collectionOptionsFactory](this)
+    const materializedDuringFactory = this.collectionsById.get(options.id)
+    if (materializedDuringFactory) {
+      return this.reuseMaterializedCollection(
+        materializedDuringFactory,
+        deferSyncStart,
+      )
+    }
+
     const shouldStartSync = config.startSync === true
     const collection = createCollection({
       ...config,
@@ -479,7 +474,6 @@ export class DbClient {
       collection._deferSyncStart()
     }
 
-    this.collectionsByOptions.set(options, collection)
     this.collectionsById.set(collection.id, {
       collection,
       shouldDehydrate: !deferSyncStart,
@@ -509,6 +503,18 @@ export class DbClient {
     }
 
     return collection
+  }
+
+  private reuseMaterializedCollection(
+    record: CollectionRecord,
+    deferSyncStart: boolean,
+  ): AnyCollection {
+    if (deferSyncStart) {
+      record.collection._deferSyncStart()
+    } else {
+      record.shouldDehydrate = true
+    }
+    return record.collection
   }
 
   dehydrate(options: DehydrateDbClientOptions = {}): DehydratedDbState {
@@ -713,7 +719,6 @@ export class DbClient {
       if (failure) throw failure.reason
     } finally {
       this.transactionScope.clear()
-      this.collectionsByOptions = new WeakMap()
       this.collectionsById.clear()
       this.pendingHydration.clear()
       this.liveQueries.clear()

--- a/packages/db/tests/db-client.test.ts
+++ b/packages/db/tests/db-client.test.ts
@@ -240,28 +240,59 @@ describe(`DbClient`, () => {
     ).toEqual([`people`])
   })
 
-  it(`requires collection ids to be unique per client`, () => {
-    const firstDescriptor = collectionOptions(
+  it(`uses the collection id to reuse separately-created descriptors`, () => {
+    const firstFactory = vi.fn(() =>
       mockSyncCollectionOptions<Person>({
         id: `people`,
         getKey: (person) => person.id,
         initialData: [people[0]!],
       }),
     )
-    const secondDescriptor = collectionOptions(
+    const secondFactory = vi.fn(() =>
       mockSyncCollectionOptions<Person>({
         id: `people`,
         getKey: (person) => person.id,
         initialData: [people[1]!],
       }),
     )
+    const firstDescriptor = collectionOptions(`people`, firstFactory)
+    const secondDescriptor = collectionOptions(`people`, secondFactory)
 
     const client = new DbClient()
-    client.collection(firstDescriptor)
+    const first = client.collection(firstDescriptor)
+    const second = client.collection(secondDescriptor)
 
-    expect(() => client.collection(secondDescriptor)).toThrow(
-      /collection ids to be unique per DbClient/,
+    expect(second).toBe(first)
+    expect(firstFactory).toHaveBeenCalledOnce()
+    expect(secondFactory).not.toHaveBeenCalled()
+    expect(second.toArray).toHaveLength(1)
+    expect(second.toArray[0]).toMatchObject(people[0]!)
+  })
+
+  it(`reuses a same-id collection materialized by a descriptor factory`, () => {
+    const client = new DbClient()
+    const nestedDescriptor = collectionOptions(`people`, () =>
+      mockSyncCollectionOptions<Person>({
+        id: `people`,
+        getKey: (person) => person.id,
+        initialData: [people[0]!],
+      }),
     )
+    const nestedCollections: Array<unknown> = []
+    const outerDescriptor = collectionOptions(`people`, () => {
+      nestedCollections.push(client.collection(nestedDescriptor))
+      return mockSyncCollectionOptions<Person>({
+        id: `people`,
+        getKey: (person) => person.id,
+        initialData: [people[1]!],
+      })
+    })
+
+    const collection = client.collection(outerDescriptor)
+
+    expect(collection).toBe(nestedCollections[0])
+    expect(collection.toArray).toHaveLength(1)
+    expect(collection.toArray[0]).toMatchObject(people[0]!)
   })
 
   it(`requires a stable explicit collection id when creating a descriptor`, () => {

--- a/packages/react-db/tests/useLiveQuery.test.tsx
+++ b/packages/react-db/tests/useLiveQuery.test.tsx
@@ -2937,6 +2937,50 @@ describe(`Query Collections`, () => {
       })
     })
 
+    it(`reuses dynamically-created collection descriptors by id`, async () => {
+      const dbClient = new DbClient()
+      const materialize = vi.fn(() =>
+        mockSyncCollectionOptions<Person>({
+          id: `dynamic-descriptor-people`,
+          getKey: (person) => person.id,
+          initialData: initialPersons,
+        }),
+      )
+      const descriptors = new Set<object>()
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <DbProvider client={dbClient}>{children}</DbProvider>
+      )
+
+      const { result, rerender } = renderHook(
+        ({ team }) =>
+          useLiveQuery({
+            query: (q) => {
+              const descriptor = collectionOptions(
+                `dynamic-descriptor-people`,
+                materialize,
+              )
+              descriptors.add(descriptor)
+
+              return q
+                .from({ people: descriptor })
+                .where(({ people }) => eq(people.team, team))
+            },
+          }),
+        { initialProps: { team: `team1` }, wrapper },
+      )
+
+      await waitFor(() => {
+        expect(result.current.data).toHaveLength(2)
+      })
+      const firstCollection = result.current.collection
+
+      rerender({ team: `team1` })
+
+      expect(descriptors.size).toBeGreaterThan(1)
+      expect(materialize).toHaveBeenCalledOnce()
+      expect(result.current.collection).toBe(firstCollection)
+    })
+
     it(`keeps the same live query collection when derived identity is stable`, async () => {
       const collection = createCollection(
         mockSyncCollectionOptions<Person>({


### PR DESCRIPTION
`DbClient` now treats a collection descriptor's `id` as its identity, so separately created descriptors with the same id reuse one collection. React code can create dynamic descriptors from current parameters without keeping a descriptor cache, as long as every collection-defining parameter is included in the id.

## Root cause

`DbClient` memoized materialized collections by descriptor object reference in a `WeakMap`. A new descriptor object therefore missed the cache even when its id matched an existing collection, and the client rejected the duplicate id. This diverged from the id-based identity used to track hydration, dehydration, cleanup, and live-query collections.

## Approach

- Use `collectionsById` as the single source of truth for materialized collections.
- Return the first collection materialized for an id without invoking later same-id descriptor factories.
- Recheck the id map after a factory runs, so a factory that recursively materializes the same id still resolves to one canonical collection.
- Keep render-time sync deferral and dehydration eligibility intact when a collection is reused.
- Document how dynamic scope values must contribute to both the descriptor id and Query key.

## Key invariants

- One `DbClient` has at most one materialized collection for each id.
- The first descriptor materialized for an id defines that collection's configuration.
- A reused collection keeps the correct render-time sync and dehydration behavior.
- Different business scopes use different ids.

## Non-goals

- Compare descriptor factories, concrete configs, query keys, or query IR by deep value.
- Merge or replace configuration from later descriptors that reuse an id.
- Share collections across separate `DbClient` instances.

## Trade-offs

Id-based lookup removes the need for caller-owned descriptor caches and matches the client's other collection bookkeeping. It also makes id collisions meaningful: callers must include every parameter that changes collection behavior in the id, and the first materialized descriptor wins.

## Verification

```bash
pnpm --filter @tanstack/db build
pnpm exec vitest run packages/db/tests/db-client.test.ts --pool-options.threads.maxThreads=2
pnpm --filter @tanstack/react-db exec vitest --run --pool-options.threads.maxThreads=2
```

The database package tests cover separately created descriptors and reentrant same-id materialization. The React package test recreates a descriptor across renders and verifies that its factory runs once and its live-query collection stays stable.

## Files changed

- `.changeset/fix-db-client-descriptor-identity.md`: record the `@tanstack/db` patch release note.
- `packages/db/src/client.ts`: canonicalize collection materialization by descriptor id.
- `packages/db/tests/db-client.test.ts`: cover same-id descriptor reuse and reentrant factories.
- `packages/react-db/tests/useLiveQuery.test.tsx`: cover fresh dynamic descriptors across React renders.
- `docs/guides/ssr.md`: state the per-client id identity rule.
- `docs/collections/query-collection.md`: replace descriptor-cache guidance with dynamic id guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Collections with the same ID now reuse a single materialized collection, preventing duplicates when descriptors are recreated.
  - Preserves existing collection data and avoids repeated materialization across renders and nested creation.

- **Documentation**
  - Clarified descriptor identity behavior and recommended including all dynamic parameters in collection IDs.
  - Updated guidance for creating business-scoped collection descriptors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->