### PR TITLE
fix(db): match index collation options semantically

### DIFF
--- a/.changeset/fix-index-collation-matching.md
+++ b/.changeset/fix-index-collation-matching.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Match index collation options by their effective values so indexes remain reusable when optional locale fields are omitted or set to `undefined`.

--- a/.changeset/fix-index-collation-matching.md
+++ b/.changeset/fix-index-collation-matching.md
@@ -2,4 +2,4 @@
 '@tanstack/db': patch
 ---
 
-Match index collation options by their effective values so indexes remain reusable when optional locale fields are omitted or set to `undefined`.
+Match index collation options by their effective values so indexes remain reusable when optional locale fields are omitted, set to `undefined`, or use equivalent locale identifiers.

--- a/packages/db/src/indexes/base-index.ts
+++ b/packages/db/src/indexes/base-index.ts
@@ -12,6 +12,18 @@ function normalizeLocaleOptions(options: object | undefined): object {
   )
 }
 
+type LocaleCompareOptions = CompareOptions & {
+  stringSort?: `locale`
+  locale?: string
+  localeOptions?: object
+}
+
+function usesLocaleCollation(
+  options: CompareOptions,
+): options is LocaleCompareOptions {
+  return (options.stringSort ?? DEFAULT_COMPARE_OPTIONS.stringSort) === `locale`
+}
+
 /**
  * Operations that indexes can support, imported from available comparison functions
  */
