### PR TITLE
fix(db): release synced keys after delete

### DIFF
--- a/.changeset/release-deleted-sync-keys.md
+++ b/.changeset/release-deleted-sync-keys.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Release synced key tracking when rows are deleted.

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -1061,6 +1061,7 @@ export class CollectionStateManager<
               break
             }
             case `delete`:
+              this.syncedKeys.delete(key)
               this.syncedData.delete(key)
               this.syncedMetadata.delete(key)
               // Clean up origin and pending tracking for deleted rows

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -1656,6 +1656,40 @@ describe(`Collection`, () => {
     })
   })
 
+  it(`should remove deleted keys from synced key tracking`, async () => {
+    const collection = createCollection(
+      mockSyncCollectionOptionsNoInitialState<{
+        id: number
+        value: string
+      }>({
+        id: `sync-key-delete-test`,
+        getKey: (item) => item.id,
+        startSync: true,
+      }),
+    )
+
+    collection.utils.begin()
+    collection.utils.write({
+      type: `insert`,
+      value: { id: 1, value: `one` },
+    })
+    collection.utils.write({
+      type: `insert`,
+      value: { id: 2, value: `two` },
+    })
+    collection.utils.commit()
+    collection.utils.markReady()
+
+    await collection.stateWhenReady()
+    expect(collection._state.syncedKeys).toEqual(new Set([1, 2]))
+
+    collection.utils.begin()
+    collection.utils.write({ type: `delete`, key: 1 })
+    collection.utils.commit()
+
+    expect(collection._state.syncedKeys).toEqual(new Set([2]))
+  })
+
   it(`should delete row metadata when sync deletes the row`, async () => {
     let testSyncFunctions: any = null
 


### PR DESCRIPTION
## 🎯 Changes

- Remove deleted row keys from `CollectionStateManager.syncedKeys` during synced deletes.
- Add a focused two-key regression test that verifies only the deleted key is removed.
- Add an `@tanstack/db` patch changeset.

The regression test inserts two rows and deletes one. Before this fix, the deleted row’s key remains in syncedKeys; after the fix, only the surviving row’s key remains.

Closes #1786

### Testing

- `pnpm build` — passed
- `pnpm test` — passed across all 28 workspace packages
- `@tanstack/db` — 3,324 tests passed, 6 skipped; no type errors
- Focused regression test — confirmed failing without the fix and passing with it
- ESLint on the changed TypeScript files — no errors

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted rows are now correctly removed from sync tracking, preventing stale deleted keys from being retained.

* **Tests**
  * Added coverage verifying that sync tracking includes inserted rows and removes them after deletion.

* **Release**
  * Prepared a patch release for the database package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->