### PR TITLE
fix(trailbase): isolate stream lifetimes and add lifecycle oracle

### DIFF
--- a/.changeset/fix-trailbase-stream-lifetimes.md
+++ b/.changeset/fix-trailbase-stream-lifetimes.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/trailbase-db-collection': patch
+---
+
+Fix unhandled rejections and resource leaks when a TrailBase subscription closes, fails, or is cleaned up. Drain buffered events before releasing the reader and prevent a canceled startup from canceling a replacement sync session.

--- a/notes/rfc-1657-trailbase.md
+++ b/notes/rfc-1657-trailbase.md
@@ -1,4 +1,4 @@
-# TrailBase stream termination
+# RFC 1657 follow-up: TrailBase stream termination
 
 Base: origin/main ad043b745. This is the narrow error-handling bug found while
 examining #1521; it does not implement that PR's polling policy.

--- a/packages/db/tests/oracle-config.ts
+++ b/packages/db/tests/oracle-config.ts
@@ -1,6 +1,7 @@
 type OracleEnvironment = Record<string, string | undefined>
 
 const staticOracleProperties = [
+  `trailbase.lifecycle`,
   `collection-sync.reentrant-drain`,
   `collection-state.retention`,
   `collection-publication.metadata-cancellation`,

--- a/packages/trailbase-db-collection/package.json
+++ b/packages/trailbase-db-collection/package.json
@@ -21,6 +21,7 @@
     "dev": "vite build --watch",
     "lint": "eslint . --fix",
     "test": "vitest --run",
+    "test:oracles": "vitest run tests/lifecycle-oracle.property.test.ts",
     "test:e2e": "vitest --run --config vitest.e2e.config.ts"
   },
   "type": "module",

--- a/packages/trailbase-db-collection/src/trailbase.ts
+++ b/packages/trailbase-db-collection/src/trailbase.ts
@@ -335,12 +335,13 @@ export function trailBaseCollectionOptions<
           // Start listening for subscriptions first. Otherwise, we'd risk a gap
           // between the initial fetch and starting to listen.
           void listen(subscribedReader)
-            .finally(async () => {
+            .finally(() => {
               // A closed stream can still have a final event being processed.
               // Release only after the listener has finished draining it.
               // A processing failure can leave the stream open; cancel it too.
               // Preserve the original failure if the stream already errored.
-              await subscribedReader.cancel().catch(() => undefined)
+              // Error settlement must not wait for transport cleanup.
+              void subscribedReader.cancel().catch(() => undefined)
               subscribedReader.releaseLock()
               if (eventReader === subscribedReader) eventReader = undefined
             })

--- a/packages/trailbase-db-collection/src/trailbase.ts
+++ b/packages/trailbase-db-collection/src/trailbase.ts
@@ -381,12 +381,18 @@ export function trailBaseCollectionOptions<
           })
         }, 120 * 1000)
 
-        reader.closed.finally(() => {
+        const subscribedReader = reader
+        const releaseReader = () => {
           if (periodicCleanupTask !== undefined) {
             clearInterval(periodicCleanupTask)
             periodicCleanupTask = undefined
           }
-        })
+          subscribedReader.releaseLock()
+          if (eventReader === subscribedReader) eventReader = undefined
+        }
+        // listen() reports read errors. Observe this separate promise too, and
+        // retire the reader so later cleanup cannot cancel an errored stream.
+        void subscribedReader.closed.then(releaseReader, releaseReader)
       }
 
       void start()

--- a/packages/trailbase-db-collection/src/trailbase.ts
+++ b/packages/trailbase-db-collection/src/trailbase.ts
@@ -171,7 +171,9 @@ export function trailBaseCollectionOptions<
   let eventReader: ReadableStreamDefaultReader<Event> | undefined
   const cancelEventReader = () => {
     if (eventReader) {
-      eventReader.cancel()
+      // An already-errored stream rejects cancellation too. Cleanup still
+      // retires its reader; that rejection must not escape as detached work.
+      void eventReader.cancel().catch(() => undefined)
       eventReader.releaseLock()
       eventReader = undefined
     }
@@ -290,8 +292,6 @@ export function trailBaseCollectionOptions<
           const { done, value: event } = await reader.read()
 
           if (done || !event) {
-            reader.releaseLock()
-            eventReader = undefined
             return
           }
 
@@ -329,17 +329,28 @@ export function trailBaseCollectionOptions<
             await eventStream.cancel()
             return
           }
-          reader = eventReader = eventStream.getReader()
+          const subscribedReader = eventStream.getReader()
+          reader = eventReader = subscribedReader
 
           // Start listening for subscriptions first. Otherwise, we'd risk a gap
           // between the initial fetch and starting to listen.
-          void listen(reader).catch((error: unknown) => {
-            if (!cancelled && collection.status === `loading`) {
-              markError(error)
-            } else if (!cancelled) {
-              console.error(`TrailBase subscription failed`, error)
-            }
-          })
+          void listen(subscribedReader)
+            .finally(async () => {
+              // A closed stream can still have a final event being processed.
+              // Release only after the listener has finished draining it.
+              // A processing failure can leave the stream open; cancel it too.
+              // Preserve the original failure if the stream already errored.
+              await subscribedReader.cancel().catch(() => undefined)
+              subscribedReader.releaseLock()
+              if (eventReader === subscribedReader) eventReader = undefined
+            })
+            .catch((error: unknown) => {
+              if (!cancelled && collection.status === `loading`) {
+                markError(error)
+              } else if (!cancelled) {
+                console.error(`TrailBase subscription failed`, error)
+              }
+            })
 
           // Eager mode: perform initial fetch to populate everything
           if (internalSyncMode === `eager`) {
@@ -352,8 +363,10 @@ export function trailBaseCollectionOptions<
             markReady()
           }
         } catch (error) {
+          // An abandoned startup must not cancel a replacement session's reader.
+          if (cancelled) return
           cancelEventReader()
-          if (!cancelled && collection.status === `loading`) {
+          if (collection.status === `loading`) {
             markError(error)
           }
           return
@@ -381,18 +394,14 @@ export function trailBaseCollectionOptions<
           })
         }, 120 * 1000)
 
-        const subscribedReader = reader
-        const releaseReader = () => {
+        const clearCleanupTask = () => {
           if (periodicCleanupTask !== undefined) {
             clearInterval(periodicCleanupTask)
             periodicCleanupTask = undefined
           }
-          subscribedReader.releaseLock()
-          if (eventReader === subscribedReader) eventReader = undefined
         }
-        // listen() reports read errors. Observe this separate promise too, and
-        // retire the reader so later cleanup cannot cancel an errored stream.
-        void subscribedReader.closed.then(releaseReader, releaseReader)
+        // listen() reports read errors. Observe this separate promise too.
+        void reader.closed.then(clearCleanupTask, clearCleanupTask)
       }
 
       void start()

