### PR TITLE
fix(db): terminate nested predicate subtraction

### DIFF
--- a/.changeset/fix-nested-predicate-subtraction.md
+++ b/.changeset/fix-nested-predicate-subtraction.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Ensure predicate subtraction terminates when common conditions are nested inside conjunctions.

--- a/packages/db/src/query/predicate-utils.ts
+++ b/packages/db/src/query/predicate-utils.ts
@@ -404,21 +404,25 @@ export function minusWherePredicates(
   )
   if (commonConditions.length > 0) {
     // Extract predicates without common conditions
-    const fromWithoutCommon = removeConditions(fromPredicate, commonConditions)
-    const subtractWithoutCommon = removeConditions(
+    const fromRemoval = removeConditions(fromPredicate, commonConditions)
+    const subtractRemoval = removeConditions(
       subtractPredicate,
       commonConditions,
     )
 
-    // Recursively compute difference on simplified predicates
-    const simplifiedDifference = minusWherePredicates(
-      fromWithoutCommon,
-      subtractWithoutCommon,
-    )
+    // Recurse only when both operands lost at least one flattened AND term.
+    // This strict decrease is the termination measure for common-condition
+    // simplification.
+    if (fromRemoval.removed && subtractRemoval.removed) {
+      const simplifiedDifference = minusWherePredicates(
+        fromRemoval.predicate,
+        subtractRemoval.predicate,
+      )
 
-    if (simplifiedDifference !== null) {
-      // Combine the simplified difference with common conditions
-      return combineConditions([...commonConditions, simplifiedDifference])
+      if (simplifiedDifference !== null) {
+        // Combine the simplified difference with common conditions
+        return combineConditions([...commonConditions, simplifiedDifference])
+      }
     }
   }
 
@@ -1037,35 +1041,35 @@ function extractAllConditions(
 
 /**
  * Remove specified conditions from a predicate.
- * Returns the predicate with the specified conditions removed, or undefined if all conditions are removed.
+ * Reports whether removal made progress and returns the remaining predicate,
+ * or undefined when all conditions were removed.
  */
 function removeConditions(
   predicate: BasicExpression<boolean>,
   conditionsToRemove: Array<BasicExpression<boolean>>,
-): BasicExpression<boolean> | undefined {
-  if (predicate.type === `func` && predicate.name === `and`) {
-    const remainingArgs = predicate.args.filter(
-      (arg) =>
-        !conditionsToRemove.some((cond) =>
-          areExpressionsEqual(arg as BasicExpression<boolean>, cond),
-        ),
-    )
+): {
+  predicate: BasicExpression<boolean> | undefined
+  removed: boolean
+} {
+  const conditions = extractAllConditions(predicate)
+  const remainingConditions = conditions.filter(
+    (condition) =>
+      !conditionsToRemove.some((conditionToRemove) =>
+        areExpressionsEqual(condition, conditionToRemove),
+      ),
+  )
 
-    if (remainingArgs.length === 0) {
-      return undefined
-    } else if (remainingArgs.length === 1) {
-      return remainingArgs[0]!
-    } else {
-      return {
-        type: `func`,
-        name: `and`,
-        args: remainingArgs,
-      } as BasicExpression<boolean>
-    }
+  if (remainingConditions.length === conditions.length) {
+    return { predicate, removed: false }
   }
 
-  // For non-AND predicates, don't remove anything
-  return predicate
+  return {
+    predicate:
+      remainingConditions.length === 0
+        ? undefined
+        : combineConditions(remainingConditions),
+    removed: true,
+  }
 }
 
 /**

--- a/packages/db/tests/query/predicate-subtraction-oracle.property.test.ts
+++ b/packages/db/tests/query/predicate-subtraction-oracle.property.test.ts
@@ -1,0 +1,223 @@
+import { fc, test as fcTest } from '@fast-check/vitest'
+import { describe, expect } from 'vitest'
+import { minusWherePredicates } from '../../src/query/predicate-utils'
+import { Func, PropRef, Value } from '../../src/query/ir'
+import { oraclePropertyOptions } from '../oracle-config'
+import type { BasicExpression } from '../../src/query/ir'
+
+type PredicateSpec =
+  | { kind: `eq`; value: number | null }
+  | { kind: `range`; operator: `gt` | `gte` | `lt` | `lte`; value: number }
+  | { kind: `in`; values: Array<number | null> }
+  | { kind: `not`; predicate: AtomicPredicateSpec }
+  | {
+      kind: `or`
+      left: AtomicPredicateSpec
+      right: AtomicPredicateSpec
+    }
+
+type AtomicPredicateSpec = Exclude<PredicateSpec, { kind: `not` | `or` }>
+
+type Association = `flat` | `left` | `right`
+
+interface DifferenceScenario {
+  shared: Array<PredicateSpec>
+  fromResidual: AtomicPredicateSpec
+  subtractResidual: AtomicPredicateSpec
+  fromAssociation: Association
+  subtractAssociation: Association
+  reverseFrom: boolean
+  reverseSubtract: boolean
+  duplicateFrom: boolean
+  duplicateSubtract: boolean
+}
+
+const scalarArbitrary = fc.oneof(
+  fc.integer({ min: -2, max: 2 }),
+  fc.constant(null),
+)
+
+const atomicPredicateArbitrary: fc.Arbitrary<AtomicPredicateSpec> = fc.oneof(
+  scalarArbitrary.map((scalar) => ({ kind: `eq` as const, value: scalar })),
+  fc.record({
+    kind: fc.constant(`range` as const),
+    operator: fc.constantFrom(`gt`, `gte`, `lt`, `lte`),
+    value: fc.integer({ min: -2, max: 2 }),
+  }),
+  fc
+    .uniqueArray(scalarArbitrary, { minLength: 1, maxLength: 4 })
+    .map((values) => ({ kind: `in` as const, values })),
+)
+
+const predicateArbitrary: fc.Arbitrary<PredicateSpec> = fc.oneof(
+  atomicPredicateArbitrary,
+  atomicPredicateArbitrary.map((predicate) => ({
+    kind: `not` as const,
+    predicate,
+  })),
+  fc
+    .tuple(atomicPredicateArbitrary, atomicPredicateArbitrary)
+    .map(([left, right]) => ({ kind: `or` as const, left, right })),
+)
+
+const scenarioArbitrary: fc.Arbitrary<DifferenceScenario> = fc.record({
+  shared: fc.array(predicateArbitrary, { minLength: 1, maxLength: 3 }),
+  fromResidual: atomicPredicateArbitrary,
+  subtractResidual: atomicPredicateArbitrary,
+  fromAssociation: fc.constantFrom(`flat`, `left`, `right`),
+  subtractAssociation: fc.constantFrom(`flat`, `left`, `right`),
+  reverseFrom: fc.boolean(),
+  reverseSubtract: fc.boolean(),
+  duplicateFrom: fc.boolean(),
+  duplicateSubtract: fc.boolean(),
+})
+
+const score = new PropRef([`score`])
+
+function value(input: unknown): Value {
+  return new Value(input)
+}
+
+function call(
+  name: string,
+  ...args: Array<BasicExpression>
+): BasicExpression<boolean> {
+  return new Func(name, args) as BasicExpression<boolean>
+}
+
+function buildAtomic(spec: AtomicPredicateSpec): BasicExpression<boolean> {
+  if (spec.kind === `in`) {
+    return call(`in`, score, value(spec.values))
+  }
+  if (spec.kind === `range`) {
+    return call(spec.operator, score, value(spec.value))
+  }
+  return call(`eq`, score, value(spec.value))
+}
+
+function buildPredicate(spec: PredicateSpec): BasicExpression<boolean> {
+  if (spec.kind === `not`) {
+    return call(`not`, buildAtomic(spec.predicate))
+  }
+  if (spec.kind === `or`) {
+    return call(`or`, buildAtomic(spec.left), buildAtomic(spec.right))
+  }
+  return buildAtomic(spec)
+}
+
+function associateAnd(
+  terms: Array<BasicExpression<boolean>>,
+  association: Association,
+): BasicExpression<boolean> {
+  if (terms.length === 1) return terms[0]!
+  if (association === `flat`) return call(`and`, ...terms)
+
+  if (association === `left`) {
+    return terms
+      .slice(1)
+      .reduce((left, right) => call(`and`, left, right), terms[0]!)
+  }
+
+  return terms
+    .slice(0, -1)
+    .reduceRight((right, left) => call(`and`, left, right), terms.at(-1)!)
+}
+
+function buildOperand(
+  sharedSpecs: Array<PredicateSpec>,
+  residualSpec: AtomicPredicateSpec,
+  association: Association,
+  reverse: boolean,
+  duplicate: boolean,
+): BasicExpression<boolean> {
+  const shared = sharedSpecs.map(buildPredicate)
+  const residual = buildAtomic(residualSpec)
+  const terms = reverse ? [residual, ...shared] : [...shared, residual]
+  if (duplicate) terms.splice(1, 0, terms[0]!)
+  return associateAnd(terms, association)
+}
+
+const finiteDomain = [-3, -2, -1, 0, 1, 2, 3, null]
+
+function evaluatePredicate(
+  expression: BasicExpression,
+  row: { score: number | null },
+): unknown {
+  if (expression.type === `val`) return expression.value
+  if (expression.type === `ref`) return row.score
+
+  const args = expression.args.map((argument) =>
+    evaluatePredicate(argument, row),
+  )
+  const isUnknown = (candidate: unknown) =>
+    candidate === null || candidate === undefined
+  switch (expression.name) {
+    case `and`:
+      return args.includes(false) ? false : args.some(isUnknown) ? null : true
+    case `or`:
+      return args.includes(true) ? true : args.some(isUnknown) ? null : false
+    case `not`:
+      return isUnknown(args[0]) ? null : !args[0]
+    case `eq`:
+      return isUnknown(args[0]) || isUnknown(args[1])
+        ? null
+        : args[0] === args[1]
+    case `gt`:
+    case `gte`:
+    case `lt`:
+    case `lte`: {
+      if (isUnknown(args[0]) || isUnknown(args[1])) return null
+      const left = args[0] as number
+      const right = args[1] as number
+      if (expression.name === `gt`) return left > right
+      if (expression.name === `gte`) return left >= right
+      if (expression.name === `lt`) return left < right
+      return left <= right
+    }
+    case `in`:
+      if (isUnknown(args[0])) return null
+      return Array.isArray(args[1]) && args[1].includes(args[0])
+    default:
+      throw new Error(`Unsupported predicate ${expression.name}`)
+  }
+}
+
+function assertSemanticDifference(scenario: DifferenceScenario): void {
+  const requested = buildOperand(
+    scenario.shared,
+    scenario.fromResidual,
+    scenario.fromAssociation,
+    scenario.reverseFrom,
+    scenario.duplicateFrom,
+  )
+  const loaded = buildOperand(
+    scenario.shared,
+    scenario.subtractResidual,
+    scenario.subtractAssociation,
+    scenario.reverseSubtract,
+    scenario.duplicateSubtract,
+  )
+
+  const result = minusWherePredicates(requested, loaded)
+  if (result === null) return
+
+  for (const candidate of finiteDomain) {
+    const row = { score: candidate }
+    const expected =
+      evaluatePredicate(requested, row) === true &&
+      evaluatePredicate(loaded, row) !== true
+    expect(evaluatePredicate(result, row) === true).toBe(expected)
+  }
+}
+
+describe(`predicate subtraction oracle`, () => {
+  fcTest.prop([scenarioArbitrary], { numRuns: 250, seed: 1777 })(
+    `preserves finite-world subtraction for a fixed replay corpus`,
+    assertSemanticDifference,
+  )
+
+  fcTest.prop([scenarioArbitrary], oraclePropertyOptions(250))(
+    `preserves finite-world subtraction for a random or replayed seed`,
+    assertSemanticDifference,
+  )
+})

--- a/packages/db/tests/query/predicate-utils.test.ts
+++ b/packages/db/tests/query/predicate-utils.test.ts
@@ -10,6 +10,7 @@ import {
   unionWherePredicates,
 } from '../../src/query/predicate-utils'
 import { Func, PropRef, Value } from '../../src/query/ir'
+import { evaluateReferenceExpression } from '../reference-expression'
 import type {
   BasicExpression,
   OrderBy,
@@ -56,6 +57,10 @@ function and(...args: Array<BasicExpression>): Func {
 
 function or(...args: Array<BasicExpression>): Func {
   return func(`or`, ...args)
+}
+
+function not(arg: BasicExpression): Func {
+  return func(`not`, arg)
 }
 
 function inOp(left: BasicExpression, values: Array<any>): Func {
@@ -1431,6 +1436,74 @@ describe(`minusWherePredicates`, () => {
   })
 
   describe(`common conditions`, () => {
+    it(`removes a common condition nested inside AND before recursing`, () => {
+      const score = ref(`score`)
+      const requested = eq(score, val(0))
+      const loaded = and(
+        not(eq(score, val(-1))),
+        and(eq(score, val(0)), lt(score, val(1))),
+      )
+
+      const result = minusWherePredicates(requested, loaded)
+
+      expect(result).toEqual(
+        and(
+          eq(score, val(0)),
+          not(and(not(eq(score, val(-1))), lt(score, val(1)))),
+        ),
+      )
+      expect(
+        evaluateReferenceExpression(result!, { score: 0 }),
+      ).toBe(false)
+    })
+
+    it(`preserves nested AND difference semantics across equality, range, and NOT terms`, () => {
+      const score = ref(`score`)
+      const domain = [-2, -1, 0, 1, 2]
+      const ranges = [gt, gte, lt, lte]
+
+      for (const requestedValue of [-1, 0, 1]) {
+        const requested = eq(score, val(requestedValue))
+        for (const excludedValue of [-1, 0, 1]) {
+          const negatedEquality = not(eq(score, val(excludedValue)))
+          for (const range of ranges) {
+            for (const boundary of [-1, 0, 1]) {
+              const rangePredicate = range(score, val(boundary))
+              const loadedPredicates = [
+                and(
+                  negatedEquality,
+                  and(eq(score, val(requestedValue)), rangePredicate),
+                ),
+                and(
+                  and(negatedEquality, eq(score, val(requestedValue))),
+                  rangePredicate,
+                ),
+                and(
+                  rangePredicate,
+                  and(negatedEquality, eq(score, val(requestedValue))),
+                ),
+              ]
+
+              for (const loaded of loadedPredicates) {
+                const result = minusWherePredicates(requested, loaded)
+                expect(result).not.toBeNull()
+
+                for (const value of domain) {
+                  const row = { score: value }
+                  const expected =
+                    evaluateReferenceExpression(requested, row) === true &&
+                    evaluateReferenceExpression(loaded, row) !== true
+                  expect(evaluateReferenceExpression(result!, row)).toBe(
+                    expected,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+
     it(`should handle common conditions: (age > 10 AND status = 'active') - (age > 20 AND status = 'active') = (age > 10 AND age <= 20 AND status = 'active')`, () => {
       const from = and(
         gt(ref(`age`), val(10)),

--- a/packages/db/tests/query/predicate-utils.test.ts
+++ b/packages/db/tests/query/predicate-utils.test.ts
@@ -1452,9 +1452,7 @@ describe(`minusWherePredicates`, () => {
           not(and(not(eq(score, val(-1))), lt(score, val(1)))),
         ),
       )
-      expect(
-        evaluateReferenceExpression(result!, { score: 0 }),
-      ).toBe(false)
+      expect(evaluateReferenceExpression(result!, { score: 0 })).toBe(false)
     })
 
     it(`preserves nested AND difference semantics across equality, range, and NOT terms`, () => {


### PR DESCRIPTION
Fix predicate subtraction so nested conjunctions cannot recurse forever. Queries whose requested and loaded predicates share a nested condition now compute their remaining demand instead of overflowing the stack.

## Root cause

The common-condition path flattened nested `AND` expressions when it found shared terms, but removed terms only from the top-level `AND`. A shared nested term could therefore trigger a recursive call with an unchanged operand. The same call then repeated until JavaScript raised `RangeError: Maximum call stack size exceeded`.

Normal tests missed this because their shared conditions were direct children of the top-level conjunction. A 100× oracle campaign found the asymmetric nested shape at seed `801267634`, path `2185:4:2:12:9:5:4:3`.

## Approach

- Flatten conjunctions consistently when removing shared conditions.
- Return whether each removal made progress.
- Recurse only when both operands strictly lose a flattened `AND` term.
- Add a deterministic regression plus a small Cartesian semantic oracle spanning nested layouts, equality, range, and `NOT` terms.

## Key invariant

Every recursive common-condition simplification must strictly reduce both operands. If it cannot prove that decrease, predicate subtraction falls through to the existing non-recursive rules.

## Non-goals

This does not redesign predicate normalization or add new subtraction laws. It only makes the existing common-condition reduction complete for nested conjunctions and explicitly terminating.

## Verification

Red on `origin/main`:

- The 100× load-subset oracle campaign failed with `RangeError: Maximum call stack size exceeded` at seed `801267634`, path `2185:4:2:12:9:5:4:3`.

Green on this branch:

```bash
pnpm vitest run packages/db/tests/query/predicate-utils.test.ts --pool-options.threads.maxThreads=2
```

- 145 predicate utility tests pass.
- An independent Cartesian probe checked 980,100 predicate pairs without a stack overflow or semantic mismatch.
- `pnpm exec changeset status --since=origin/main` validates the `@tanstack/db` patch changeset.

## Files changed

- `packages/db/src/query/predicate-utils.ts`: require strict recursive progress and remove nested shared conjunction terms.
- `packages/db/tests/query/predicate-utils.test.ts`: pin the failing shape and exhaust related nested predicate layouts over a small value domain.
- `.changeset/fix-nested-predicate-subtraction.md`: record the patch release note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed predicate subtraction for queries with nested `AND` conditions.
  - Prevented predicate processing from getting stuck when conditions overlap across nested expressions.
  - Improved handling of equality, range, and negated conditions during predicate subtraction.

- **Tests**
  - Added coverage for nested predicate subtraction across multiple values and condition types.
  - Added property-based validation to verify correct results across varied predicate combinations and boolean arrangements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->