@@ -183,26 +195,25 @@ export abstract class BaseIndex<
    * The direction is ignored because the index can be reversed if the direction is different.
    */
   matchesCompareOptions(compareOptions: CompareOptions): boolean {
-    const indexStringSort =
-      this.compareOptions.stringSort ?? DEFAULT_COMPARE_OPTIONS.stringSort
-    const requestedStringSort =
-      compareOptions.stringSort ?? DEFAULT_COMPARE_OPTIONS.stringSort
+    const indexCompareOptions = this.compareOptions
+    const indexUsesLocale = usesLocaleCollation(indexCompareOptions)
+    const requestedUsesLocale = usesLocaleCollation(compareOptions)
 
     if (
-      this.compareOptions.nulls !== compareOptions.nulls ||
-      indexStringSort !== requestedStringSort
+      indexCompareOptions.nulls !== compareOptions.nulls ||
+      indexUsesLocale !== requestedUsesLocale
     ) {
       return false
     }
 
-    if (indexStringSort !== `locale`) {
+    if (!indexUsesLocale || !requestedUsesLocale) {
       return true
     }
 
     return (
-      this.compareOptions.locale === compareOptions.locale &&
+      indexCompareOptions.locale === compareOptions.locale &&
       deepEquals(
-        normalizeLocaleOptions(this.compareOptions.localeOptions),
+        normalizeLocaleOptions(indexCompareOptions.localeOptions),
         normalizeLocaleOptions(compareOptions.localeOptions),
       )
     )

--- a/packages/db/src/indexes/base-index.ts
+++ b/packages/db/src/indexes/base-index.ts
@@ -6,6 +6,12 @@ import type { RangeQueryOptions } from './btree-index.js'
 import type { CompareOptions } from '../query/builder/types.js'
 import type { BasicExpression, OrderByDirection } from '../query/ir.js'
 
+function normalizeLocaleOptions(options: object | undefined): object {
+  return Object.fromEntries(
+    Object.entries(options ?? {}).filter(([, value]) => value !== undefined),
+  )
+}
+
 /**
  * Operations that indexes can support, imported from available comparison functions
  */
@@ -177,18 +183,28 @@ export abstract class BaseIndex<
    * The direction is ignored because the index can be reversed if the direction is different.
    */
   matchesCompareOptions(compareOptions: CompareOptions): boolean {
-    const thisCompareOptionsWithoutDirection = {
-      ...this.compareOptions,
-      direction: undefined,
-    }
-    const compareOptionsWithoutDirection = {
-      ...compareOptions,
-      direction: undefined,
+    const indexStringSort =
+      this.compareOptions.stringSort ?? DEFAULT_COMPARE_OPTIONS.stringSort
+    const requestedStringSort =
+      compareOptions.stringSort ?? DEFAULT_COMPARE_OPTIONS.stringSort
+
+    if (
+      this.compareOptions.nulls !== compareOptions.nulls ||
+      indexStringSort !== requestedStringSort
+    ) {
+      return false
     }
 
-    return deepEquals(
-      thisCompareOptionsWithoutDirection,
-      compareOptionsWithoutDirection,
+    if (indexStringSort !== `locale`) {
+      return true
+    }
+
+    return (
+      this.compareOptions.locale === compareOptions.locale &&
+      deepEquals(
+        normalizeLocaleOptions(this.compareOptions.localeOptions),
+        normalizeLocaleOptions(compareOptions.localeOptions),
+      )
     )
   }
 

--- a/packages/db/src/indexes/base-index.ts
+++ b/packages/db/src/indexes/base-index.ts
@@ -12,6 +12,10 @@ function normalizeLocaleOptions(options: object | undefined): object {
   )
 }
 
+function canonicalizeLocale(locale: string | undefined): string | undefined {
+  return locale === undefined ? undefined : Intl.getCanonicalLocales(locale)[0]
+}
+
 type LocaleCompareOptions = CompareOptions & {
   stringSort?: `locale`
   locale?: string
@@ -211,7 +215,8 @@ export abstract class BaseIndex<
     }
 
     return (
-      indexCompareOptions.locale === compareOptions.locale &&
+      canonicalizeLocale(indexCompareOptions.locale) ===
+        canonicalizeLocale(compareOptions.locale) &&
       deepEquals(
         normalizeLocaleOptions(indexCompareOptions.localeOptions),
         normalizeLocaleOptions(compareOptions.localeOptions),

--- a/packages/db/tests/collection-auto-index.test.ts
+++ b/packages/db/tests/collection-auto-index.test.ts
@@ -252,11 +252,15 @@ describe(`Collection Auto-Indexing`, () => {
 
   it(`should create auto-indexes for transformed fields of subqueries when autoIndex is "eager"`, async () => {})
 
-  it(`should not create duplicate auto-indexes for the same field`, async () => {
+  it(`should not create duplicate auto-indexes when locale options are omitted`, async () => {
     const autoIndexCollection = createCollection<TestItem, string>({
       getKey: (item) => item.id,
       autoIndex: `eager`,
       defaultIndexType: BTreeIndex,
+      defaultStringCollation: {
+        stringSort: `locale`,
+        localeOptions: { sensitivity: undefined },
+      },
       startSync: true,
       sync: {
         sync: ({ begin, write, commit, markReady }) => {

--- a/packages/db/tests/collection-indexes.test.ts
+++ b/packages/db/tests/collection-indexes.test.ts
@@ -16,6 +16,8 @@ import {
 import { PropRef } from '../src/query/ir'
 import { BTreeIndex } from '../src/indexes/btree-index.js'
 import { DEFAULT_COMPARE_OPTIONS } from '../src/utils.js'
+import { findIndexForField } from '../src/utils/index-optimization.js'
+import { makeComparator } from '../src/utils/comparison.js'
 import { expectIndexUsage, stripVirtualProps, withIndexTracking } from './utils'
 import type { Collection } from '../src/collection/index.js'
 import type { MutationFn, PendingMutation } from '../src/types'
@@ -208,6 +210,26 @@ describe(`Collection Indexes`, () => {
           stringSort: `lexical`,
         }),
       ).toBe(false)
+    })
+
+    it(`should reuse an index for equivalent locale identifiers`, () => {
+      const indexCompareOptions = {
+        ...DEFAULT_COMPARE_OPTIONS,
+        locale: `en-us`,
+      }
+      const index = collection.createIndex((row) => row.name, {
+        options: {
+          compareOptions: indexCompareOptions,
+          compareFn: makeComparator(indexCompareOptions),
+        },
+      })
+
+      expect(
+        findIndexForField(collection, [`name`], {
+          ...DEFAULT_COMPARE_OPTIONS,
+          locale: `en-US`,
+        }),
+      ).toBe(index)
     })
 
     it(`should create multiple indexes`, () => {

--- a/packages/db/tests/collection-indexes.test.ts
+++ b/packages/db/tests/collection-indexes.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/query/builder/functions'
 import { PropRef } from '../src/query/ir'
 import { BTreeIndex } from '../src/indexes/btree-index.js'
+import { DEFAULT_COMPARE_OPTIONS } from '../src/utils.js'
 import { expectIndexUsage, stripVirtualProps, withIndexTracking } from './utils'
 import type { Collection } from '../src/collection/index.js'
 import type { MutationFn, PendingMutation } from '../src/types'
@@ -159,6 +160,54 @@ describe(`Collection Indexes`, () => {
 
       expect(index.name).toBe(`ageIndex`)
       expect(index.indexedKeysSet.size).toBe(5)
+    })
+
+    it(`should match compare options by collation semantics`, () => {
+      const index = collection.createIndex((row) => row.status)
+
+      expect(
+        index.matchesCompareOptions({
+          ...DEFAULT_COMPARE_OPTIONS,
+          locale: undefined,
+          localeOptions: undefined,
+        }),
+      ).toBe(true)
+      expect(
+        index.matchesCompareOptions({
+          ...DEFAULT_COMPARE_OPTIONS,
+          localeOptions: { sensitivity: undefined },
+        }),
+      ).toBe(true)
+      expect(
+        index.matchesCompareOptions({
+          ...DEFAULT_COMPARE_OPTIONS,
+          direction: `desc`,
+        }),
+      ).toBe(true)
+      expect(
+        index.matchesCompareOptions({
+          ...DEFAULT_COMPARE_OPTIONS,
+          locale: `de-DE`,
+        }),
+      ).toBe(false)
+      expect(
+        index.matchesCompareOptions({
+          ...DEFAULT_COMPARE_OPTIONS,
+          localeOptions: { sensitivity: `base` },
+        }),
+      ).toBe(false)
+      expect(
+        index.matchesCompareOptions({
+          ...DEFAULT_COMPARE_OPTIONS,
+          nulls: `last`,
+        }),
+      ).toBe(false)
+      expect(
+        index.matchesCompareOptions({
+          ...DEFAULT_COMPARE_OPTIONS,
+          stringSort: `lexical`,
+        }),
+      ).toBe(false)
     })
 
     it(`should create multiple indexes`, () => {

--- a/packages/db/tests/query/join-subquery.test.ts
+++ b/packages/db/tests/query/join-subquery.test.ts
@@ -954,7 +954,68 @@ describe(`Lazy join: subquery whose join key resolves to an indexed collection`,
   })
 })
 
-describe(`Lazy join without a usable index`, () => {
+describe(`Lazy join index availability`, () => {
+  test(`uses an auto-index with omitted locale options`, async () => {
+    type Team = { id: string }
+    type Member = { id: string; teamId: string }
+    const teams = createCollection(
+      mockSyncCollectionOptions<Team>({
+        id: `lazy-default-collation-teams`,
+        getKey: (team) => team.id,
+        initialData: [{ id: `t1` }],
+      }),
+    )
+    const members = createCollection(
+      mockSyncCollectionOptions<Member>({
+        id: `lazy-default-collation-members`,
+        getKey: (member) => member.id,
+        initialData: [{ id: `m1`, teamId: `t1` }],
+        syncMode: `on-demand`,
+        autoIndex: `eager`,
+        defaultIndexType: BTreeIndex,
+        defaultStringCollation: {
+          stringSort: `locale`,
+          localeOptions: { sensitivity: undefined },
+        },
+        sync: {
+          sync: ({ begin, write, commit, markReady }) => {
+            begin()
+            write({ type: `insert`, value: { id: `m1`, teamId: `t1` } })
+            commit()
+            markReady()
+            return { loadSubset: () => true }
+          },
+        },
+      }),
+    )
+    const warnSpy = vi.spyOn(console, `warn`).mockImplementation(() => {})
+    const live = createLiveQueryCollection((q) =>
+      q
+        .from({ team: teams })
+        .leftJoin({ member: members }, ({ team, member }) =>
+          eq(team.id, member.teamId),
+        )
+        .select(({ team, member }) => ({
+          id: team.id,
+          memberId: member.id,
+        })),
+    )
+
+    try {
+      await live.preload()
+      expect(live.toArray.map(stripVirtualProps)).toEqual([
+        { id: `t1`, memberId: `m1` },
+      ])
+      expect(members.indexes.size).toBe(1)
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(`Join requires an index`),
+      )
+    } finally {
+      warnSpy.mockRestore()
+      await Promise.all([live.cleanup(), teams.cleanup(), members.cleanup()])
+    }
+  })
+
   test(`warns when demand falls back to a full local scan`, async () => {
     type Team = { id: string }
     type Member = { id: string; teamId: string }


### PR DESCRIPTION
## 🎯 Changes

Collections can now reuse compatible indexes when optional locale fields are omitted, set to `undefined`, or use equivalent locale identifiers such as `en-us` and `en-US`. This prevents false join fallback warnings, unnecessary local scans, and duplicate auto-indexes.

### Root Cause

`BaseIndex.matchesCompareOptions` used structural equality on full compare-options objects after ignoring direction. Collection normalization can include optional locale fields with `undefined` values while an index stores the same effective collation without those keys. It also compared locale identifiers as raw strings even though `Intl` canonicalizes equivalent identifiers.

### Approach

- Compare null placement and the effective, defaulted string-sort mode directly.
- Keep direction out of compatibility checks because indexes can be traversed in reverse.
- Canonicalize locale identifiers before comparing them.
- Normalize `localeOptions` by dropping `undefined` entries before comparison.
- Ignore locale-only fields for lexical sorting because they do not affect its order.

### Key Invariants

- Omitted options and options set to `undefined` describe the same configured collation.
- Equivalent locale identifiers may share an index.
- Different null placement, string-sort mode, canonical locale, or defined locale option must reject an index.
- Ascending and descending queries may share one compatible index.
- Repeated eager auto-index requests for the same field and effective collation create one index.

### Non-goals

This does not change global `deepEquals` semantics, join planning, or `loadSubset` pushdown behavior. It also does not equate omitted `Intl.CollatorOptions` with explicitly supplied default values; defining compatibility by fully resolved `Intl` state remains a separate design decision.

### Trade-offs

Normalization stays local to index collation matching. Changing `deepEquals` globally would alter structural equality for unrelated callers. Canonicalizing identifiers handles stable locale aliases without comparing environment-derived `Intl.Collator.resolvedOptions()` fields.

### Files changed

- `packages/db/src/indexes/base-index.ts`: match effective collation values, canonicalize locale identifiers, and normalize locale options.
- `packages/db/tests/collection-indexes.test.ts`: cover semantic matching, real mismatches, and index reuse across equivalent locale identifiers.
- `packages/db/tests/collection-auto-index.test.ts`: cover duplicate prevention for normalized locale options.
- `packages/db/tests/query/join-subquery.test.ts`: cover lazy-join index reuse and warning suppression.
- `.changeset/fix-index-collation-matching.md`: publish `@tanstack/db` as a patch.

## ✅ Checklist

- [x] I tested this code locally with the package build and focused test suite below.

```bash
pnpm --filter @tanstack/db build
pnpm --filter @tanstack/db exec vitest run tests/collection-indexes.test.ts tests/collection-auto-index.test.ts tests/query/join-subquery.test.ts tests/query/indexes.test.ts tests/query/order-by.test.ts tests/collection-change-events.test.ts --pool-options.threads.maxThreads=2
pnpm exec prettier --check packages/db/src/indexes/base-index.ts packages/db/tests/collection-indexes.test.ts
pnpm exec eslint packages/db/src/indexes/base-index.ts packages/db/tests/collection-indexes.test.ts
```

The focused suite passes 281 tests with 6 skipped and no type errors.

## 🚀 Release Impact

- [x] This change affects published code, and I generated `.changeset/fix-index-collation-matching.md` for a patch release of `@tanstack/db`.
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved index matching for locale-based string sorting when optional collation settings are omitted or set to `undefined`.
  - Recognized equivalent locale identifiers as matching sorting options.
  - Prevented duplicate indexes from being created when equivalent sorting options are used.
  - Fixed lazy joins so indexes are created and preloaded correctly when collation options are not specified.
  - Reduced unnecessary index warnings during joined queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->