--- a/packages/trailbase-db-collection/tests/ORACLE.md
+++ b/packages/trailbase-db-collection/tests/ORACLE.md
@@ -14,6 +14,9 @@ The same interpreter runs a fixed corpus and generated histories.
 - Graceful closure drains buffered events before releasing the reader.
 - Processing failures cancel an open source. Terminal paths release readers and
   timers without detached rejections, including same-turn cleanup.
+- A startup processing error rejects readiness before asynchronous cancellation
+  settles. Two fixed controls hold cancellation through later list completion,
+  then resolve or reject it; cleanup cannot turn failed startup into readiness.
 - Cleanup clears the collection. Late work from an old session cannot publish
   into, cancel, or report errors against a replacement session.
 
@@ -25,7 +28,9 @@ ordinary runs add 30 fixed-seed and 50 fresh-seed histories with shrinking.
 This is not a model of pagination, filtered subsets, optimistic mutation
 acknowledgements, service reconnects, or arbitrary event/list interleavings.
 The generated event phase starts after loading; existing loading-time unit
-matrices remain valuable. The on-demand driver calls the core subset boundary,
+matrices and the two held-cancellation startup controls remain valuable. Those
+controls were both RED when listener failure awaited cancellation, and GREEN
+when cancellation was observed separately. The on-demand driver calls the core subset boundary,
 not a live query. Service-backed E2E coverage remains separate.
 
 ## Run and replay

--- a/packages/trailbase-db-collection/tests/ORACLE.md
+++ b/packages/trailbase-db-collection/tests/ORACLE.md
@@ -1,0 +1,69 @@
+# TrailBase lifecycle oracle
+
+`lifecycle-oracle.property.test.ts` runs the real adapter and collection against
+a controlled RecordApi and native ReadableStream. Only network I/O is mocked.
+An independent Map models rows; explicit gates control subscribe/list settlement.
+The same interpreter runs a fixed corpus and generated histories.
+
+## Laws and scope
+
+- Published inserts, updates and deletes agree with the model after each event.
+- Eager startup waits for its list; on-demand startup does not claim to load rows.
+  Required startup failures reject. Later stream failures retain rows and report
+  the error, matching the adapter's current policy.
+- Graceful closure drains buffered events before releasing the reader.
+- Processing failures cancel an open source. Terminal paths release readers and
+  timers without detached rejections, including same-turn cleanup.
+- Cleanup clears the collection. Late work from an old session cannot publish
+  into, cancel, or report errors against a replacement session.
+
+Histories contain one to three sessions, eager/on-demand modes, delayed startup
+and list resolve/reject, zero to eight row edits, five stream endings, and
+immediate versus settled cleanup. Thirty-two fixed cases pin the boundaries;
+ordinary runs add 30 fixed-seed and 50 fresh-seed histories with shrinking.
+
+This is not a model of pagination, filtered subsets, optimistic mutation
+acknowledgements, service reconnects, or arbitrary event/list interleavings.
+The generated event phase starts after loading; existing loading-time unit
+matrices remain valuable. The on-demand driver calls the core subset boundary,
+not a live query. Service-backed E2E coverage remains separate.
+
+## Run and replay
+
+Run from `packages/trailbase-db-collection`:
+
+```sh
+pnpm test:oracles --coverage.enabled=false
+TANSTACK_DB_ORACLE_RUNS_MULTIPLIER=10 pnpm test:oracles --coverage.enabled=false --testTimeout=60000
+```
+
+For a failing random campaign, use its reported seed and shrink path:
+
+```sh
+TANSTACK_DB_ORACLE_SEED=123 TANSTACK_DB_ORACLE_PATH=0:1 TANSTACK_DB_ORACLE_PROPERTY=trailbase.lifecycle pnpm test:oracles --coverage.enabled=false -t 'random or replayed'
+```
+
+Replace the example seed/path with the failure's values. Shared configuration
+lives in `packages/db/tests/oracle-config.ts`; do not copy its replay parser.
+
+## Evidence against false greens
+
+Before the stale-startup fix, both campaigns independently shrank to: cancel a
+pending subscription, restart and load a healthy stream, reject the old subscribe.
+The old startup canceled the replacement reader. The fixed corpus pins this in
+both modes and sends further edits through the replacement stream.
+
+Five isolated source-transform mutations were each rejected by the fixed corpus:
+
+| Reintroduced fault                                | Failing cases | Detecting assertion                               |
+| ------------------------------------------------- | ------------: | ------------------------------------------------- |
+| Unobserved `reader.closed.finally()` rejection    |             4 | No detached rejections                            |
+| Release reader as soon as `closed` settles        |             2 | Buffered close reports no error                   |
+| Omit source cancellation after processing failure |             2 | Underlying source canceled                        |
+| Ignore cleanup's cancellation rejection           |             2 | Same-turn cleanup has no detached rejection       |
+| Let abandoned startup cancel the current reader   |             2 | Replacement remains locked, uncanceled and usable |
+
+These targeted mutations test known failure classes, not overall mutation
+coverage or a proof of completeness. The 10× campaign passed 800 generated
+histories (fixed seed 714203, random seed 127535183) plus the 32 corpus cases.
+No service-backed E2E run is claimed.

