### PR TITLE
fix(db): publish one event per key for metadata-only sync commits

### DIFF
--- a/.changeset/fix-metadata-only-sync-duplicate-events.md
+++ b/.changeset/fix-metadata-only-sync-duplicate-events.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db': patch
+---
+
+Capture pre-sync visible state for keys that a pending sync transaction only writes metadata for, so retiring an optimistic mutation publishes one change event per key instead of two. The duplicated event corrupted multiplicity bookkeeping in live queries, making a later optimistic write on the same key fail with "Query contributors with the same row key are not congruent".

--- a/packages/db/src/collection/state.ts
+++ b/packages/db/src/collection/state.ts
@@ -825,6 +825,32 @@ export class CollectionStateManager<
   }
 
   /**
+   * Collects every key the given sync transactions can publish a change event
+   * for.
+   *
+   * Row metadata writes count even when the transaction carries no row
+   * operation: committing one still retires a completed optimistic mutation for
+   * that key, which flips virtual props such as `$synced`. Every site that asks
+   * "which keys does this sync commit touch" must agree on this set. When they
+   * disagree, `recomputeOptimisticState` and `commitPendingTransactions` each
+   * emit the same transition and the published batch names one key twice.
+   */
+  private collectAffectedKeys(
+    transactions: Iterable<PendingSyncedTransaction<TOutput, TKey>>,
+  ): Set<TKey> {
+    const keys = new Set<TKey>()
+    for (const transaction of transactions) {
+      for (const operation of transaction.operations) {
+        keys.add(operation.key as TKey)
+      }
+      for (const key of transaction.rowMetadataWrites.keys()) {
+        keys.add(key)
+      }
+    }
+    return keys
+  }
+
+  /**
    * Attempts to commit pending synced transactions if there are no active transactions
    * This method processes operations from pending transactions and applies them to the synced data
    */
@@ -905,15 +931,7 @@ export class CollectionStateManager<
       let truncatePendingLocalOrigins: Set<TKey> | undefined
 
       // First collect all keys that will be affected by sync operations
