### PR TITLE
fix(electric): cancel bounded refresh waits

### DIFF
--- a/.changeset/cancel-electric-refresh-wait.md
+++ b/.changeset/cancel-electric-refresh-wait.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/electric-db-collection': patch
+---
+
+Cancel an on-demand refresh wait when its request or collection is cleaned up, preventing snapshots from starting after teardown.

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -625,10 +625,34 @@ function createLoadSubsetDedupe<T extends Row<unknown>>({
     // long-poll requests promptly. Bound the wait so on-demand live queries don't
     // remain loading until the long-poll naturally times out.
     // If the refresh fails or times out, we fall through to requestSnapshot which
-    // still works.
+    // still works. Cleanup or request cancellation ends the wait without starting
+    // a snapshot that no current demand can use.
     if (stream.isUpToDate) {
       let timeoutId: ReturnType<typeof setTimeout> | undefined
+      let removeAbortListeners = () => {}
       try {
+        const abortSignals = new Set(
+          [signal, opts.signal].filter(
+            (candidate): candidate is AbortSignal => candidate !== undefined,
+          ),
+        )
+        const aborted = new Promise<void>((resolve) => {
+          const onAbort = () => resolve()
+          if (Array.from(abortSignals).some((candidate) => candidate.aborted)) {
+            resolve()
+            return
+          }
+
+          abortSignals.forEach((candidate) =>
+            candidate.addEventListener(`abort`, onAbort, { once: true }),
+          )
+          removeAbortListeners = () => {
+            abortSignals.forEach((candidate) =>
+              candidate.removeEventListener(`abort`, onAbort),
+            )
+          }
+        })
+
         await Promise.race([
           stream.forceDisconnectAndRefresh(),
           new Promise<void>((resolve) => {
@@ -637,6 +661,7 @@ function createLoadSubsetDedupe<T extends Row<unknown>>({
               FORCE_DISCONNECT_AND_REFRESH_TIMEOUT_MS,
             )
           }),
+          aborted,
         ])
       } catch (error) {
         if (handleSnapshotError(error, `forceDisconnectAndRefresh`)) {
@@ -647,11 +672,12 @@ function createLoadSubsetDedupe<T extends Row<unknown>>({
           error,
         )
       } finally {
+        removeAbortListeners()
         clearTimeout(timeoutId)
       }
     }
 
-    if (opts.signal?.aborted) return
+    if (signal.aborted || opts.signal?.aborted) return
 
     // Upstream limitation: ShapeStream.requestSnapshot() publishes its rows
     // through the stream callback before its Promise resolves. It accepts no

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -587,12 +587,13 @@ function createLoadSubsetDedupe<T extends Row<unknown>>({
       const snapshotParams = compileSQL<T>(opts, compileOptions)
       try {
         const { data: rows } = await stream.fetchSnapshot(snapshotParams)
-        if (opts.signal?.aborted || !isBufferingInitialSync()) {
+        if (isAborted() || !isBufferingInitialSync()) {
           debug(`${logPrefix}Ignoring snapshot - sync completed while fetching`)
           return
         }
 
         if (rows.length > 0) {
+          if (isAborted()) return
           begin()
           for (const row of rows) {
             write({
@@ -605,7 +606,7 @@ function createLoadSubsetDedupe<T extends Row<unknown>>({
           debug(`${logPrefix}Applied snapshot with ${rows.length} rows`)
         }
       } catch (error) {
-        if (opts.signal?.aborted) return
+        if (isAborted()) return
         if (handleSnapshotError(error, `fetchSnapshot`)) {
           return
         }

--- a/packages/electric-db-collection/src/electric.ts
+++ b/packages/electric-db-collection/src/electric.ts
@@ -579,7 +579,9 @@ function createLoadSubsetDedupe<T extends Row<unknown>>({
 
   const loadSubset = async (opts: LoadSubsetOptions) => {
     const commitCursor = getCommitCursor()
-    if (opts.signal?.aborted) return
+    const isAborted = (): boolean =>
+      signal.aborted || opts.signal?.aborted === true
+    if (isAborted()) return
 
     if (isBufferingInitialSync()) {
       const snapshotParams = compileSQL<T>(opts, compileOptions)
@@ -677,7 +679,7 @@ function createLoadSubsetDedupe<T extends Row<unknown>>({
       }
     }
 
-    if (signal.aborted || opts.signal?.aborted) return
+    if (isAborted()) return
 
     // Upstream limitation: ShapeStream.requestSnapshot() publishes its rows
     // through the stream callback before its Promise resolves. It accepts no

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -2896,6 +2896,112 @@ describe(`Electric Integration`, () => {
       }
     })
 
+    it(`should cancel a pending refresh wait when the collection is cleaned up`, async () => {
+      vi.useFakeTimers()
+      let resolveRefresh: () => void = () => {}
+      const refresh = new Promise<void>((resolve) => {
+        resolveRefresh = resolve
+      })
+
+      try {
+        mockStream.isUpToDate = true
+        mockForceDisconnectAndRefresh.mockReturnValueOnce(refresh)
+
+        const testCollection = createCollection(
+          electricCollectionOptions({
+            id: `on-demand-refresh-cleanup-test`,
+            shapeOptions: {
+              url: `http://test-url`,
+              params: { table: `test_table` },
+            },
+            syncMode: `on-demand`,
+            getKey: (item: Row) => item.id as number,
+            startSync: true,
+          }),
+        )
+
+        let loadSettled = false
+        const load = Promise.resolve(
+          testCollection._sync.loadSubset({ limit: 10 }),
+        ).then(() => {
+          loadSettled = true
+        })
+
+        await Promise.resolve()
+        await testCollection.cleanup()
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(loadSettled).toBe(true)
+        expect(mockRequestSnapshot).not.toHaveBeenCalled()
+        expect(vi.getTimerCount()).toBe(0)
+
+        resolveRefresh()
+        await refresh
+        await load
+        expect(mockRequestSnapshot).not.toHaveBeenCalled()
+      } finally {
+        resolveRefresh()
+        await vi.runOnlyPendingTimersAsync()
+        vi.useRealTimers()
+      }
+    })
+
+    it(`should retry a refresh wait after the requesting demand is aborted`, async () => {
+      vi.useFakeTimers()
+      let resolveRefresh: () => void = () => {}
+      const refresh = new Promise<void>((resolve) => {
+        resolveRefresh = resolve
+      })
+
+      try {
+        mockStream.isUpToDate = true
+        mockForceDisconnectAndRefresh.mockReturnValueOnce(refresh)
+
+        const testCollection = createCollection(
+          electricCollectionOptions({
+            id: `on-demand-refresh-abort-retry-test`,
+            shapeOptions: {
+              url: `http://test-url`,
+              params: { table: `test_table` },
+            },
+            syncMode: `on-demand`,
+            getKey: (item: Row) => item.id as number,
+            startSync: true,
+          }),
+        )
+        const abortController = new AbortController()
+        let abortedLoadSettled = false
+        const abortedLoad = Promise.resolve(
+          testCollection._sync.loadSubset({
+            limit: 10,
+            signal: abortController.signal,
+          }),
+        ).then(() => {
+          abortedLoadSettled = true
+        })
+
+        await Promise.resolve()
+        abortController.abort()
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(abortedLoadSettled).toBe(true)
+        expect(mockRequestSnapshot).not.toHaveBeenCalled()
+        expect(vi.getTimerCount()).toBe(0)
+
+        mockForceDisconnectAndRefresh.mockResolvedValueOnce(undefined)
+        await testCollection._sync.loadSubset({ limit: 10 })
+
+        expect(mockForceDisconnectAndRefresh).toHaveBeenCalledTimes(2)
+        expect(mockRequestSnapshot).toHaveBeenCalledTimes(1)
+        await testCollection.cleanup()
+        await abortedLoad
+      } finally {
+        resolveRefresh()
+        await vi.runOnlyPendingTimersAsync()
+        vi.useRealTimers()
+      }
+    })
+
     it(`should clear the refresh timeout when refresh settles early`, async () => {
       vi.useFakeTimers()
       try {

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -2659,6 +2659,20 @@ describe(`Electric Integration`, () => {
 
   // Tests for syncMode configuration
   describe(`syncMode configuration`, () => {
+    const createOnDemandCollection = (id: string) =>
+      createCollection(
+        electricCollectionOptions({
+          id,
+          shapeOptions: {
+            url: `http://test-url`,
+            params: { table: `test_table` },
+          },
+          syncMode: `on-demand`,
+          getKey: (item: Row) => item.id as number,
+          startSync: true,
+        }),
+      )
+
     it(`should not request snapshots during subscription in eager mode`, () => {
       vi.clearAllMocks()
 
@@ -2898,26 +2912,14 @@ describe(`Electric Integration`, () => {
 
     it(`should cancel a pending refresh wait when the collection is cleaned up`, async () => {
       vi.useFakeTimers()
-      let resolveRefresh: () => void = () => {}
-      const refresh = new Promise<void>((resolve) => {
-        resolveRefresh = resolve
-      })
+      const refresh = createDeferred<void>()
 
       try {
         mockStream.isUpToDate = true
-        mockForceDisconnectAndRefresh.mockReturnValueOnce(refresh)
+        mockForceDisconnectAndRefresh.mockReturnValueOnce(refresh.promise)
 
-        const testCollection = createCollection(
-          electricCollectionOptions({
-            id: `on-demand-refresh-cleanup-test`,
-            shapeOptions: {
-              url: `http://test-url`,
-              params: { table: `test_table` },
-            },
-            syncMode: `on-demand`,
-            getKey: (item: Row) => item.id as number,
-            startSync: true,
-          }),
+        const testCollection = createOnDemandCollection(
+          `on-demand-refresh-cleanup-test`,
         )
 
         let loadSettled = false
@@ -2935,12 +2937,12 @@ describe(`Electric Integration`, () => {
         expect(mockRequestSnapshot).not.toHaveBeenCalled()
         expect(vi.getTimerCount()).toBe(0)
 
-        resolveRefresh()
-        await refresh
+        refresh.resolve()
+        await refresh.promise
         await load
         expect(mockRequestSnapshot).not.toHaveBeenCalled()
       } finally {
-        resolveRefresh()
+        refresh.resolve()
         await vi.runOnlyPendingTimersAsync()
         vi.useRealTimers()
       }
@@ -2948,26 +2950,14 @@ describe(`Electric Integration`, () => {
 
     it(`should retry a refresh wait after the requesting demand is aborted`, async () => {
       vi.useFakeTimers()
-      let resolveRefresh: () => void = () => {}
-      const refresh = new Promise<void>((resolve) => {
-        resolveRefresh = resolve
-      })
+      const refresh = createDeferred<void>()
 
       try {
         mockStream.isUpToDate = true
-        mockForceDisconnectAndRefresh.mockReturnValueOnce(refresh)
+        mockForceDisconnectAndRefresh.mockReturnValueOnce(refresh.promise)
 
-        const testCollection = createCollection(
-          electricCollectionOptions({
-            id: `on-demand-refresh-abort-retry-test`,
-            shapeOptions: {
-              url: `http://test-url`,
-              params: { table: `test_table` },
-            },
-            syncMode: `on-demand`,
-            getKey: (item: Row) => item.id as number,
-            startSync: true,
-          }),
+        const testCollection = createOnDemandCollection(
+          `on-demand-refresh-abort-retry-test`,
         )
         const abortController = new AbortController()
         let abortedLoadSettled = false
@@ -2996,7 +2986,7 @@ describe(`Electric Integration`, () => {
         await testCollection.cleanup()
         await abortedLoad
       } finally {
-        resolveRefresh()
+        refresh.resolve()
         await vi.runOnlyPendingTimersAsync()
         vi.useRealTimers()
       }

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -2659,15 +2659,7 @@ describe(`Electric Integration`, () => {
 
   // Tests for syncMode configuration
   describe(`syncMode configuration`, () => {
-    const createOnDemandCollection = (
-      id: string,
-    ): Collection<
-      Row,
-      number,
-      ElectricCollectionUtils,
-      StandardSchemaV1<unknown, unknown>,
-      Row
-    > =>
+    const createOnDemandCollection = (id: string) =>
       createCollection(
         electricCollectionOptions({
           id,

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -2659,7 +2659,15 @@ describe(`Electric Integration`, () => {
 
   // Tests for syncMode configuration
   describe(`syncMode configuration`, () => {
-    const createOnDemandCollection = (id: string) =>
+    const createOnDemandCollection = (
+      id: string,
+    ): Collection<
+      Row,
+      number,
+      ElectricCollectionUtils,
+      StandardSchemaV1<unknown, unknown>,
+      Row
+    > =>
       createCollection(
         electricCollectionOptions({
           id,
@@ -2946,6 +2954,31 @@ describe(`Electric Integration`, () => {
         await vi.runOnlyPendingTimersAsync()
         vi.useRealTimers()
       }
+    })
+
+    it(`does not start a refresh when the collection signal is already aborted`, async () => {
+      mockStream.isUpToDate = true
+      const abortController = new AbortController()
+      abortController.abort()
+      const testCollection = createCollection(
+        electricCollectionOptions({
+          id: `on-demand-refresh-already-aborted-test`,
+          shapeOptions: {
+            url: `http://test-url`,
+            params: { table: `test_table` },
+            signal: abortController.signal,
+          },
+          syncMode: `on-demand`,
+          getKey: (item: Row) => item.id as number,
+          startSync: true,
+        }),
+      )
+
+      await testCollection._sync.loadSubset({ limit: 10 })
+
+      expect(mockForceDisconnectAndRefresh).not.toHaveBeenCalled()
+      expect(mockRequestSnapshot).not.toHaveBeenCalled()
+      await testCollection.cleanup()
     })
 
     it(`should retry a refresh wait after the requesting demand is aborted`, async () => {

--- a/packages/electric-db-collection/tests/electric.test.ts
+++ b/packages/electric-db-collection/tests/electric.test.ts
@@ -2948,6 +2948,59 @@ describe(`Electric Integration`, () => {
       }
     })
 
+    it(`does not start buffered snapshot publication after adapter cleanup`, async () => {
+      const snapshot = createDeferred<{
+        data: Array<{
+          key: string
+          value: Row
+          headers: { operation: `insert` }
+        }>
+      }>()
+      mockFetchSnapshot.mockReturnValueOnce(snapshot.promise)
+      const options = electricCollectionOptions({
+        id: `progressive-snapshot-cleanup-test`,
+        shapeOptions: {
+          url: `http://test-url`,
+          params: { table: `test_table` },
+        },
+        syncMode: `progressive`,
+        getKey: (item: Row) => item.id as number,
+        startSync: true,
+      })
+      const begin = vi.fn()
+      const write = vi.fn()
+      const commit = vi.fn(() => true as const)
+      const controls = options.sync.sync({
+        collection: { id: options.id, status: `loading` },
+        begin,
+        write,
+        commit,
+        markReady: vi.fn(),
+        markError: vi.fn(),
+        truncate: vi.fn(),
+      } as never)
+      if (!controls || typeof controls === `function` || !controls.loadSubset) {
+        throw new Error(`Expected progressive sync controls`)
+      }
+
+      const load = controls.loadSubset({ limit: 10 })
+      controls.cleanup?.()
+      snapshot.resolve({
+        data: [
+          {
+            key: `1`,
+            value: { id: 1, name: `Late snapshot user` },
+            headers: { operation: `insert` },
+          },
+        ],
+      })
+      if (load !== true) await load
+
+      expect(begin).not.toHaveBeenCalled()
+      expect(write).not.toHaveBeenCalled()
+      expect(commit).not.toHaveBeenCalled()
+    })
+
     it(`does not start a refresh when the collection signal is already aborted`, async () => {
       mockStream.isUpToDate = true
       const abortController = new AbortController()


### PR DESCRIPTION
# Summary

Cancel an on-demand Electric refresh wait as soon as its collection or requesting demand is aborted. This prevents a subset load from remaining pending until the 250 ms bound and stops it from starting a snapshot after teardown.

## Root cause

PR #1575 bounded `forceDisconnectAndRefresh()` with a timer, but the race did not include either lifecycle signal. Cleanup and demand cancellation were only noticed after the refresh or timer settled, and collection cleanup was not checked before `requestSnapshot()`.

The existing tests covered early refresh success and failure, timeout, late settlement, and timer cleanup. They did not cancel the collection or demand while the pre-snapshot refresh was still pending.

## Approach

- Race the refresh and 250 ms timer against both the collection and request abort signals.
- Remove abort listeners and clear the timer on every settlement path.
- Recheck both signals before starting a snapshot.
- Keep an aborted demand out of dedup coverage so a later demand can retry.

## Key invariants

- A refresh that finishes or times out without cancellation still requests one snapshot.
- Cleanup and demand cancellation settle the waiting load without requesting a snapshot.
- Late refresh settlement cannot restart canceled work.
- An aborted demand remains retryable.

## Non-goals and upstream limit

This does not change the 250 ms bound from #1575. It also cannot cancel a snapshot after `ShapeStream.requestSnapshot()` has started: Electric exposes neither a request signal nor request identity for the rows it publishes. The existing source comment documents that boundary.

## Verification

```bash
pnpm exec vitest run packages/electric-db-collection/tests/electric.test.ts -t 'refresh wait' --pool-options.threads.maxThreads=2
pnpm --filter @tanstack/electric-db-collection test
pnpm --filter @tanstack/electric-db-collection build
pnpm exec eslint packages/electric-db-collection/src/electric.ts packages/electric-db-collection/tests/electric.test.ts
```

- Electric package: 493 tests passed; type checks passed.
- Focused cancellation/retry cases: 2 passed.
- Build passed.
- Lint passed with no errors; 13 pre-existing `no-shadow` warnings remain in the test file.

## Files changed

- `packages/electric-db-collection/src/electric.ts`: make the bounded refresh wait cancellation-aware.
- `packages/electric-db-collection/tests/electric.test.ts`: cover cleanup, demand abort, timer cleanup, late settlement, and retry.
- `.changeset/cancel-electric-refresh-wait.md`: patch release note.

---

Follow-up to #1575. Part of #1657.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved on-demand refresh cancellation when a request or collection is cleaned up.
  - Prevented unnecessary snapshot requests after cancellation or teardown.
  - Ensured interrupted refreshes can be retried successfully when a new request is made.
  - Improved cleanup of pending refresh operations to avoid lingering waits and unexpected activity after shutdown.
  - Prevented late snapshot data from being applied after cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->