--- a/packages/trailbase-db-collection/tests/lifecycle-oracle.property.test.ts
+++ b/packages/trailbase-db-collection/tests/lifecycle-oracle.property.test.ts
@@ -1,0 +1,375 @@
+import { fc, test as fcTest } from '@fast-check/vitest'
+import { expect, it, vi } from 'vitest'
+import { createCollection } from '@tanstack/db'
+import { oraclePropertyOptions, oracleRuns } from '../../db/tests/oracle-config'
+import { trailBaseCollectionOptions } from '../src/trailbase'
+import { MockRecordApi } from './mock-record-api'
+import type { Event, ListResponse } from 'trailbase'
+
+type Row = { id: number; value: number }
+type Change = { operation: `set` | `delete`; id: number; value: number }
+type Ending =
+  | `close`
+  | `buffered-close`
+  | `read-error`
+  | `parse-error`
+  | `cleanup`
+type Session =
+  | { kind: `cancel-subscribe`; late: `resolve` | `reject` }
+  | { kind: `cancel-load`; late: `resolve` | `reject` }
+  | { kind: `reject-subscribe` }
+  | { kind: `reject-load` }
+  | {
+      kind: `stream`
+      changes: Array<Change>
+      ending: Ending
+      immediate: boolean
+    }
+type Scenario = { mode: `eager` | `on-demand`; sessions: Array<Session> }
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  // Every adapter promise is observed even when its session is abandoned.
+  void promise.catch(() => undefined)
+  return { promise, resolve, reject }
+}
+
+function observe(promise: Promise<unknown>) {
+  let result: `pending` | `fulfilled` | `rejected` = `pending`
+  let error: unknown
+  void promise.then(
+    () => {
+      result = `fulfilled`
+    },
+    (failure: unknown) => {
+      result = `rejected`
+      error = failure
+    },
+  )
+  return {
+    get result() {
+      return result
+    },
+    get error() {
+      return error
+    },
+  }
+}
+
+// All adapter I/O is gated. One host turn drains native stream microtasks and
+// exposes detached rejections; it does not stand in for a network completion.
+const turn = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+const failure = new Error(`oracle stream failure`)
+const invalidValue = -10_000
+
+function source() {
+  let controller!: ReadableStreamDefaultController<Event>
+  const cancel = vi.fn()
+  const stream = new ReadableStream<Event>({
+    start(value) {
+      controller = value
+    },
+    cancel,
+  })
+  return {
+    stream,
+    cancel,
+    controller,
+    subscription: deferred<ReadableStream<Event>>(),
+    list: deferred<ListResponse<Row>>(),
+    listCalls: 0,
+  }
+}
+
+/**
+ * Reference: rows are an independent key/value relation. Before readiness a
+ * required load failure rejects startup; afterward a broken stream retains
+ * the last rows and reports an error. Cleanup clears rows and retires work.
+ * The model never reads adapter bookkeeping, pending transactions or caches.
+ */
+async function checkLifecycle({ mode, sessions }: Scenario) {
+  const api = new MockRecordApi<Row>()
+  let current = source()
+  api.subscribe.mockImplementation(() => current.subscription.promise)
+  api.list.mockImplementation(() => {
+    current.listCalls++
+    return current.list.promise
+  })
+  const allSources: Array<ReturnType<typeof source>> = []
+  const retired: Array<() => void> = []
+  const unhandled: Array<unknown> = []
+  const onUnhandled = (error: unknown) => unhandled.push(error)
+  const reported = vi.spyOn(console, `error`).mockImplementation(() => {})
+  const intervals = vi.spyOn(globalThis, `setInterval`)
+  const cleared = vi.spyOn(globalThis, `clearInterval`)
+  process.on(`unhandledRejection`, onUnhandled)
+  const collection = createCollection(
+    trailBaseCollectionOptions({
+      recordApi: api,
+      getKey: (row: Row) => row.id,
+      syncMode: mode,
+      parse: {
+        value: (value) => {
+          if (value === invalidValue) throw failure
+          return value
+        },
+      },
+      serialize: {},
+    }),
+  )
+  let expected = new Map<number, Row>()
+  const publicRows = () =>
+    Array.from(collection.values(), ({ id, value }) => ({ id, value })).sort(
+      (a, b) => a.id - b.id,
+    )
+  const assertRows = () =>
+    expect(publicRows()).toEqual(
+      [...expected.values()].sort((a, b) => a.id - b.id),
+    )
+  const assertNoTimers = () => {
+    for (const timer of intervals.mock.results) {
+      if (timer.type === `return`)
+        expect(cleared).toHaveBeenCalledWith(timer.value)
+    }
+  }
+  const flushRetired = async () => {
+    retired.splice(0).forEach((settle) => settle())
+    await turn()
+    assertRows()
+    expect(unhandled).toEqual([])
+  }
+  try {
+    for (const [epoch, plan] of sessions.entries()) {
+      current = source()
+      const active = current
+      allSources.push(active)
+      expected = new Map()
+      reported.mockClear()
+      collection.startSyncImmediate()
+      const preload = observe(collection.preload())
+      await turn()
+      expect(api.subscribe).toHaveBeenCalledTimes(epoch + 1)
+      expect(collection.status).toBe(`loading`)
+      expect(preload.result).toBe(`pending`)
+      assertRows()
+
+      if (plan.kind === `cancel-subscribe`) {
+        await collection.cleanup()
+        retired.push(() =>
+          plan.late === `resolve`
+            ? active.subscription.resolve(active.stream)
+            : active.subscription.reject(failure),
+        )
+      } else if (plan.kind === `reject-subscribe`) {
+        active.subscription.reject(failure)
+        await turn()
+        expect(preload.result).toBe(`rejected`)
+        expect(preload.error).toBe(failure)
+        expect(collection.status).toBe(`error`)
+        expect(active.listCalls).toBe(0)
+        await collection.cleanup()
+      } else {
+        active.subscription.resolve(active.stream)
+        await turn()
+        const load =
+          mode === `eager`
+            ? preload
+            : observe(Promise.resolve(collection._sync.loadSubset({})))
+        await turn()
+        expect(active.listCalls).toBe(1)
+        expect(load.result).toBe(`pending`)
+        expect(preload.result).toBe(mode === `eager` ? `pending` : `fulfilled`)
+
+        if (plan.kind === `cancel-load`) {
+          await collection.cleanup()
+          retired.push(() =>
+            plan.late === `resolve`
+              ? active.list.resolve({ records: [{ id: 99, value: epoch }] })
+              : active.list.reject(failure),
+          )
+        } else if (plan.kind === `reject-load`) {
+          active.list.reject(failure)
+          await turn()
+          expect(load.result).toBe(`rejected`)
+          expect(load.error).toBe(failure)
+          expect(collection.status).toBe(mode === `eager` ? `error` : `ready`)
+          assertRows()
+          await collection.cleanup()
+        } else {
+          const baseline = { id: 0, value: epoch }
+          active.list.resolve({ records: [baseline] })
+          expected.set(0, baseline)
+          await turn()
+          expect(load.result).toBe(`fulfilled`)
+          expect(preload.result).toBe(`fulfilled`)
+          expect(collection.status).toBe(`ready`)
+          assertRows()
+
+          // Old subscribe/list work finishes only once the replacement owns
+          // a live stream and baseline, not merely after the old cleanup.
+          await flushRetired()
+          expect(active.stream.locked).toBe(true)
+          expect(active.cancel).not.toHaveBeenCalled()
+
+          for (const change of plan.changes) {
+            const previous = expected.get(change.id)
+            if (change.operation === `delete`) {
+              if (!previous) continue // Only issue legal deletes from the model.
+              active.controller.enqueue({ Delete: previous })
+              expected.delete(change.id)
+            } else {
+              const row = { id: change.id, value: change.value }
+              active.controller.enqueue(
+                previous ? { Update: row } : { Insert: row },
+              )
+              expected.set(change.id, row)
+            }
+            await turn()
+            assertRows()
+            expect(collection.status).toBe(`ready`)
+          }
+
+          if (plan.ending === `buffered-close`) {
+            for (const id of [10, 11]) {
+              const row = { id, value: epoch }
+              active.controller.enqueue({ Insert: row })
+              expected.set(id, row)
+            }
+          }
+          if (plan.ending === `close` || plan.ending === `buffered-close`)
+            active.controller.close()
+          if (plan.ending === `read-error`) active.controller.error(failure)
+          if (plan.ending === `parse-error`)
+            active.controller.enqueue({
+              Insert: { id: 12, value: invalidValue },
+            })
+          if (plan.immediate || plan.ending === `cleanup`) {
+            await collection.cleanup()
+            expected.clear()
+          }
+          await turn()
+          assertRows()
+          expect(active.stream.locked).toBe(false)
+          assertNoTimers()
+          const isFailure =
+            plan.ending === `read-error` || plan.ending === `parse-error`
+          if (isFailure && !plan.immediate) {
+            expect(reported).toHaveBeenCalledExactlyOnceWith(
+              `TrailBase subscription failed`,
+              failure,
+            )
+          } else expect(reported).not.toHaveBeenCalled()
+          if (plan.ending === `cleanup` || plan.ending === `parse-error`)
+            expect(active.cancel).toHaveBeenCalledOnce()
+          if (!plan.immediate && plan.ending !== `cleanup`)
+            expect(collection.status).toBe(`ready`)
+          await collection.cleanup()
+        }
+      }
+      expected.clear()
+      await turn()
+      assertRows()
+      expect(collection.status).toBe(`cleaned-up`)
+      expect(unhandled).toEqual([])
+      assertNoTimers()
+    }
+    await flushRetired()
+    for (const active of allSources) expect(active.stream.locked).toBe(false)
+  } finally {
+    await collection.cleanup()
+    // Release all controlled gates even when a mutant fails an early assertion.
+    for (const active of allSources) {
+      active.subscription.resolve(active.stream)
+      active.list.resolve({ records: [] })
+    }
+    await turn()
+    process.off(`unhandledRejection`, onUnhandled)
+    reported.mockRestore()
+    intervals.mockRestore()
+    cleared.mockRestore()
+  }
+}
+
+const changeArb = fc.record({
+  operation: fc.constantFrom<Change[`operation`]>(`set`, `delete`),
+  id: fc.integer({ min: 0, max: 3 }),
+  value: fc.integer({ min: -20, max: 20 }),
+})
+const sessionArb: fc.Arbitrary<Session> = fc.oneof(
+  fc.record({
+    kind: fc.constantFrom(`cancel-subscribe` as const, `cancel-load` as const),
+    late: fc.constantFrom(`resolve` as const, `reject` as const),
+  }),
+  fc.record({
+    kind: fc.constantFrom(`reject-subscribe` as const, `reject-load` as const),
+  }),
+  fc.record({
+    kind: fc.constant(`stream` as const),
+    changes: fc.array(changeArb, { maxLength: 8 }),
+    ending: fc.constantFrom<Ending>(
+      `close`,
+      `buffered-close`,
+      `read-error`,
+      `parse-error`,
+      `cleanup`,
+    ),
+    immediate: fc.boolean(),
+  }),
+)
+const scenarioArb = fc.record({
+  mode: fc.constantFrom(`eager` as const, `on-demand` as const),
+  sessions: fc.array(sessionArb, { minLength: 1, maxLength: 3 }),
+})
+const live = (ending: Ending, immediate = false): Session => ({
+  kind: `stream`,
+  ending,
+  immediate,
+  changes: [
+    { operation: `set`, id: 1, value: 3 },
+    { operation: `set`, id: 1, value: 4 },
+    { operation: `delete`, id: 1, value: 0 },
+  ],
+})
+
+// Fixed witnesses ensure every lifecycle boundary is exercised, independently
+// of the random distribution. The same interpreter runs corpus and fuzz cases.
+const corpus: Array<{ name: string; sessions: Array<Session> }> = [
+  ...(
+    [`close`, `buffered-close`, `read-error`, `parse-error`, `cleanup`] as const
+  ).flatMap((ending) =>
+    [false, true].map((immediate) => ({
+      name: `${ending}, immediate=${immediate}`,
+      sessions: [live(ending, immediate)],
+    })),
+  ),
+  ...([`cancel-subscribe`, `cancel-load`] as const).flatMap((kind) =>
+    ([`resolve`, `reject`] as const).map((late) => ({
+      name: `${kind}, stale ${late} after restart`,
+      sessions: [{ kind, late }, live(`close`)],
+    })),
+  ),
+  ...([`reject-subscribe`, `reject-load`] as const).map((kind) => ({
+    name: kind,
+    sessions: [{ kind }, live(`close`)],
+  })),
+]
+it.each(
+  corpus.flatMap((entry) =>
+    ([`eager`, `on-demand`] as const).map((mode) => ({ ...entry, mode })),
+  ),
+)(`preserves lifecycle laws: $mode / $name`, ({ mode, sessions }) =>
+  checkLifecycle({ mode, sessions }),
+)
+fcTest.prop([scenarioArb], { seed: 714_203, numRuns: oracleRuns(30) })(
+  `matches generated lifecycle histories with a fixed seed`,
+  checkLifecycle,
+)
+fcTest.prop([scenarioArb], oraclePropertyOptions(50, `trailbase.lifecycle`))(
+  `matches generated lifecycle histories with a random or replayed seed`,
+  checkLifecycle,
+)

