### PR TITLE
fix: clear release-blocking lint errors

### DIFF
--- a/packages/db/tests/collection-auto-index.test.ts
+++ b/packages/db/tests/collection-auto-index.test.ts
@@ -197,7 +197,7 @@ describe(`Collection Auto-Indexing`, () => {
 
     await collection.stateWhenReady()
 
-    expect(() => collection.createIndex((row) => row.age)).toThrow(
+    expect(() => collection.createIndex((item) => item.age)).toThrow(
       CollectionConfigurationError,
     )
   })

--- a/packages/db/tests/collection-subscribe-changes.test.ts
+++ b/packages/db/tests/collection-subscribe-changes.test.ts
@@ -2765,6 +2765,7 @@ describe(`Virtual properties`, () => {
           })
         })
         syncFns.commit()
+        return Promise.resolve()
       },
     })
 

--- a/packages/db/tests/collection-subscription-lifecycle-history.property.test.ts
+++ b/packages/db/tests/collection-subscription-lifecycle-history.property.test.ts
@@ -52,14 +52,14 @@ type RuntimeOwner = {
 
 async function runHistory(
   history: ReadonlyArray<LifecycleCommand>,
-  options: {
+  runOptions: {
     acquisitionMode?: `async-pending` | `sync-success`
     cancellation?: `manual` | `reject`
     continueAfterMismatch?: boolean
   } = {},
 ): Promise<Set<string>> {
-  const acquisitionMode = options.acquisitionMode ?? `async-pending`
-  const check = options.continueAfterMismatch ? expect.soft : expect
+  const acquisitionMode = runOptions.acquisitionMode ?? `async-pending`
+  const check = runOptions.continueAfterMismatch ? expect.soft : expect
   const failures = new Map<number, Error>()
   const failureForAttempt = (attemptId: number): Error => {
     const existing = failures.get(attemptId)
@@ -68,7 +68,7 @@ async function runHistory(
     failures.set(attemptId, failure)
     return failure
   }
-  const cancellation = options.cancellation ?? `manual`
+  const cancellation = runOptions.cancellation ?? `manual`
   const model = createLifecycleModel(
     acquisitionMode,
     failureForAttempt,
@@ -280,10 +280,10 @@ async function runHistory(
         const result = subscription.requestSnapshot({
           where: where[command.demand],
           signal: runtimeOwner?.controller.signal,
-          onLoadSubsetResult: (result, requestOptions) => {
+          onLoadSubsetResult: (loadResult, requestOptions) => {
             const attemptId =
               attemptByOptions.get(requestOptions) ?? `unacquired`
-            const resultKind = result === true ? `true` : `promise`
+            const resultKind = loadResult === true ? `true` : `promise`
             observedResults.push({ attemptId, resultKind })
             observedTrace.push({ type: `result`, attemptId, resultKind })
           },
@@ -352,7 +352,7 @@ async function runHistory(
         }
         collection.startSyncImmediate()
         if (queuesReplay) check(subscription.status).toBe(`loadingSubset`)
-      } else if (command.type === `unsubscribe`) {
+      } else {
         for (const attempt of runtimeAttempts.values()) attempt.current = false
         subscription.unsubscribe()
         observedUnsubscribed = true

--- a/packages/db/tests/collection-subscription-lifecycle-publication.property.test.ts
+++ b/packages/db/tests/collection-subscription-lifecycle-publication.property.test.ts
@@ -466,9 +466,9 @@ const publicationCommandHistoryArbitrary: fc.Arbitrary<
 
 async function runPublicationHistory(
   history: ReadonlyArray<PublicationCommand>,
-  options: PublicationRunOptions = {},
+  runOptions: PublicationRunOptions = {},
 ): Promise<Array<PublicationObservation>> {
-  const check = options.continueAfterMismatch ? expect.soft : expect
+  const check = runOptions.continueAfterMismatch ? expect.soft : expect
   const observations: Array<PublicationObservation> = []
   const lifecycle = createLifecycleModel()
   const publication: PublicationModel = {
@@ -501,14 +501,14 @@ async function runPublicationHistory(
   const collection = createCollection<Row, RowKey>({
     id: `generated-lifecycle-publication`,
     getKey: ({ id }) => id,
-    syncMode: options.withoutLoader ? `eager` : `on-demand`,
+    syncMode: runOptions.withoutLoader ? `eager` : `on-demand`,
     sync: {
       sync: (operations) => {
         const ownSession = ++session
         operationsBySession.set(ownSession, operations)
         sourceRows.set(ownSession, new Map())
         operations.markReady()
-        if (options.withoutLoader) return
+        if (runOptions.withoutLoader) return
         return {
           loadSubset: (options) => {
             const demand = demandForWhere.get(options.where)
@@ -614,11 +614,11 @@ async function runPublicationHistory(
       expected: expectedBatches,
     })
     if (
-      options.mismatches &&
+      runOptions.mismatches &&
       JSON.stringify(normalizedObserved) !== JSON.stringify(expected)
     ) {
-      const historyName = options.historyName ?? JSON.stringify(history)
-      options.mismatches.push({
+      const historyName = runOptions.historyName ?? JSON.stringify(history)
+      runOptions.mismatches.push({
         history: historyName,
         commandIndex,
         command,
@@ -803,7 +803,7 @@ async function runPublicationHistory(
         command,
         effect,
         priorPublicationCount,
-        options.withoutLoader ?? false,
+        runOptions.withoutLoader ?? false,
       )
       // Public retention never rewrites the independently installed source.
       // The publication model stops tracking source commands after unsubscribe;

--- a/packages/db/tests/collection-subscription-replay-oracle.property.test.ts
+++ b/packages/db/tests/collection-subscription-replay-oracle.property.test.ts
@@ -1441,7 +1441,7 @@ async function runOptimisticReplayScenario(
   }
 }
 
-const { multiplier, ...replay } = readOracleRunConfig()
+const { multiplier, ...replayConfig } = readOracleRunConfig()
 const generatedRuns = 30 * multiplier
 
 describe(`CollectionSubscription replay oracle`, () => {
@@ -4472,7 +4472,7 @@ describe(`CollectionSubscription replay oracle`, () => {
     [replayScenarioArbitrary],
     oracleRandomParameters(
       generatedRuns,
-      replay,
+      replayConfig,
       `subscription-replay.completion`,
     ),
   )(
@@ -4484,7 +4484,7 @@ describe(`CollectionSubscription replay oracle`, () => {
     [sequentialReplayScenarioArbitrary],
     oracleRandomParameters(
       generatedRuns,
-      replay,
+      replayConfig,
       `subscription-replay.sequential`,
     ),
   )(
@@ -4504,7 +4504,7 @@ describe(`CollectionSubscription replay oracle`, () => {
     [cleanupRestartScenarioArbitrary],
     oracleRandomParameters(
       generatedRuns,
-      replay,
+      replayConfig,
       `subscription-replay.restart`,
     ),
   )(
@@ -4521,7 +4521,7 @@ describe(`CollectionSubscription replay oracle`, () => {
     [fc.scheduler()],
     oracleRandomParameters(
       generatedRuns,
-      replay,
+      replayConfig,
       `subscription-replay.same-tick`,
     ),
   )(
@@ -4539,7 +4539,11 @@ describe(`CollectionSubscription replay oracle`, () => {
 
   fcTest.prop(
     [sharedSubscriptionScenarioArbitrary],
-    oracleRandomParameters(generatedRuns, replay, `subscription-replay.shared`),
+    oracleRandomParameters(
+      generatedRuns,
+      replayConfig,
+      `subscription-replay.shared`,
+    ),
   )(
     `keeps independent transport and logical ownership aligned for a random or replayed seed`,
     runSharedSubscriptionScenario,
@@ -4557,7 +4561,7 @@ describe(`CollectionSubscription replay oracle`, () => {
     [optimisticReplayScenarioArbitrary],
     oracleRandomParameters(
       generatedRuns,
-      replay,
+      replayConfig,
       `subscription-replay.optimistic`,
     ),
   )(

--- a/packages/db/tests/collection.test.ts
+++ b/packages/db/tests/collection.test.ts
@@ -133,14 +133,14 @@ describe(`Collection`, () => {
     const liveCollection = createLiveQueryCollection((q) =>
       q
         .from({ collection })
-        .where(({ collection }) => eq(collection.project_id, 1))
-        .select(({ collection }) => ({
-          id: collection.id,
-          text: collection.text,
-          project_id: collection.project_id,
-          $synced: collection.$synced,
-          $origin: collection.$origin,
-          $key: collection.$key,
+        .where(({ collection: item }) => eq(item.project_id, 1))
+        .select(({ collection: item }) => ({
+          id: item.id,
+          text: item.text,
+          project_id: item.project_id,
+          $synced: item.$synced,
+          $origin: item.$origin,
+          $key: item.$key,
         })),
     )
 

--- a/packages/db/tests/query/load-subset-source-readiness-refinement-oracle.test.ts
+++ b/packages/db/tests/query/load-subset-source-readiness-refinement-oracle.test.ts
@@ -177,7 +177,7 @@ it.each([
       expect(preloadState).toBe(`pending`)
 
       const freshChild: Child = { id: `fresh-child`, group: `fresh` }
-      let freshHasSettled = false
+      const freshSettlement = { settled: false }
       const settleOld = async () => {
         if (oldOutcome === `resolve`) {
           pending[0]!.rows.resolve([])
@@ -190,7 +190,7 @@ it.each([
         expect(child.get(freshChild.id)).toBeUndefined()
         pending[1]!.rows.resolve([freshChild])
         await flushPromises()
-        freshHasSettled = true
+        freshSettlement.settled = true
       }
       const settlements =
         settlementOrder === `old-first`
@@ -198,8 +198,10 @@ it.each([
           : [settleFresh, settleOld]
       for (const settle of settlements) {
         await settle()
-        expect(live.status).toBe(freshHasSettled ? `ready` : `loading`)
-        expect(preloadState).toBe(freshHasSettled ? `resolved` : `pending`)
+        expect(live.status).toBe(freshSettlement.settled ? `ready` : `loading`)
+        expect(preloadState).toBe(
+          freshSettlement.settled ? `resolved` : `pending`,
+        )
         expect(live.utils.lastSubsetError).toBeUndefined()
       }
 

--- a/packages/electric-db-collection/e2e/electric.e2e.test.ts
+++ b/packages/electric-db-collection/e2e/electric.e2e.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, inject } from 'vitest'
-import { createCollection, BasicIndex } from '@tanstack/db'
+import { BasicIndex, createCollection } from '@tanstack/db'
 import { ELECTRIC_TEST_HOOKS, electricCollectionOptions } from '../src/electric'
 import { makePgClient } from '../../db-collection-e2e/support/global-setup'
 import {

--- a/packages/electric-db-collection/tests/electric-live-query.test.ts
+++ b/packages/electric-db-collection/tests/electric-live-query.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  BasicIndex,
   createCollection,
   createLiveQueryCollection,
   eq,
   gt,
   lt,
-  BasicIndex,
 } from '@tanstack/db'
 import { electricCollectionOptions } from '../src/electric'
 import type { ElectricCollectionUtils } from '../src/electric'

--- a/packages/query-db-collection/e2e/offline-refresh.e2e.test.ts
+++ b/packages/query-db-collection/e2e/offline-refresh.e2e.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest'
-import { createCollection, BTreeIndex } from '@tanstack/db'
+import { BTreeIndex, createCollection } from '@tanstack/db'
 import { QueryClient } from '@tanstack/query-core'
 import { startOfflineExecutor } from '@tanstack/offline-transactions'
 import { queryCollectionOptions } from '../src/query'

--- a/packages/query-db-collection/e2e/query.e2e.test.ts
+++ b/packages/query-db-collection/e2e/query.e2e.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe } from 'vitest'
-import { createCollection, BTreeIndex } from '@tanstack/db'
+import { BTreeIndex, createCollection } from '@tanstack/db'
 import { QueryClient } from '@tanstack/query-core'
 import { queryCollectionOptions } from '../src/query'
 import {

--- a/packages/react-db/src/useLiveInfiniteQuery.ts
+++ b/packages/react-db/src/useLiveInfiniteQuery.ts
@@ -340,8 +340,7 @@ export function useLiveInfiniteQuery<TContext extends Context>(
     isCleanedUp: snapshot.isCleanedUp,
     collection:
       snapshot.collection as EnabledLiveQueryReturn<TContext>[`collection`],
-    isEnabled:
-      snapshot.isEnabled as EnabledLiveQueryReturn<TContext>[`isEnabled`],
+    isEnabled: snapshot.isEnabled,
     pages: snapshot.pages as Array<Array<InferResultType<TContext>[number]>>,
     pageParams: snapshot.pageParams as Array<number>,
     fetchNextPage,

--- a/packages/trailbase-db-collection/e2e/trailbase.e2e.test.ts
+++ b/packages/trailbase-db-collection/e2e/trailbase.e2e.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, inject } from 'vitest'
-import { createCollection, BTreeIndex } from '@tanstack/db'
+import { BTreeIndex, createCollection } from '@tanstack/db'
 import { initClient } from 'trailbase'
 import { trailBaseCollectionOptions } from '../src/trailbase'
 import {


### PR DESCRIPTION
Fix the lint errors blocking release CI and all 17 warnings reported in the DB tests. Test assertions and package runtime behavior stay the same.

### Review notes

TypeScript does not track the readiness test's boolean assignment inside an async callback, so ESLint treated both later conditions as always false. Store that callback-updated flag in an object to retain the assertions for both settlement orders. The lifecycle command union also leaves only `unsubscribe` after the preceding branches, so its final comparison was redundant.

Rename shadowed test bindings and explicitly return a resolved promise from the async insert fixture. Include workspace ESLint's import ordering fixes and removal of a redundant React type assertion. No lint rules are disabled; no release version or API changes are needed.

### Verification

- `pnpm --filter './packages/**' lint` — passed; unrelated warnings remain in other packages.
- DB test run covering the seven edited test files — 8 files and 411 tests passed (the collection filename filter also selects live-query collection tests).
- Prettier on all changed files and `git diff --check`.

Test command:
```sh
pnpm --filter @tanstack/db test tests/collection-auto-index.test.ts tests/collection-subscribe-changes.test.ts tests/collection-subscription-lifecycle-history.property.test.ts tests/collection-subscription-lifecycle-publication.property.test.ts tests/collection-subscription-replay-oracle.property.test.ts tests/collection.test.ts tests/query/load-subset-source-readiness-refinement-oracle.test.ts
```

### Files

- DB tests: auto-index and collection callback names; insert promise return; lifecycle history and publication options; replay configuration name; source readiness settlement flag.
- Electric, Query, and TrailBase test imports: automatic ordering fixes.
- React `useLiveInfiniteQuery`: remove a redundant type assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal type handling for live infinite queries.
  - Clarified naming and callback handling across database tests.

- **Tests**
  - Improved readiness assertions for live-query and preload state.
  - Made asynchronous test handlers’ completion explicit.
  - Standardized test configuration and import ordering.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->