### PR TITLE
fix(db): lazily initialize runtime reference identities

### DIFF
--- a/.changeset/lazy-runtime-reference-identities.md
+++ b/.changeset/lazy-runtime-reference-identities.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Lazily initialize runtime reference identities to avoid generating random values during Cloudflare Worker module evaluation.

--- a/packages/db/src/query/runtime-reference-identity.ts
+++ b/packages/db/src/query/runtime-reference-identity.ts
@@ -28,8 +28,7 @@ let runtimeReferenceIdentityFactory:
 export function getRuntimeReferenceIdentity(
   value: object,
 ): RuntimeReferenceIdentity {
-  runtimeReferenceIdentityFactory ??=
-    createRuntimeReferenceIdentityFactory()
+  runtimeReferenceIdentityFactory ??= createRuntimeReferenceIdentityFactory()
 
   return runtimeReferenceIdentityFactory(value)
 }

--- a/packages/db/src/query/runtime-reference-identity.ts
+++ b/packages/db/src/query/runtime-reference-identity.ts
@@ -21,8 +21,18 @@ export function createRuntimeReferenceIdentityFactory(): (
   }
 }
 
-export const getRuntimeReferenceIdentity =
-  createRuntimeReferenceIdentityFactory()
+let runtimeReferenceIdentityFactory:
+  | ReturnType<typeof createRuntimeReferenceIdentityFactory>
+  | undefined
+
+export function getRuntimeReferenceIdentity(
+  value: object,
+): RuntimeReferenceIdentity {
+  runtimeReferenceIdentityFactory ??=
+    createRuntimeReferenceIdentityFactory()
+
+  return runtimeReferenceIdentityFactory(value)
+}
 
 function createRuntimeReferenceNamespace(): string {
   const randomValues = new Uint32Array(4)

--- a/packages/db/tests/query/ir-stable-identity.test.ts
+++ b/packages/db/tests/query/ir-stable-identity.test.ts
@@ -315,8 +315,9 @@ describe(`semantic expression identity`, () => {
     vi.resetModules()
 
     try {
-      const { getRuntimeReferenceIdentity } =
-        await import(`../../src/query/runtime-reference-identity.js`)
+      const { getRuntimeReferenceIdentity } = await import(
+        `../../src/query/runtime-reference-identity.js`
+      )
 
       expect(getRandomValues).not.toHaveBeenCalled()
 

--- a/packages/db/tests/query/ir-stable-identity.test.ts
+++ b/packages/db/tests/query/ir-stable-identity.test.ts
@@ -309,6 +309,26 @@ describe(`semantic expression identity`, () => {
     },
   )
 
+  it(`does not initialize runtime reference identities during module evaluation`, async () => {
+    const getRandomValues = vi.fn((values: Uint32Array) => values)
+    vi.stubGlobal(`crypto`, { getRandomValues })
+    vi.resetModules()
+
+    try {
+      const { getRuntimeReferenceIdentity } =
+        await import(`../../src/query/runtime-reference-identity.js`)
+
+      expect(getRandomValues).not.toHaveBeenCalled()
+
+      getRuntimeReferenceIdentity({})
+      getRuntimeReferenceIdentity({})
+
+      expect(getRandomValues).toHaveBeenCalledOnce()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it(`does not reuse reference identities across runtimes`, () => {
     const firstRuntime = createRuntimeReferenceIdentityFactory()
     const secondRuntime = createRuntimeReferenceIdentityFactory()


### PR DESCRIPTION
## 🎯 Changes

Lazily initializes runtime reference identities when they are first needed instead of during module evaluation.

The previous eager initialization called `crypto.getRandomValues()` at global scope, causing `@tanstack/db` imports to fail in Cloudflare Workers before the request handler could run.

The initialized factory remains cached for the lifetime of the runtime, preserving the existing namespace, `WeakMap`, and reference identity semantics.

This PR also adds:

- A regression test proving module evaluation does not call `getRandomValues`.
- Verification that the first identity request initializes the factory exactly once.
- A patch changeset for `@tanstack/db`.

The fix was additionally verified in a production Cloudflare Worker.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

---------

This fixes #1781 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary random value generation when database modules are loaded in Cloudflare Workers.
  * Runtime reference identities are now initialized only when first needed, improving module startup behavior.

* **Tests**
  * Added coverage confirming identities are initialized lazily and reused consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->