--- a/packages/trailbase-db-collection/tests/lifecycle-oracle.property.test.ts
+++ b/packages/trailbase-db-collection/tests/lifecycle-oracle.property.test.ts
@@ -69,7 +69,7 @@ const invalidValue = -10_000
 
 function source() {
   let controller!: ReadableStreamDefaultController<Event>
-  const cancel = vi.fn()
+  const cancel = vi.fn((): void | Promise<void> => {})
   const stream = new ReadableStream<Event>({
     start(value) {
       controller = value
@@ -358,6 +358,53 @@ const corpus: Array<{ name: string; sessions: Array<Session> }> = [
     sessions: [{ kind }, live(`close`)],
   })),
 ]
+it.each([`resolve`, `reject`] as const)(
+  `rejects startup before stream cancellation can %s`,
+  async (cancellation) => {
+    const active = source()
+    const cancelled = deferred<void>()
+    active.cancel.mockImplementation(() => cancelled.promise)
+    const api = new MockRecordApi<Row>()
+    api.subscribe.mockResolvedValue(active.stream)
+    api.list.mockImplementation(() => active.list.promise)
+    const collection = createCollection(
+      trailBaseCollectionOptions({
+        recordApi: api,
+        getKey: (row: Row) => row.id,
+        syncMode: `eager`,
+        parse: {
+          value: () => {
+            throw failure
+          },
+        },
+        serialize: {},
+      }),
+    )
+    const preload = observe(collection.preload())
+    try {
+      await turn()
+      expect(api.list).toHaveBeenCalledOnce()
+      active.controller.enqueue({ Insert: { id: 1, value: invalidValue } })
+      await turn()
+      expect(active.cancel).toHaveBeenCalledOnce()
+      // Cleanup I/O is still pending, but it cannot postpone the load error.
+      expect(preload.result).toBe(`rejected`)
+      expect(preload.error).toBe(failure)
+      expect(collection.status).toBe(`error`)
+      active.list.resolve({ records: [] })
+      await turn()
+      expect(preload.result).toBe(`rejected`)
+      expect(collection.status).toBe(`error`)
+    } finally {
+      if (cancellation === `resolve`) cancelled.resolve()
+      else cancelled.reject(new Error(`cancel failure`))
+      active.list.resolve({ records: [] })
+      await collection.cleanup()
+      await turn()
+    }
+  },
+)
+
 it.each(
   corpus.flatMap((entry) =>
     ([`eager`, `on-demand`] as const).map((mode) => ({ ...entry, mode })),

--- a/packages/trailbase-db-collection/tests/mock-record-api.ts
+++ b/packages/trailbase-db-collection/tests/mock-record-api.ts
@@ -1,0 +1,90 @@
+import { vi } from 'vitest'
+import type {
+  CreateOperation,
+  DeleteOperation,
+  Event,
+  FilterOrComposite,
+  ListOperation,
+  ListOpts,
+  ListResponse,
+  Pagination,
+  ReadOperation,
+  ReadOpts,
+  RecordApi,
+  RecordId,
+  SubscribeOpts,
+  UpdateOperation,
+} from 'trailbase'
+
+export class MockRecordApi<T> implements RecordApi<T> {
+  list = vi.fn(
+    (_opts?: {
+      pagination?: Pagination
+      order?: Array<string>
+      filters?: Array<FilterOrComposite>
+      count?: boolean
+      expand?: Array<string>
+    }): Promise<ListResponse<T>> => {
+      return Promise.resolve({ records: [] })
+    },
+  )
+  listOp = vi.fn((_opts?: ListOpts): ListOperation<T> => {
+    throw `listOp`
+  })
+  listGeoOp = vi.fn((_geometryColumn: string, _opts?: ListOpts) => {
+    throw `listGeoOp`
+  })
+
+  read = vi.fn(
+    (
+      _id: string | number,
+      _opt?: {
+        expand?: Array<string>
+      },
+    ): Promise<T> => {
+      throw `read`
+    },
+  )
+  readOp = vi.fn((_id: RecordId, _opt?: ReadOpts): ReadOperation<T> => {
+    throw `readOp`
+  })
+
+  create = vi.fn((_record: T): Promise<string | number> => {
+    throw `create`
+  })
+  createBulk = vi.fn((_records: Array<T>): Promise<Array<string | number>> => {
+    throw `createBulk`
+  })
+  createOp = vi.fn((_record: T): CreateOperation<T> => {
+    throw `createOp`
+  })
+
+  update = vi.fn((_id: string | number, _record: Partial<T>): Promise<void> => {
+    throw `update`
+  })
+  updateOp = vi.fn((_id: RecordId, _record: Partial<T>): UpdateOperation => {
+    throw `updateOp`
+  })
+
+  delete = vi.fn((_id: string | number): Promise<void> => {
+    throw `delete`
+  })
+  deleteOp = vi.fn((_id: RecordId): DeleteOperation => {
+    throw `deleteOp`
+  })
+
+  subscribe = vi.fn((_id: string | number): Promise<ReadableStream<Event>> => {
+    return Promise.resolve(
+      new ReadableStream({
+        start: (controller: ReadableStreamDefaultController<Event>) => {
+          controller.close()
+        },
+      }),
+    )
+  })
+  subscribeAll = vi.fn(
+    (_opts?: SubscribeOpts): Promise<ReadableStream<Event>> => {
+      throw `subscribeAll`
+    },
+  )
+}

--- a/packages/trailbase-db-collection/tests/trailbase.test.ts
+++ b/packages/trailbase-db-collection/tests/trailbase.test.ts
@@ -2,22 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { createCollection, createTransaction } from '@tanstack/db'
 import { trailBaseCollectionOptions } from '../src/trailbase'
 import { stripVirtualProps } from '../../db/tests/utils'
-import type {
-  CreateOperation,
-  DeleteOperation,
-  Event,
-  FilterOrComposite,
-  ListOperation,
-  ListOpts,
-  ListResponse,
-  Pagination,
-  ReadOperation,
-  ReadOpts,
-  RecordApi,
-  RecordId,
-  SubscribeOpts,
-  UpdateOperation,
-} from 'trailbase'
+import { MockRecordApi } from './mock-record-api'
+import type { Event, ListResponse } from 'trailbase'
 
 type Data = {
   id: number | null
@@ -32,79 +18,6 @@ const stripState = (state: Map<number | string | null, Data>) =>
       stripVirtualProps(value),
     ]),
   )
-
-class MockRecordApi<T> implements RecordApi<T> {
-  list = vi.fn(
-    (_opts?: {
-      pagination?: Pagination
-      order?: Array<string>
-      filters?: Array<FilterOrComposite>
-      count?: boolean
-      expand?: Array<string>
-    }): Promise<ListResponse<T>> => {
-      return Promise.resolve({ records: [] })
-    },
-  )
-  listOp = vi.fn((_opts?: ListOpts): ListOperation<T> => {
-    throw `listOp`
-  })
-  listGeoOp = vi.fn((_geometryColumn: string, _opts?: ListOpts) => {
-    throw `listGeoOp`
-  })
-
-  read = vi.fn(
-    (
-      _id: string | number,
-      _opt?: {
-        expand?: Array<string>
-      },
-    ): Promise<T> => {
-      throw `read`
-    },
-  )
-  readOp = vi.fn((_id: RecordId, _opt?: ReadOpts): ReadOperation<T> => {
-    throw `readOp`
-  })
-
-  create = vi.fn((_record: T): Promise<string | number> => {
-    throw `create`
-  })
-  createBulk = vi.fn((_records: Array<T>): Promise<Array<string | number>> => {
-    throw `createBulk`
-  })
-  createOp = vi.fn((_record: T): CreateOperation<T> => {
-    throw `createOp`
-  })
-
-  update = vi.fn((_id: string | number, _record: Partial<T>): Promise<void> => {
-    throw `update`
-  })
-  updateOp = vi.fn((_id: RecordId, _record: Partial<T>): UpdateOperation => {
-    throw `updateOp`
-  })
-
-  delete = vi.fn((_id: string | number): Promise<void> => {
-    throw `delete`
-  })
-  deleteOp = vi.fn((_id: RecordId): DeleteOperation => {
-    throw `deleteOp`
-  })
-
-  subscribe = vi.fn((_id: string | number): Promise<ReadableStream<Event>> => {
-    return Promise.resolve(
-      new ReadableStream({
-        start: (controller: ReadableStreamDefaultController<Event>) => {
-          controller.close()
-        },
-      }),
-    )
-  })
-  subscribeAll = vi.fn(
-    (_opts?: SubscribeOpts): Promise<ReadableStream<Event>> => {
-      throw `subscribeAll`
-    },
-  )
-}
 
 function setUp(recordApi: MockRecordApi<Data>) {
   // Get the options with utilities
@@ -138,7 +51,111 @@ async function expectWildcardFailureSettlesPreload(): Promise<void> {
 }
 
 describe(`TrailBase Integration`, () => {
-  it.each([`close`, `error`] as const)(
+  it.each(
+    ([`loading`, `ready`] as const).flatMap((phase) =>
+      ([`close`, `error`] as const).map((ending) => ({ phase, ending })),
+    ),
+  )(
+    `handles same-turn $ending and cleanup while $phase`,
+    async ({ phase, ending }) => {
+      const recordApi = new MockRecordApi<Data>()
+      const row: Data = { id: 1, updated: 0, data: `loaded` }
+      let resolveList!: (response: ListResponse<Data>) => void
+      recordApi.list.mockReturnValue(
+        new Promise((resolve) => {
+          resolveList = resolve
+        }),
+      )
+      let controller!: ReadableStreamDefaultController<Event>
+      const stream = new ReadableStream<Event>({
+        start(value) {
+          controller = value
+        },
+      })
+      recordApi.subscribe.mockResolvedValue(stream)
+      const errors: Array<unknown> = []
+      const recordUnhandled = (error: unknown) => errors.push(error)
+      process.on(`unhandledRejection`, recordUnhandled)
+      const collection = createCollection(setUp(recordApi))
+      const preload = collection.preload().then(
+        () => `ready`,
+        (error: unknown) => error,
+      )
+      try {
+        await vi.waitFor(() => expect(recordApi.list).toHaveBeenCalledOnce())
+        if (phase === `ready`) {
+          resolveList({ records: [row] })
+          expect(await preload).toBe(`ready`)
+          expect(collection.get(1)).toMatchObject(row)
+        }
+        if (ending === `error`) controller.error(new Error(`connection lost`))
+        else controller.close()
+        // No microtask between stream termination and cleanup.
+        await collection.cleanup()
+        resolveList({ records: [row] })
+        if (phase === `loading`)
+          expect(await preload).toMatchObject({ name: `AbortError` })
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(errors).toEqual([])
+        expect(stream.locked).toBe(false)
+        expect(collection.status).toBe(`cleaned-up`)
+        expect(collection.size).toBe(0)
+        expect(recordApi.subscribe).toHaveBeenCalledOnce()
+        expect(recordApi.list).toHaveBeenCalledOnce()
+      } finally {
+        resolveList({ records: [] })
+        await collection.cleanup()
+        await preload
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        process.off(`unhandledRejection`, recordUnhandled)
+      }
+    },
+  )
+
+  it(`cancels an open stream when processing an event fails`, async () => {
+    const recordApi = new MockRecordApi<Data>()
+    let controller!: ReadableStreamDefaultController<Event>
+    const cancel = vi.fn()
+    const stream = new ReadableStream<Event>({
+      start(value) {
+        controller = value
+      },
+      cancel,
+    })
+    recordApi.subscribe.mockResolvedValue(stream)
+    const failure = new Error(`parse rejected row`)
+    const reported = vi.spyOn(console, `error`).mockImplementation(() => {})
+    const collection = createCollection(
+      trailBaseCollectionOptions({
+        recordApi,
+        getKey: (row: Data) => row.id!,
+        parse: {
+          id: () => {
+            throw failure
+          },
+        },
+        serialize: {},
+      }),
+    )
+    try {
+      await collection.preload()
+      controller.enqueue({ Insert: { id: 1, updated: 0, data: `invalid` } })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(reported).toHaveBeenCalledExactlyOnceWith(
+        `TrailBase subscription failed`,
+        failure,
+      )
+      expect(cancel).toHaveBeenCalledOnce()
+      expect(stream.locked).toBe(false)
+      await collection.cleanup()
+      expect(cancel).toHaveBeenCalledOnce()
+    } finally {
+      await collection.cleanup()
+      reported.mockRestore()
+    }
+  })
+
+  it.each([`close`, `buffered-close`, `error`] as const)(
     `releases a settled stream without unhandled rejection after %s`,
     async (ending) => {
       const recordApi = new MockRecordApi<Data>()
@@ -164,6 +181,14 @@ describe(`TrailBase Integration`, () => {
         await collection.preload()
         const timer = intervals.mock.results.at(-1)?.value
         expect(timer).toBeDefined()
+        const expectedRows = new Map([[1, row]])
+        if (ending === `buffered-close`) {
+          for (const id of [2, 3]) {
+            const value: Data = { id, updated: 0, data: `buffered-${id}` }
+            expectedRows.set(id, value)
+            controller.enqueue({ Insert: value })
+          }
+        }
         if (ending === `error`) controller.error(failure)
         else controller.close()
         await new Promise((resolve) => setTimeout(resolve, 0))
@@ -172,7 +197,7 @@ describe(`TrailBase Integration`, () => {
         expect(clear).toHaveBeenCalledWith(timer)
         expect(stream.locked).toBe(false)
         expect(collection.status).toBe(`ready`)
-        expect(stripState(collection.state)).toEqual(new Map([[1, row]]))
+        expect(stripState(collection.state)).toEqual(expectedRows)
         expect(recordApi.subscribe).toHaveBeenCalledOnce()
         expect(recordApi.list).toHaveBeenCalledOnce()
         if (ending === `error`) {

--- a/packages/trailbase-db-collection/tests/trailbase.test.ts
+++ b/packages/trailbase-db-collection/tests/trailbase.test.ts
@@ -138,6 +138,64 @@ async function expectWildcardFailureSettlesPreload(): Promise<void> {
 }
 
 describe(`TrailBase Integration`, () => {
+  it.each([`close`, `error`] as const)(
+    `releases a settled stream without unhandled rejection after %s`,
+    async (ending) => {
+      const recordApi = new MockRecordApi<Data>()
+      const row: Data = { id: 1, updated: 0, data: `retained` }
+      recordApi.list.mockResolvedValue({ records: [row] })
+      let controller!: ReadableStreamDefaultController<Event>
+      const stream = new ReadableStream<Event>({
+        start(value) {
+          controller = value
+        },
+      })
+      recordApi.subscribe.mockResolvedValue(stream)
+      const failure = new Error(`connection lost`)
+      const errors: Array<unknown> = []
+      const recordUnhandled = (error: unknown) => errors.push(error)
+      const reported = vi.spyOn(console, `error`).mockImplementation(() => {})
+      const intervals = vi.spyOn(globalThis, `setInterval`)
+      const clear = vi.spyOn(globalThis, `clearInterval`)
+      process.on(`unhandledRejection`, recordUnhandled)
+      const collection = createCollection(setUp(recordApi))
+
+      try {
+        await collection.preload()
+        const timer = intervals.mock.results.at(-1)?.value
+        expect(timer).toBeDefined()
+        if (ending === `error`) controller.error(failure)
+        else controller.close()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        expect(errors).toEqual([])
+        expect(clear).toHaveBeenCalledWith(timer)
+        expect(stream.locked).toBe(false)
+        expect(collection.status).toBe(`ready`)
+        expect(stripState(collection.state)).toEqual(new Map([[1, row]]))
+        expect(recordApi.subscribe).toHaveBeenCalledOnce()
+        expect(recordApi.list).toHaveBeenCalledOnce()
+        if (ending === `error`) {
+          expect(reported).toHaveBeenCalledExactlyOnceWith(
+            `TrailBase subscription failed`,
+            failure,
+          )
+        } else expect(reported).not.toHaveBeenCalled()
+
+        await collection.cleanup()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(errors).toEqual([])
+      } finally {
+        await collection.cleanup()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        process.off(`unhandledRejection`, recordUnhandled)
+        reported.mockRestore()
+        intervals.mockRestore()
+        clear.mockRestore()
+      }
+    },
+  )
+
   it(`marks initial sync ready only after its rows are applied`, async () => {
     const recordApi = new MockRecordApi<Data>()
     let resolveList!: (response: ListResponse<Data>) => void

--- a/todo.md
+++ b/todo.md
@@ -5,16 +5,16 @@ examining #1521; it does not implement that PR's polling policy.
 
 - [x] Reproduce with the actual Collection and TrailBase adapter.
 - [x] Add close/error matrix checking reported errors, unhandled rejections,
-  reader lock, cleanup timer, retained rows/status, and absence of extra loads.
+      reader lock, cleanup timer, retained rows/status, and absence of extra loads.
 - [x] RED: normal close passes; errored stream leaks an unhandled rejection and
-  keeps its reader locked. Later cleanup can reject again when canceling it.
-  /private/tmp/trailbase-stream-red.log.
+      keeps its reader locked. Later cleanup can reject again when canceling it.
+      /private/tmp/trailbase-stream-red.log.
 - [x] Fix: observe both settlements of reader.closed, clear interval, release
-  reader, and clear only the matching active-reader reference. The existing
-  listen catch remains the error reporter.
+      reader, and clear only the matching active-reader reference. The existing
+      listen catch remains the error reporter.
 - [x] GREEN: all12 package runtime tests pass; no type errors. ESLint no errors
-  and one pre-existing require-await warning. Prettier unchanged.
-  /private/tmp/trailbase-stream-green.log.
+      and one pre-existing require-await warning. Prettier unchanged.
+      /private/tmp/trailbase-stream-green.log.
 - [ ] Release note and PR after integration review. No implementation pushed.
 
 ## Why the tests missed it
@@ -118,7 +118,7 @@ lint errors (one pre-existing require-await warning). Logs:
       Log: /private/tmp/trailbase-oracle-first.log.
 - [x] Guard canceled startup before touching shared reader ownership. GREEN.
 - [x] Mutation assay: all five known stream fault variants rejected by this
-      oracle itself. Logs: /private/tmp/trailbase-oracle-assay-*.log.
+      oracle itself. Logs: /private/tmp/trailbase-oracle-assay-\*.log.
 - [x] 10× campaign: 800 generated histories plus 32 fixed cases pass, random
       seed 127535183. Log: /private/tmp/trailbase-oracle-stress.log.
 - [x] Document laws, exclusions, replay commands and mutation evidence in

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,36 @@
+# TrailBase stream termination
+
+Base: origin/main ad043b745. This is the narrow error-handling bug found while
+examining #1521; it does not implement that PR's polling policy.
+
+- [x] Reproduce with the actual Collection and TrailBase adapter.
+- [x] Add close/error matrix checking reported errors, unhandled rejections,
+  reader lock, cleanup timer, retained rows/status, and absence of extra loads.
+- [x] RED: normal close passes; errored stream leaks an unhandled rejection and
+  keeps its reader locked. Later cleanup can reject again when canceling it.
+  /private/tmp/trailbase-stream-red.log.
+- [x] Fix: observe both settlements of reader.closed, clear interval, release
+  reader, and clear only the matching active-reader reference. The existing
+  listen catch remains the error reporter.
+- [x] GREEN: all12 package runtime tests pass; no type errors. ESLint no errors
+  and one pre-existing require-await warning. Prettier unchanged.
+  /private/tmp/trailbase-stream-green.log.
+- [ ] Release note and PR after integration review. No implementation pushed.
+
+## Why the tests missed it
+
+Existing tests close streams normally or cancel them deliberately. None errors
+a live stream after startup. The listen() rejection handler did not observe the
+separate promise returned by reader.closed.finally(). Normal close and rejected
+close therefore need separate laws, including resource cleanup after failure.
+
+## Boundaries preserved
+
+Initial subscribe failure still rejects readiness. Post-start disconnection
+keeps the last ready rows. No polling/reconnect behavior, automatic refetch,
+mutation confirmation policy, or core change is added.
+
+The broader #1521 proposal claims a polling cycle which does not exist, marks
+ready even after required list failure, and skips acknowledgement waits based
+only on initial subscription availability. Do not transplant it. Stale same-ID
+ack evidence and actual degradation/recovery policy remain separate decisions.

--- a/todo.md
+++ b/todo.md
@@ -34,3 +34,102 @@ The broader #1521 proposal claims a polling cycle which does not exist, marks
 ready even after required list failure, and skips acknowledgement waits based
 only on initial subscription availability. Do not transplant it. Stale same-ID
 ack evidence and actual degradation/recovery policy remain separate decisions.
+
+## PR preparation review
+
+Fetched origin/main: still ad043b745. Simplification review found no worthwhile
+cuts. Correctness review found a regression in the initial fix: reader.closed
+can settle before listen() drains its last queued event. Releasing the lock at
+that point turns graceful buffered closure into a spurious subscription error.
+
+- [x] Add buffered-close to the close/error matrix. Enqueue two inserts before
+      closing; assert both rows applied, no error report, timer cleared, reader
+      released and later collection cleanup safe. RED: one fail, two controls pass.
+      `/private/tmp/trailbase-buffered-close-red.log`.
+- [x] Retire the reader after listen() settles, with a caught finally chain.
+      reader.closed now only clears the timer and observes both settlements.
+- [x] Full package: 13 runtime tests plus one type test pass, no type errors.
+      Built the missing Electric declaration dependency before the full type gate.
+      ESLint: no errors, one pre-existing require-await warning.
+      `/private/tmp/trailbase-prep-final-{green,lint}.log`.
+- [ ] Commit review follow-up, changeset and PR after preparation approval.
+
+The original matrix terminated an idle reader after readiness. It did not cross
+buffered delivery with close. This is why it missed the race; no new recovery
+policy or retry loop is needed to correct reader ownership.
+
+The follow-up review found that retiring the reader after listen() rejects must
+also cancel a still-open source: parsing/writing can fail without a stream read
+failure. Added an actual parse-failure test with an underlying cancel spy. RED:
+zero source cancellations. The listener's handled finally now awaits cancellation
+(preserving the original error on an already-errored stream) before releasing its
+lock. Buffered-close, normal-close and read-error controls remain GREEN.
+
+Final gate: 14 runtime tests and one type test pass; no type errors, lint errors,
+or new warnings. RED log: /private/tmp/trailbase-processing-failure-red.log.
+Final GREEN/lint logs reuse the prep-final paths above.
+
+Adjacent pre-existing limitation, not claimed solved: erroring the stream and
+calling collection.cleanup() in the same turn can still expose the unobserved
+promise from cancelEventReader(). Its cancellation path is unchanged. The
+reviewer also verified that an error during pending initial loading now retires
+the reader before a later, settled cleanup. Do not equate that with the same-turn
+cleanup case. Track the latter as a further cancellation test/fix before claiming
+full termination coverage.
+
+## Same-turn cleanup follow-up
+
+User approved including the adjacent cancellation failure. Added the four-cell
+loading/ready × close/error matrix with no microtask between stream termination
+and collection cleanup. Both error cells RED, both close controls GREEN.
+`/private/tmp/trailbase-same-turn-red.log`.
+
+cancelEventReader now observes its cancellation promise, since native errored
+streams reject cancellation with the original stream error. The reader is still
+retired synchronously. The tests observe preload immediately, resolve delayed
+loading after cleanup, and assert no unhandled rejection, no late rows, no new
+fetch/subscription, an unlocked stream and cleaned-up status.
+
+TrailBase has no dedicated fast-check/model oracle yet. Its local tests are
+example/matrix integration tests. Its service-backed E2E entry runs shared
+predicate, pagination, join, deduplication, collation, mutation, live-update and
+progressive suites; these are not a generated lifecycle model. E2E was inspected,
+not run during this preparation. A bounded future lifecycle oracle should vary
+startup/list completion, event delivery, stream termination, processing failures,
+cleanup and restart, with independent row/status/resource observations. Do not
+add polling semantics to that model without a separate policy decision.
+
+Full local gate: 18 runtime tests plus one type test pass; no type errors or
+lint errors (one pre-existing require-await warning). Logs:
+`/private/tmp/trailbase-same-turn-{green,lint}.log`. No new commit or push yet.
+
+## Lifecycle oracle (user-approved)
+
+- [x] Drive the actual adapter and collection with controlled subscribe/list
+      promises and native streams; model visible rows independently.
+- [x] Cross eager/on-demand, startup failures, delayed old-session settlements,
+      row edits, graceful/buffered close, read/parse failures, cleanup and restart.
+      Keep existing unit and loading-time matrices. Extract only the shared mock.
+- [x] Add 32 corpus cases plus fixed and fresh-seed fast-check campaigns using
+      the existing replay configuration, not a second seed parser.
+- [x] New bug RED in both generated campaigns and both modes' fixed witnesses:
+      old canceled subscribe rejects after restart and cancels the current reader.
+      Fixed seed 714203, path 21:0:2:2; random seed -951227069, path 39:0:3:2:2:2.
+      Log: /private/tmp/trailbase-oracle-first.log.
+- [x] Guard canceled startup before touching shared reader ownership. GREEN.
+- [x] Mutation assay: all five known stream fault variants rejected by this
+      oracle itself. Logs: /private/tmp/trailbase-oracle-assay-*.log.
+- [x] 10× campaign: 800 generated histories plus 32 fixed cases pass, random
+      seed 127535183. Log: /private/tmp/trailbase-oracle-stress.log.
+- [x] Document laws, exclusions, replay commands and mutation evidence in
+      packages/trailbase-db-collection/tests/ORACLE.md.
+
+The gap that exposed the new bug was ownership across sessions: testing only
+cleanup followed by old settlement leaves no replacement resource to corrupt.
+The oracle settles old work while the next stream is live, then sends new edits.
+This is a small lifecycle oracle, not complete TrailBase adapter coverage.
+No polling, reconnect, pagination or mutation-confirmation policy was added.
+
+Final local gate: 52 runtime tests plus one type test pass, no type errors.
+Lint has no errors and only the existing require-await warning. Logs:
+/private/tmp/trailbase-oracle-{green,lint}.log. Changes remain local, uncommitted.


### PR DESCRIPTION
Fix TrailBase stream cleanup so failures do not leak detached rejections or cancel a replacement sync session. Add a lifecycle oracle around the actual adapter and collection; it found the stale-startup cancellation bug during both fixed-seed and random runs.

## Why and how

The listener and `reader.closed` are separate promises. Observing one does not handle rejection from the other. Also, `closed` can settle while the listener still has buffered events to process: releasing the reader there interrupts a normal close.

- Observe stream-closure and cancellation rejections explicitly.
- Cancel and release a reader after its listener finishes, including processing failures that leave the underlying source open. Clear only that reader's active reference.
- Ignore failed startup work from a canceled session before it can touch the replacement reader.

The invariants are: buffered events drain before release; cleanup retires its resources without detached errors; and old work cannot cancel or publish into a replacement session. Existing behavior remains: required startup failures reject, while post-start stream failures retain the last rows and report the error.

## Tests and review guidance

The oracle controls RecordApi promises and native ReadableStreams, then checks visible rows against an independent Map. It crosses eager/on-demand modes, startup/list failures, late old-session completions, row edits, five stream endings, and immediate/settled cleanup. Existing unit matrices remain; their mock RecordApi is shared rather than duplicated.

- **52 runtime tests + 1 type test pass**, with no type errors. ESLint has no errors and one existing `require-await` warning.
- **800 generated histories + 32 fixed cases pass** in the 10× campaign (seeds `714203` and `127535183`).
- Five isolated fault mutations all fail the oracle: detached closure rejection, premature reader release, missing processing-failure cancellation, detached cleanup rejection, and stale-startup cancellation.
- The stale-startup bug shrank to two sessions: cancel pending subscribe → restart a healthy stream → reject old subscribe. Both modes now have fixed witnesses that also verify later row delivery.

From `packages/trailbase-db-collection`:

```sh
pnpm exec vitest run --coverage.enabled=false --maxWorkers=2
TANSTACK_DB_ORACLE_RUNS_MULTIPLIER=10 pnpm test:oracles --coverage.enabled=false --maxWorkers=2 --testTimeout=60000
```

See `tests/ORACLE.md` for laws, replay instructions and mutation evidence. Runtime changes are confined to `src/trailbase.ts`; the core change only registers the oracle's replay key. Includes a TrailBase patch changeset.

## Scope

No polling, reconnect, pagination, mutation-acknowledgement, or public API changes. This addresses stream-lifetime errors encountered while examining #1521, not that PR's broader degradation proposal; it does not close #1521. The oracle is not complete adapter coverage: generated events begin after loading, on-demand loads enter through the core subset boundary, and service-backed E2E tests were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TrailBase subscription cleanup when streams close, fail, or are canceled.
  - Prevented unhandled errors and resource leaks during subscription shutdown.
  - Ensured buffered events are processed before a subscription is fully released.
  - Prevented an earlier canceled startup from interrupting a replacement sync session.
  - Startup failures now become available promptly without waiting for transport cleanup.

- **Tests**
  - Added comprehensive lifecycle coverage for eager and on-demand synchronization, cleanup, cancellation, and stream failures.

- **Documentation**
  - Added guidance on TrailBase lifecycle behavior and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->