-      const changedKeys = new Set<TKey>()
-      for (const transaction of committedSyncedTransactions) {
-        for (const operation of transaction.operations) {
-          changedKeys.add(operation.key as TKey)
-        }
-        for (const [key] of transaction.rowMetadataWrites) {
-          changedKeys.add(key)
-        }
-      }
+      const changedKeys = this.collectAffectedKeys(committedSyncedTransactions)
 
       const virtualSnapshotKeys = new Set(changedKeys)
       for (const key of this.pendingOptimisticDirectUpserts) {
@@ -1391,14 +1409,10 @@ export class CollectionStateManager<
     this.pendingSyncedTransactions.splice(index, 1)
     transaction.applied.reject(new SyncTransactionAbortedError())
 
-    const remainingPendingKeys = new Set<TKey>()
-    for (const pending of this.pendingSyncedTransactions) {
-      for (const operation of pending.operations) {
-        remainingPendingKeys.add(operation.key as TKey)
-      }
-    }
-    for (const operation of transaction.operations) {
-      const key = operation.key as TKey
+    const remainingPendingKeys = this.collectAffectedKeys(
+      this.pendingSyncedTransactions,
+    )
+    for (const key of this.collectAffectedKeys([transaction])) {
       if (!remainingPendingKeys.has(key)) {
         this.recentlySyncedKeys.delete(key)
         this.preSyncVisibleState.delete(key)
@@ -1447,12 +1461,7 @@ export class CollectionStateManager<
     if (this.pendingSyncedTransactions.length === 0) return
 
     // Get all keys that will be affected by sync operations
-    const syncedKeys = new Set<TKey>()
-    for (const transaction of this.pendingSyncedTransactions) {
-      for (const operation of transaction.operations) {
-        syncedKeys.add(operation.key as TKey)
-      }
-    }
+    const syncedKeys = this.collectAffectedKeys(this.pendingSyncedTransactions)
 
     // Mark keys as about to be synced to suppress intermediate events from recomputeOptimisticState
     for (const key of syncedKeys) {

--- a/packages/db/tests/collection-metadata-only-sync-commit.test.ts
+++ b/packages/db/tests/collection-metadata-only-sync-commit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { createCollection } from '../src/collection/index.js'
+import { createTransaction } from '../src/transactions.js'
+import { createLiveQueryCollection } from '../src/query/index.js'
+import type { ChangeMessage, SyncConfig } from '../src/types.js'
+import type { WithVirtualProps } from '../src/virtual-props.js'
+
+type Row = { id: string; position: number }
+
+/**
+ * `commitPendingTransactions` derives the keys it may emit events for from a
+ * sync transaction's operations *and* its row metadata writes, because a
+ * metadata-only transaction still flips virtual props ($synced / $origin) when
+ * it retires a completed optimistic mutation. `capturePreSyncVisibleState` only
+ * looked at the operations, so a metadata-only sync transaction left its key out
+ * of `recentlySyncedKeys`. `recomputeOptimisticState` then emitted that same
+ * transition into the batch, and the force-emit at the end of the sync commit
+ * concatenated the two — publishing one key twice in a single batch.
+ *
+ * Downstream that is a malformed diff: the live query counts the old row at -2
+ * and the new one at +2, so the next optimistic write on the key leaves two
+ * positive contributors and the keyed reduction throws "Query contributors with
+ * the same row key are not congruent".
+ *
+ * See https://github.com/TanStack/db/issues/1767
+ */
+describe(`metadata-only sync commits`, () => {
+  it(`publishes one event per key when retiring an optimistic mutation`, async () => {
+    let syncApi!: Parameters<SyncConfig<Row, string>[`sync`]>[0]
+
+    const rows = createCollection<Row, string>({
+      id: `metadata-only-sync-rows`,
+      getKey: (row) => row.id,
+      startSync: true,
+      sync: {
+        sync: (params) => {
+          syncApi = params
+          params.begin()
+          params.write({ type: `insert`, value: { id: `r1`, position: 0 } })
+          params.commit()
+          params.markReady()
+        },
+      },
+    })
+
+    const liveRows = createLiveQueryCollection((q) => q.from({ row: rows }))
+    await liveRows.preload()
+
+    const batches: Array<
+      Array<ChangeMessage<WithVirtualProps<Row, string>, string>>
+    > = []
+    rows.subscribeChanges((changes) => {
+      batches.push(changes)
+    })
+
+    // Mirrors what an adapter does when a write is acknowledged: apply the
+    // server row, then record bookkeeping metadata for the key. The metadata
+    // write lands in its own sync transaction that carries no row operations,
+    // and stays pending until the user transaction finishes persisting.
+    const round = (position: number) =>
+      createTransaction({
+        mutationFn: async () => {
+          syncApi.begin({ immediate: true })
+          syncApi.write({ type: `update`, value: { id: `r1`, position } })
+          syncApi.commit()
+
+          syncApi.begin()
+          syncApi.metadata?.row.set(`r1`, { syncedAt: position })
+          syncApi.commit()
+        },
+      }).mutate(() => {
+        rows.update(`r1`, (draft) => {
+          draft.position = draft.position + 1
+        })
+      })
+
+    await round(1).isPersisted.promise
+    // Before the fix the batch above named `r1` twice, which corrupted the live
+    // query's multiplicity bookkeeping and made this second round throw.
+    await round(2).isPersisted.promise
+
+    expect(rows.get(`r1`)?.position).toBe(2)
+    expect(liveRows.get(`r1`)?.position).toBe(2)
+    expect(rows._state.syncedMetadata.get(`r1`)).toEqual({ syncedAt: 2 })
+
+    // A published batch is a diff, so it must never name one key twice.
+    for (const batch of batches) {
+      const keys = batch.map((change) => change.key)
+      expect(keys).toEqual([...new Set(keys)])
+    }
+  })
+})

--- a/packages/query-db-collection/tests/optimistic-writeback.test.ts
+++ b/packages/query-db-collection/tests/optimistic-writeback.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { QueryClient } from '@tanstack/query-core'
+import {
+  createCollection,
+  createLiveQueryCollection,
+  createTransaction,
+} from '@tanstack/db'
+import { queryCollectionOptions } from '../src/query'
+
+type Row = { id: string; position: number }
+
+describe(`optimistic writes acknowledged by writeUpsert`, () => {
+  // `writeUpsert` refreshes the query cache after it commits, and applying that
+  // result writes row ownership metadata. That metadata write lands in a sync
+  // transaction carrying no row operations, which used to make the collection
+  // publish the key twice in one batch when the optimistic mutation retired.
+  // The duplicated diff corrupted the live query's multiplicity bookkeeping, so
+  // the second round threw "Query contributors with the same row key are not
+  // congruent" out of `Transaction.mutate`, before its own mutationFn ever ran.
+  // See https://github.com/TanStack/db/issues/1767
+  it(`survives two consecutive optimistic-then-synced writes on one key`, async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    // Live server state, so a refetch can never resurrect a stale row.
+    const server = { position: 0 }
+
+    const rows = createCollection(
+      queryCollectionOptions<Row>({
+        id: `rows`,
+        queryClient,
+        queryKey: [`rows`],
+        queryFn: async () => [{ id: `r1`, position: server.position }],
+        getKey: (row) => row.id,
+      }),
+    )
+
+    const liveRows = createLiveQueryCollection((q) => q.from({ row: rows }))
+    await liveRows.preload()
+
+    const round = (position: number) => {
+      const tx = createTransaction({
+        mutationFn: async () => {
+          server.position = position // the server accepted the write
+          rows.utils.writeUpsert({ id: `r1`, position })
+        },
+      })
+      tx.mutate(() => {
+        rows.update(`r1`, (draft) => {
+          draft.position = draft.position + 1
+        })
+      })
+      return tx
+    }
+
+    await round(1).isPersisted.promise
+    await round(2).isPersisted.promise
+
+    expect(rows.get(`r1`)?.position).toBe(2)
+    expect(liveRows.get(`r1`)?.position).toBe(2)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #1767.

Two optimistic writes in a row on the same key blow up on the second one:

```
Error: Query contributors with the same row key are not congruent
```

### What's going on

When a collection publishes a batch of changes, that batch is a diff, so each key should appear in it at most once. Here it appeared twice, with both events saying the same thing.

The sequence, using a query collection as the example:

1. You make an optimistic update, and your `mutationFn` acknowledges it with `utils.writeUpsert`.
2. `writeUpsert` refreshes the query cache, and applying that result records row ownership metadata. That metadata write goes into its own sync transaction — one with **no row operations at all**, just a metadata entry.
3. That transaction stays pending while your transaction is persisting.
4. When your transaction completes, two different code paths each notice the row switching from optimistic to synced (`$synced: false → true`), and both emit an event for it. Both land in the same published batch.

The guard meant to prevent that double-emit is `recentlySyncedKeys`, seeded by `capturePreSyncVisibleState`. But it derived its keys from a sync transaction's row *operations* only, while `commitPendingTransactions` derives its keys from operations **plus** row metadata writes. A metadata-only transaction fell straight through the gap between those two sets.

Downstream, the duplicated diff leaves the live query counting the old row at -2 and the new one at +2. The next optimistic write on that key then leaves two positive contributors with different values, which is exactly what the keyed reduction rejects.

That also explains the shape of the bug report: round one is what corrupts the bookkeeping, and round two is what notices.

### The fix

Pull the "which keys does this sync commit touch" derivation into a single helper, `collectAffectedKeys`, and use it in all three places that ask the question — `commitPendingTransactions`, `capturePreSyncVisibleState`, and `cancelPendingSyncedTransaction`. The bug was those key sets drifting apart, so this keeps them from drifting again rather than just patching the one that was behind.

Behaviour change is limited to the two sites that were missing metadata keys. `commitPendingTransactions` already had them.

### Tests

Two regression tests, both of which fail with the exact error before the fix:

- `packages/db/tests/collection-metadata-only-sync-commit.test.ts` — core-level. Drives a metadata-only sync transaction directly through the sync API while an optimistic mutation is in flight, and asserts no published batch ever names one key twice.
- `packages/query-db-collection/tests/optimistic-writeback.test.ts` — the reported path, via `utils.writeUpsert`.

### Why the existing tests missed it

The suite covers sync transactions that carry row operations, and covers row metadata, but never a transaction that writes metadata with *no* row operations while an optimistic mutation is pending — the one shape where the two key sets disagree. The core test above closes that gap, and its "a batch never names a key twice" assertion is the more general form of the invariant, so it should catch other ways of producing a malformed batch too.

### Verification

`db` 3071 · `query-db-collection` 170 + 114 e2e · `electric` 242 · `react-db` 161 · `offline-transactions` 65 · `powersync` 92 · plus trailbase, rxdb, solid, svelte, vue and angular — all passing, typecheck and lint clean.

One note: `collection-events.test.ts > should emit events with correct structure` times out under full-suite load on my machine. It does the same on an unmodified `main` (3 runs out of 3), so it looks pre-existing and unrelated to this change.

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate change events when synchronizing metadata-only updates.
  * Prevented live queries from becoming inconsistent after repeated optimistic writes to the same record.
  * Ensured synchronized metadata updates correctly participate in change tracking.

* **Tests**
  * Added regression coverage for metadata-only synchronization and consecutive optimistic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->