### PR TITLE
fix: reject ignored infinite-query page callbacks

### DIFF
--- a/.changeset/reject-ignored-page-callback.md
+++ b/.changeset/reject-ignored-page-callback.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-db': minor
+'@tanstack/vue-db': minor
+'@tanstack/svelte-db': minor
+---
+
+Remove the ignored `getNextPageParam` option from `useLiveInfiniteQuery` and reject it with a clear error when passed at runtime. Delete this callback from your config; for server pagination, use an on-demand Query Collection whose `queryFn` fulfills `meta.loadSubsetOptions`. Document fixed-server-page loading and clarify that `initialPageParam` labels result pages rather than setting a server cursor.

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -777,9 +777,11 @@ request. This example assumes a zero-based page API with a fixed size of 50.
 The endpoint must apply the supplied filters and sorts **before** pagination,
 keep a consistent ordered result while its pages are read, and return
 `nextPage: null` only when it has authoritatively exhausted that result.
-The example `api.listPosts` translates the full `where` expression (including
-cursor predicates) and `orderBy` options into the endpoint's syntax, and rejects
-unsupported expressions. See [QueryFn and Predicate Push-Down](#queryfn-and-predicate-push-down)
+This example uses offset-based pagination. `api.listPosts` translates the full
+`where` expression and `orderBy` options into the endpoint's syntax, and rejects
+unsupported expressions. The separate `cursor` hints are deliberately unused;
+cursor-based adapters must handle those hints alongside `where`, not treat them
+as already included in it. See [QueryFn and Predicate Push-Down](#queryfn-and-predicate-push-down)
 for translation helpers. Do not drop predicates or filter after paginating:
 either changes the requested window.
 

--- a/docs/collections/query-collection.md
+++ b/docs/collections/query-collection.md
@@ -750,21 +750,96 @@ const todosCollection = createCollection(
 todosCollection.insert({ text: "Buy milk", completed: false })
 ```
 
-### Example: Large Dataset Pagination
+### Server pagination with live queries
+
+`useLiveInfiniteQuery` in React, Vue, and Svelte grows a local ordered query
+window. It does not run TanStack Query's `InfiniteQueryObserver`. Query
+Collections use `QueryObserver`, so `queryFn` receives
+`meta.loadSubsetOptions`, not `pageParam`.
+
+The previously ignored `getNextPageParam` option has been removed. Delete it
+from your hook config; passing it at runtime now throws a clear error.
+`initialPageParam` labels result pages only. It does not set a remote offset
+or server cursor.
+
+For server loading, use `syncMode: 'on-demand'` and make `queryFn` fulfill the
+requested filter, order, offset, and limit. Use a deterministic total order
+(for example, a timestamp followed by a unique ID). The loader may request a
+prefix, a suffix, a tie group, or the full filtered source. A request is not
+necessarily one UI page: the hook fetches an extra row to determine
+`hasNextPage`. Returning one capped endpoint page can incorrectly make the
+query appear exhausted even when the server has more rows.
+
+#### Endpoints with fixed-size pages
+
+If your endpoint uses page numbers, drain enough server pages to fulfill each
+request. This example assumes a zero-based page API with a fixed size of 50.
+The endpoint must apply the supplied filters and sorts **before** pagination,
+keep a consistent ordered result while its pages are read, and return
+`nextPage: null` only when it has authoritatively exhausted that result.
+The example `api.listPosts` translates the full `where` expression (including
+cursor predicates) and `orderBy` options into the endpoint's syntax, and rejects
+unsupported expressions. See [QueryFn and Predicate Push-Down](#queryfn-and-predicate-push-down)
+for translation helpers. Do not drop predicates or filter after paginating:
+either changes the requested window.
 
 ```typescript
-// Load additional pages without refetching existing data
-const loadMoreTodos = async (page) => {
-  const newTodos = await api.getTodos({ page, limit: 50 })
+import { createCollection } from '@tanstack/db'
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
 
-  // Add new items without affecting existing ones
-  todosCollection.utils.writeBatch(() => {
-    newTodos.forEach((todo) => {
-      todosCollection.utils.writeInsert(todo)
-    })
-  })
-}
+type Post = { id: number; createdAt: number; title: string }
+const serverPageSize = 50
+
+const postsCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['posts'],
+    queryClient,
+    syncMode: 'on-demand',
+    getKey: (post: Post) => post.id,
+    queryFn: async (ctx): Promise<Array<Post>> => {
+      const { where, orderBy, offset = 0, limit } = ctx.meta?.loadSubsetOptions ?? {}
+      const skip = offset % serverPageSize
+      let page: number | null = Math.floor(offset / serverPageSize)
+      const gathered: Array<Post> = []
+
+      while (page !== null && (limit === undefined || gathered.length < skip + limit)) {
+        ctx.signal.throwIfAborted()
+        const response: { rows: Array<Post>; nextPage: number | null } =
+          await api.listPosts({
+            page,
+            pageSize: serverPageSize,
+            where,
+            orderBy,
+            signal: ctx.signal,
+          })
+        gathered.push(...response.rows)
+        page = response.nextPage
+      }
+
+      return gathered.slice(skip, limit === undefined ? undefined : skip + limit)
+    },
+  }),
+)
+
+// React example; the collection protocol is the same for Vue and Svelte.
+const { data, fetchNextPage, hasNextPage } = useLiveInfiniteQuery(
+  (q) => q.from({ post: postsCollection })
+    .orderBy(({ post }) => post.createdAt)
+    .orderBy(({ post }) => post.id),
+  { pageSize: 20 },
+)
 ```
+
+Reject failed requests instead of returning partial rows as success. An
+unlimited request must drain until the endpoint reports exhaustion. If the
+endpoint uses opaque cursors instead of page numbers, keep that cursor handling
+inside `queryFn` or its adapter; honoring a new offset may require starting at
+the beginning again. The hook does not maintain remote cursor history.
+
+Manually appending rows with `writeUpsert` is a separate, lower-level loading
+strategy. It does not make an eager `queryFn` incremental: a later successful
+refetch still replaces its complete state and can remove appended rows.
+`staleTime: Infinity` does not prevent explicit refetch or invalidation.
 
 ## Important Behaviors
 

--- a/docs/framework/react/overview.md
+++ b/docs/framework/react/overview.md
@@ -165,13 +165,18 @@ const { data, pages, fetchNextPage, hasNextPage } = useLiveInfiniteQuery(
     .orderBy(({ posts }) => posts.createdAt, 'desc'),
   {
     pageSize: 20,
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === 20 ? allPages.length : undefined
   }
 )
 ```
 
 `fetchNextPage()` returns a promise that resolves after the page request settles. Failures are exposed through the returned `error` value and do not reject the promise.
+
+This hook widens an ordered live query; it is not TanStack Query's
+`useInfiniteQuery`. `getNextPageParam` was previously ignored and is now rejected.
+`initialPageParam` only labels the returned pages; it does not set a server cursor
+or skip remote rows. For server pagination, use an on-demand Query Collection
+whose `queryFn` fulfills `meta.loadSubsetOptions`. See the
+[server pagination guide](../../collections/query-collection.md#server-pagination-with-live-queries).
 
 The deprecated dependency array is only available when using the query function variant, not when passing a pre-created collection.
 

--- a/notes/rfc-1657-server-pagination.md
+++ b/notes/rfc-1657-server-pagination.md
@@ -1,4 +1,4 @@
-# Server pagination investigation
+# RFC 1657 follow-up: server pagination investigation
 
 Base: `origin/main` at `ad043b745` (verified after fetch on 2026-09-10).
 Worktree: `codex-rfc-server-pagination`.

--- a/packages/query-db-collection/tests/server-pagination-boundary.test.ts
+++ b/packages/query-db-collection/tests/server-pagination-boundary.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { createServerPaginationFixture } from './server-pagination-fixture'
+
+describe(`manual server page ownership`, () => {
+  it(`an explicit refetch replaces directly appended eager rows despite infinite stale time`, async () => {
+    const fixture = createServerPaginationFixture({
+      rows: [{ id: 1, rank: 1 }],
+      syncMode: `eager`,
+    })
+    try {
+      await fixture.collection.preload()
+      fixture.collection.utils.writeUpsert({ id: 2, rank: 2 })
+      expect([...fixture.collection.keys()]).toEqual([1, 2])
+      await fixture.collection.utils.refetch()
+      expect([...fixture.collection.keys()]).toEqual([1])
+    } finally {
+      await fixture.collection.cleanup()
+      fixture.client.clear()
+    }
+  })
+})

--- a/packages/query-db-collection/tests/server-pagination-fixture.ts
+++ b/packages/query-db-collection/tests/server-pagination-fixture.ts
@@ -1,0 +1,75 @@
+import { QueryClient } from '@tanstack/query-core'
+import { BTreeIndex, createCollection } from '@tanstack/db'
+import { queryCollectionOptions } from '../src/index'
+import { evaluateReferenceExpression } from '../../db/tests/reference-expression'
+import type { LoadSubsetOptions } from '@tanstack/db'
+
+export type ServerRow = { id: number; rank: number }
+
+// An ordinary QueryObserver, not InfiniteQueryObserver. This fixture models
+// numeric rows supplied in ascending id/rank order; it is not a general sorter.
+// The endpoint either fulfills the request or returns one nonconforming cap.
+export function createServerPaginationFixture(options: {
+  syncMode: `eager` | `on-demand`
+  rows: Array<ServerRow>
+  cap?: number
+  serverPageSize?: number
+}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  const requests: Array<{
+    pageParam: unknown
+    subset: LoadSubsetOptions | undefined
+  }> = []
+  const serverPages: Array<number> = []
+  const collection = createCollection(
+    queryCollectionOptions({
+      queryClient: client,
+      queryKey: [`server-pagination-probe`],
+      syncMode: options.syncMode,
+      autoIndex: `eager`,
+      defaultIndexType: BTreeIndex,
+      getKey: (row: ServerRow) => row.id,
+      queryFn: async (context): Promise<Array<ServerRow>> => {
+        requests.push({
+          pageParam: `pageParam` in context ? context.pageParam : undefined,
+          subset: context.meta?.loadSubsetOptions,
+        })
+        const subset = context.meta?.loadSubsetOptions
+        const start = subset?.offset ?? 0
+        const limit = options.cap ?? subset?.limit ?? options.rows.length
+        const matching = options.rows.filter((row) =>
+          subset?.where
+            ? evaluateReferenceExpression(subset.where, row) === true
+            : true,
+        )
+        if (options.serverPageSize !== undefined) {
+          const pageSize = options.serverPageSize
+          const firstPage = Math.floor(start / pageSize)
+          const prefixSkip = start % pageSize
+          const gathered: Array<ServerRow> = []
+          let page: number | undefined = firstPage
+          while (page !== undefined && gathered.length < prefixSkip + limit) {
+            serverPages.push(page)
+            // Server authority stays inside the adapter. Query DB receives only
+            // the completed row array, not this endpoint-specific continuation.
+            const response: {
+              rows: Array<ServerRow>
+              nextPage: number | undefined
+            } = await Promise.resolve({
+              rows: matching.slice(page * pageSize, (page + 1) * pageSize),
+              nextPage:
+                (page + 1) * pageSize < matching.length ? page + 1 : undefined,
+            })
+            gathered.push(...response.rows)
+            page = response.nextPage
+          }
+          return gathered.slice(prefixSkip, prefixSkip + limit)
+        }
+        return matching.slice(start, start + limit)
+      },
+    }),
+  )
+  return { collection, requests, serverPages, client }
+}

--- a/packages/query-db-collection/tests/server-pagination-fixture.ts
+++ b/packages/query-db-collection/tests/server-pagination-fixture.ts
@@ -7,7 +7,7 @@ import type { LoadSubsetOptions } from '@tanstack/db'
 export type ServerRow = { id: number; rank: number }
 
 // An ordinary QueryObserver, not InfiniteQueryObserver. This fixture models
-// numeric rows supplied in ascending id/rank order; it is not a general sorter.
+// numeric rows supplied in the query's requested order; it is not a general sorter.
 // The endpoint either fulfills the request or returns one nonconforming cap.
 export function createServerPaginationFixture(options: {
   syncMode: `eager` | `on-demand`

--- a/packages/react-db/src/useLiveInfiniteQuery.ts
+++ b/packages/react-db/src/useLiveInfiniteQuery.ts
@@ -41,7 +41,8 @@ import type {
 const DEFAULT_GC_TIME_MS = 1
 const unpreparedQueryValue = Symbol(`unpreparedQueryValue`)
 
-export type UseLiveInfiniteQueryConfig<TContext extends Context> = {
+// Keep the generic parameter for existing typed config wrappers.
+export type UseLiveInfiniteQueryConfig<_TContext extends Context> = {
   /**
    * Explicit identity for queries that contain opaque functional variants or
    * are hot enough that deriving identity from structured IR is too expensive.
@@ -51,18 +52,8 @@ export type UseLiveInfiniteQueryConfig<TContext extends Context> = {
   /** Override the nearest DbProvider for this query. */
   client?: DbClient
   pageSize?: number
+  /** First result-page label, not a server cursor or remote offset. */
   initialPageParam?: number
-  /**
-   * @deprecated This callback is not used by the current implementation.
-   * Pagination is determined internally via a peek-ahead strategy.
-   * Provided for API compatibility with TanStack Query conventions.
-   */
-  getNextPageParam?: (
-    lastPage: Array<InferResultType<TContext>[number]>,
-    allPages: Array<Array<InferResultType<TContext>[number]>>,
-    lastPageParam: number,
-    allPageParams: Array<number>,
-  ) => number | undefined
 }
 
 export type UseLiveInfiniteQueryReturn<TContext extends Context> = Omit<
@@ -107,7 +98,7 @@ type InfiniteQueryRenderState = {
  * without recreating the live query collection on each page change.
  *
  * @param queryFn - Query function that defines what data to fetch. Must include `.orderBy()` for setWindow to work.
- * @param config - Configuration including pageSize and getNextPageParam
+ * @param config - Configuration including pageSize and an optional initial page label
  * @param deps - Deprecated array of dependencies that trigger query re-execution when changed
  * @returns Object with pages, data, and pagination controls
  */
@@ -135,6 +126,11 @@ export function useLiveInfiniteQuery<TContext extends Context>(
   config: UseLiveInfiniteQueryConfig<TContext>,
   deps?: Array<unknown>,
 ): UseLiveInfiniteQueryReturn<TContext> {
+  if (`getNextPageParam` in config) {
+    throw new Error(
+      `getNextPageParam is not supported by useLiveInfiniteQuery. Use an on-demand collection and fulfill meta.loadSubsetOptions in queryFn for server pagination.`,
+    )
+  }
   const pageSize = normalizeLiveQueryWindowPageSize(config.pageSize)
   const initialPageParam = config.initialPageParam ?? 0
   const contextDbClient = useOptionalDbClient()

--- a/packages/react-db/tests/server-pagination-probe.test.tsx
+++ b/packages/react-db/tests/server-pagination-probe.test.tsx
@@ -71,6 +71,50 @@ describe(`server pagination contract probes`, () => {
     },
   )
 
+  it(`retains a tie group across backend and UI page boundaries`, async () => {
+    // Already sorted by rank, then id. IDs decrease between groups so an
+    // accidental id-first order cannot produce the expected result.
+    const sourceRows = [
+      ...Array.from({ length: 6 }, (_, index) => ({ id: index + 10, rank: 1 })),
+      ...Array.from({ length: 3 }, (_, index) => ({ id: index + 1, rank: 2 })),
+    ]
+    const fixture = createServerPaginationFixture({
+      rows: sourceRows,
+      syncMode: `on-demand`,
+      serverPageSize: 2,
+    })
+    const { result, unmount } = renderHook(() =>
+      useLiveInfiniteQuery(
+        (q) =>
+          q
+            .from({ row: fixture.collection })
+            .orderBy(({ row }) => row.rank)
+            .orderBy(({ row }) => row.id),
+        { pageSize: 3 },
+      ),
+    )
+    try {
+      await waitFor(() => expect(result.current.isReady).toBe(true))
+      for (const size of [3, 6, 9]) {
+        expect(result.current.data.map((row) => row.id)).toEqual(
+          sourceRows.slice(0, size).map((row) => row.id),
+        )
+        expect(result.current.hasNextPage).toBe(size < sourceRows.length)
+        if (size < sourceRows.length)
+          await act(() => result.current.fetchNextPage())
+      }
+      expect(new Set(fixture.serverPages)).toEqual(new Set([0, 1, 2, 3, 4]))
+      const requestCount = fixture.requests.length
+      await act(() => result.current.fetchNextPage())
+      expect(fixture.requests).toHaveLength(requestCount)
+    } finally {
+      unmount()
+      await result.current.collection?.cleanup()
+      await fixture.collection.cleanup()
+      fixture.client.clear()
+    }
+  })
+
   it(`eager page responses remain local data, not an infinite-query transport`, async () => {
     const fixture = createServerPaginationFixture({
       rows,

--- a/packages/react-db/tests/server-pagination-probe.test.tsx
+++ b/packages/react-db/tests/server-pagination-probe.test.tsx
@@ -1,0 +1,178 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useLiveInfiniteQuery } from '../src/useLiveInfiniteQuery'
+import { createServerPaginationFixture } from '../../query-db-collection/tests/server-pagination-fixture'
+
+const rows = Array.from({ length: 8 }, (_, id) => ({ id, rank: id }))
+const pageCases = [1, 2, 3, 5].flatMap((serverPageSize) =>
+  [1, 2, 5].flatMap((pageSize) =>
+    [0, 1, 8].map((rowCount) => ({ serverPageSize, pageSize, rowCount })),
+  ),
+)
+
+describe(`server pagination contract probes`, () => {
+  it(`rejects a server-page callback before constructing a query`, () => {
+    const queryFn = vi.fn(() => {
+      throw new Error(`query must not be constructed`)
+    })
+    const config = { pageSize: 2, getNextPageParam: () => 1 }
+    const error = vi.spyOn(console, `error`).mockImplementation(() => {})
+    try {
+      expect(() =>
+        renderHook(() => useLiveInfiniteQuery(queryFn, config)),
+      ).toThrow(`getNextPageParam is not supported`)
+      expect(queryFn).not.toHaveBeenCalled()
+    } finally {
+      error.mockRestore()
+    }
+  })
+
+  it.each(pageCases)(
+    `drains server pages of $serverPageSize for UI pages of $pageSize over $rowCount rows`,
+    async ({ serverPageSize, pageSize, rowCount }) => {
+      const sourceRows = rows.slice(0, rowCount)
+      const fixture = createServerPaginationFixture({
+        rows: sourceRows,
+        syncMode: `on-demand`,
+        serverPageSize,
+      })
+      const { result, unmount } = renderHook(() =>
+        useLiveInfiniteQuery(
+          (q) =>
+            q.from({ row: fixture.collection }).orderBy(({ row }) => row.id),
+          { pageSize },
+        ),
+      )
+      try {
+        await waitFor(() => expect(result.current.isReady).toBe(true))
+        for (let size = pageSize; ; size += pageSize) {
+          expect(result.current.data.map((row) => row.id)).toEqual(
+            sourceRows.slice(0, size).map((row) => row.id),
+          )
+          expect(result.current.hasNextPage).toBe(size < rowCount)
+          if (size >= rowCount) break
+          await act(() => result.current.fetchNextPage())
+        }
+        if (rowCount > serverPageSize)
+          expect(fixture.serverPages.length).toBeGreaterThan(1)
+        if (rowCount > pageSize + 1) {
+          expect(
+            fixture.requests.some(
+              (request) => (request.subset?.offset ?? 0) > 0,
+            ),
+          ).toBe(true)
+        }
+      } finally {
+        unmount()
+        await result.current.collection?.cleanup()
+        await fixture.collection.cleanup()
+        fixture.client.clear()
+      }
+    },
+  )
+
+  it(`eager page responses remain local data, not an infinite-query transport`, async () => {
+    const fixture = createServerPaginationFixture({
+      rows,
+      syncMode: `eager`,
+      cap: 4,
+    })
+    const { result, unmount } = renderHook(() =>
+      useLiveInfiniteQuery(
+        (q) => q.from({ row: fixture.collection }).orderBy(({ row }) => row.id),
+        { pageSize: 2, initialPageParam: 10 },
+      ),
+    )
+    try {
+      await waitFor(() => expect(result.current.isReady).toBe(true))
+      expect(result.current.data.map((row) => row.id)).toEqual([0, 1])
+      expect(result.current.pageParams).toEqual([10])
+      await act(() => result.current.fetchNextPage())
+      expect(result.current.data.map((row) => row.id)).toEqual([0, 1, 2, 3])
+      expect(result.current.pageParams).toEqual([10, 11])
+      expect(result.current.hasNextPage).toBe(false)
+      await act(() => result.current.fetchNextPage())
+      expect(fixture.requests).toHaveLength(1)
+      expect(fixture.requests[0]?.pageParam).toBeUndefined()
+    } finally {
+      unmount()
+      await result.current.collection?.cleanup()
+      await fixture.collection.cleanup()
+      fixture.client.clear()
+    }
+  })
+
+  it(`on-demand prefixes grow through Query DB and retain earlier rows`, async () => {
+    const fixture = createServerPaginationFixture({
+      rows,
+      syncMode: `on-demand`,
+    })
+    const { result, unmount } = renderHook(() =>
+      useLiveInfiniteQuery(
+        (q) =>
+          q
+            .from({ row: fixture.collection })
+            .orderBy(({ row }) => row.id)
+            .orderBy(({ row }) => row.rank),
+        { pageSize: 2 },
+      ),
+    )
+    try {
+      await waitFor(() => expect(result.current.isReady).toBe(true))
+      for (const size of [2, 4, 6, 8]) {
+        expect(result.current.data.map((row) => row.id)).toEqual(
+          rows.slice(0, size).map((row) => row.id),
+        )
+        expect(result.current.hasNextPage).toBe(size < rows.length)
+        if (size < rows.length) await act(() => result.current.fetchNextPage())
+      }
+      expect(
+        fixture.requests.flatMap((request) =>
+          request.subset?.limit === undefined ? [] : [request.subset.limit],
+        ),
+      ).toEqual([3, 5, 7, 9])
+      expect(
+        fixture.requests.every((request) => request.pageParam === undefined),
+      ).toBe(true)
+    } finally {
+      unmount()
+      await result.current.collection?.cleanup()
+      await fixture.collection.cleanup()
+      fixture.client.clear()
+    }
+  })
+
+  // Deliberately nonconforming provider: this is a protocol boundary control,
+  // not an oracle accepting truncated responses as successful pagination.
+  it(`a capped response can underfill locally while the server still has rows`, async () => {
+    const fixture = createServerPaginationFixture({
+      rows,
+      syncMode: `on-demand`,
+      cap: 2,
+    })
+    const { result, unmount } = renderHook(() =>
+      useLiveInfiniteQuery(
+        (q) =>
+          q
+            .from({ row: fixture.collection })
+            .orderBy(({ row }) => row.id)
+            .orderBy(({ row }) => row.rank),
+        { pageSize: 2 },
+      ),
+    )
+    try {
+      await waitFor(() => expect(result.current.isReady).toBe(true))
+      expect(result.current.data.map((row) => row.id)).toEqual([0, 1])
+      expect(rows.length).toBeGreaterThan(result.current.data.length)
+      expect(result.current.hasNextPage).toBe(false)
+      const requestCount = fixture.requests.length
+      await act(() => result.current.fetchNextPage())
+      expect(fixture.requests).toHaveLength(requestCount)
+    } finally {
+      unmount()
+      await result.current.collection?.cleanup()
+      await fixture.collection.cleanup()
+      fixture.client.clear()
+    }
+  })
+})

--- a/packages/react-db/tests/useLiveInfiniteQuery.test-d.tsx
+++ b/packages/react-db/tests/useLiveInfiniteQuery.test-d.tsx
@@ -6,6 +6,12 @@ import type {
 import type { Context } from '@tanstack/db'
 
 describe(`useLiveInfiniteQuery type assertions`, () => {
+  it(`does not advertise a server-page callback`, () => {
+    expectTypeOf<
+      Extract<keyof UseLiveInfiniteQueryConfig<Context>, `getNextPageParam`>
+    >().toEqualTypeOf<never>()
+  })
+
   it(`keeps legacy generic wrappers source-compatible`, () => {
     function acceptsContext<TContext extends Context>(
       _config: UseLiveInfiniteQueryConfig<TContext>,

--- a/packages/react-db/tests/useLiveInfiniteQuery.test.tsx
+++ b/packages/react-db/tests/useLiveInfiniteQuery.test.tsx
@@ -236,8 +236,6 @@ describe(`useLiveInfiniteQuery`, () => {
               .orderBy(({ posts: p }) => p.createdAt, `desc`),
           {
             pageSize: 5,
-            getNextPageParam: (lastPage) =>
-              lastPage.length === 5 ? lastPage.length : undefined,
           },
         )
       },

--- a/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
+++ b/packages/svelte-db/src/useLiveInfiniteQuery.svelte.ts
@@ -37,21 +37,12 @@ type PreviousController = {
 
 type InfiniteQueryOptions = {
   pageSize?: number
+  /** First result-page label, not a server cursor or remote offset. */
   initialPageParam?: number
 }
 
-export type LiveInfiniteQueryConfig<TRow> = InfiniteQueryOptions & {
-  /**
-   * @deprecated Pagination uses the shared controller's peek-ahead strategy.
-   * This remains for compatibility with TanStack Query conventions.
-   */
-  getNextPageParam?: (
-    lastPage: Array<TRow>,
-    allPages: Array<Array<TRow>>,
-    lastPageParam: number,
-    allPageParams: Array<number>,
-  ) => number | undefined
-}
+// Keep the generic parameter for existing typed config wrappers.
+export type LiveInfiniteQueryConfig<_TRow> = InfiniteQueryOptions
 
 export type UseLiveInfiniteQueryConfig<TContext extends Context> =
   LiveInfiniteQueryConfig<InferResultType<TContext>[number]>
@@ -116,6 +107,11 @@ export function useLiveInfiniteQuery<TContext extends Context>(
   config: InfiniteQueryOptions,
   deps: Array<() => unknown> = [],
 ): UseLiveInfiniteQueryReturn<TContext> {
+  if (`getNextPageParam` in config) {
+    throw new Error(
+      `getNextPageParam is not supported by useLiveInfiniteQuery. Use an on-demand collection and fulfill meta.loadSubsetOptions in queryFn for server pagination.`,
+    )
+  }
   let validatedCollection: InternalCollection | null = null
   let previousController: PreviousController | null = null
   let previousInput: ReturnType<

--- a/packages/svelte-db/tests/useLiveInfiniteQuery.svelte.test.ts
+++ b/packages/svelte-db/tests/useLiveInfiniteQuery.svelte.test.ts
@@ -46,6 +46,20 @@ function usePostsCollectionInfiniteQuery(
 }
 
 describe(`useLiveInfiniteQuery`, () => {
+  it(`rejects a server-page callback before constructing a query`, () => {
+    const queryFn = vi.fn(() => {
+      throw new Error(`query must not be constructed`)
+    })
+    const config = { pageSize: 2, getNextPageParam: () => 1 }
+    const stop = $effect.root(() => {
+      expect(() => useLiveInfiniteQuery(queryFn, config)).toThrow(
+        `getNextPageParam is not supported`,
+      )
+      expect(queryFn).not.toHaveBeenCalled()
+    })
+    stop()
+  })
+
   let cleanup: (() => void) | undefined
 
   afterEach(() => {
@@ -71,7 +85,6 @@ describe(`useLiveInfiniteQuery`, () => {
     cleanup = $effect.root(() => {
       query = useLiveInfiniteQuery(() => livePosts, {
         pageSize: 3,
-        getNextPageParam: (lastPage) => lastPage[0]?.createdAt,
       })
     })
     flushSync()

--- a/packages/svelte-db/tests/useLiveInfiniteQuery.test-d.ts
+++ b/packages/svelte-db/tests/useLiveInfiniteQuery.test-d.ts
@@ -7,6 +7,12 @@ import type {
 import type { Context, InitialQueryBuilder } from '@tanstack/db'
 
 describe(`useLiveInfiniteQuery type assertions`, () => {
+  it(`does not advertise a server-page callback`, () => {
+    expectTypeOf<
+      Extract<keyof UseLiveInfiniteQueryConfig<Context>, `getNextPageParam`>
+    >().toEqualTypeOf<never>()
+  })
+
   it(`keeps legacy generic wrappers source-compatible`, () => {
     function acceptsContext<TContext extends Context>(
       _config: UseLiveInfiniteQueryConfig<TContext>,

--- a/packages/vue-db/src/useLiveInfiniteQuery.ts
+++ b/packages/vue-db/src/useLiveInfiniteQuery.ts
@@ -33,21 +33,12 @@ type PreviousController = {
 
 type InfiniteQueryOptions = {
   pageSize?: number
+  /** First result-page label, not a server cursor or remote offset. */
   initialPageParam?: number
 }
 
-export type LiveInfiniteQueryConfig<TRow> = InfiniteQueryOptions & {
-  /**
-   * @deprecated Pagination uses the shared controller's peek-ahead strategy.
-   * This remains for compatibility with TanStack Query conventions.
-   */
-  getNextPageParam?: (
-    lastPage: Array<TRow>,
-    allPages: Array<Array<TRow>>,
-    lastPageParam: number,
-    allPageParams: Array<number>,
-  ) => number | undefined
-}
+// Keep the generic parameter for existing typed config wrappers.
+export type LiveInfiniteQueryConfig<_TRow> = InfiniteQueryOptions
 
 export type UseLiveInfiniteQueryConfig<
   TContext extends Context & NonSingleResult,
@@ -127,6 +118,11 @@ export function useLiveInfiniteQuery<
   config: InfiniteQueryOptions,
   deps: Array<MaybeRefOrGetter<unknown>> = [],
 ): UseLiveInfiniteQueryReturn<TContext> {
+  if (`getNextPageParam` in config) {
+    throw new Error(
+      `getNextPageParam is not supported by useLiveInfiniteQuery. Use an on-demand collection and fulfill meta.loadSubsetOptions in queryFn for server pagination.`,
+    )
+  }
   let validatedCollection: InternalCollection | null = null
   let previousController: PreviousController | null = null
   let previousInput: ReturnType<

--- a/packages/vue-db/tests/useLiveInfiniteQuery.test-d.ts
+++ b/packages/vue-db/tests/useLiveInfiniteQuery.test-d.ts
@@ -4,6 +4,7 @@ import { createCollection, createLiveQueryCollection } from '@tanstack/db'
 import { useLiveInfiniteQuery } from '../src/useLiveInfiniteQuery'
 import { mockSyncCollectionOptions } from '../../db/tests/utils'
 import type { InitialQueryBuilder } from '@tanstack/db'
+import type { LiveInfiniteQueryConfig } from '../src/useLiveInfiniteQuery'
 
 type Post = {
   id: string
@@ -11,6 +12,12 @@ type Post = {
 }
 
 describe(`useLiveInfiniteQuery type assertions`, () => {
+  it(`does not advertise a server-page callback`, () => {
+    expectTypeOf<
+      Extract<keyof LiveInfiniteQueryConfig<Post>, `getNextPageParam`>
+    >().toEqualTypeOf<never>()
+  })
+
   it(`preserves query and pre-created collection result types`, () => {
     const posts = createCollection(
       mockSyncCollectionOptions<Post>({
@@ -34,7 +41,6 @@ describe(`useLiveInfiniteQuery type assertions`, () => {
     )
     const collectionResult = useLiveInfiniteQuery(shallowRef(livePosts), {
       pageSize: 5,
-      getNextPageParam: (lastPage) => lastPage[0]?.createdAt,
     })
 
     expectTypeOf(collectionResult.data.value[0]!.id).toEqualTypeOf<string>()

--- a/packages/vue-db/tests/useLiveInfiniteQuery.test.ts
+++ b/packages/vue-db/tests/useLiveInfiniteQuery.test.ts
@@ -36,6 +36,22 @@ async function flushVue(): Promise<void> {
 }
 
 describe(`useLiveInfiniteQuery`, () => {
+  it(`rejects a server-page callback before constructing a query`, () => {
+    const queryFn = vi.fn(() => {
+      throw new Error(`query must not be constructed`)
+    })
+    const config = { pageSize: 2, getNextPageParam: () => 1 }
+    const scope = effectScope()
+    try {
+      expect(() =>
+        scope.run(() => useLiveInfiniteQuery(queryFn, config)),
+      ).toThrow(`getNextPageParam is not supported`)
+      expect(queryFn).not.toHaveBeenCalled()
+    } finally {
+      scope.stop()
+    }
+  })
+
   let cleanup: (() => void) | undefined
 
   afterEach(() => {
@@ -61,7 +77,6 @@ describe(`useLiveInfiniteQuery`, () => {
     const query = scope.run(() =>
       useLiveInfiniteQuery(collection, {
         pageSize: 3,
-        getNextPageParam: (lastPage) => lastPage[0]?.createdAt,
       }),
     )
     cleanup = () => scope.stop()

--- a/todo.md
+++ b/todo.md
@@ -11,25 +11,25 @@ the existing on-demand server-pagination protocol. This is an API migration,
 not a new InfiniteQueryObserver bridge or remote cursor registry.
 
 - [x] Remove the callback from React, Vue, and Svelte config types. Keep generic
-  config wrappers source-compatible; unrelated return types stay unchanged.
+      config wrappers source-compatible; unrelated return types stay unchanged.
 - [x] RED first: all three hook guards failed against baseline with the query
-  callback reached before rejection. Logs: `/private/tmp/968-{react,vue,svelte}-red.log`.
+      callback reached before rejection. Logs: `/private/tmp/968-{react,vue,svelte}-red.log`.
 - [x] GREEN: reject the removed option before hook resources/query construction.
-  Type tests also assert the callback is not advertised.
+      Type tests also assert the callback is not advertised.
 - [x] Preserve existing successful hook tests without the ignored callback.
 - [x] Expand the actual Query DB/React boundary to 36 cells: server page sizes
-  1/2/3/5 × UI sizes 1/2/5 × row counts 0/1/8. Each checkpoint compares full
-  visible IDs and hasNextPage to an independent array slice.
+      1/2/3/5 × UI sizes 1/2/5 × row counts 0/1/8. Each checkpoint compares full
+      visible IDs and hasNextPage to an independent array slice.
 - [x] Keep eager transport, prefix retention, invalid capped-provider, page-label,
-  and explicit-refetch ownership controls. The capped provider violates the
-  request protocol; its characterization is not a successful pagination oracle.
+      and explicit-refetch ownership controls. The capped provider violates the
+      request protocol; its characterization is not a successful pagination oracle.
 - [x] Replace the misleading manual-append pagination example with an on-demand
-  fixed-server-page drain example; explain ordering/filter translation,
-  cancellation, exhaustion, unlimited loads, and opaque-cursor boundaries.
+      fixed-server-page drain example; explain ordering/filter translation,
+      cancellation, exhaustion, unlimited loads, and opaque-cursor boundaries.
 - [x] Fix the React overview to stop recommending the ignored callback.
 - [x] Full React: 220 checks (runtime and type cases), Vue: 96, Svelte: 101.
-  Query DB full suite: 195 runtime cases plus its type pass. All GREEN.
-  Electric declarations built to satisfy existing cross-package Query DB types.
+      Query DB full suite: 195 runtime cases plus its type pass. All GREEN.
+      Electric declarations built to satisfy existing cross-package Query DB types.
 - [x] Focused lint: no errors or warnings. No core/adapter runtime edits.
 - [x] Prepare minor framework changesets and focused PR publication.
 

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,165 @@
+# Server pagination investigation
+
+Base: `origin/main` at `ad043b745` (verified after fetch on 2026-09-10).
+Worktree: `codex-rfc-server-pagination`.
+
+## Accepted implementation
+
+The user approved option A: remove the silently ignored `getNextPageParam`
+option, reject it before query construction for untyped callers, and explain
+the existing on-demand server-pagination protocol. This is an API migration,
+not a new InfiniteQueryObserver bridge or remote cursor registry.
+
+- [x] Remove the callback from React, Vue, and Svelte config types. Keep generic
+  config wrappers source-compatible; unrelated return types stay unchanged.
+- [x] RED first: all three hook guards failed against baseline with the query
+  callback reached before rejection. Logs: `/private/tmp/968-{react,vue,svelte}-red.log`.
+- [x] GREEN: reject the removed option before hook resources/query construction.
+  Type tests also assert the callback is not advertised.
+- [x] Preserve existing successful hook tests without the ignored callback.
+- [x] Expand the actual Query DB/React boundary to 36 cells: server page sizes
+  1/2/3/5 × UI sizes 1/2/5 × row counts 0/1/8. Each checkpoint compares full
+  visible IDs and hasNextPage to an independent array slice.
+- [x] Keep eager transport, prefix retention, invalid capped-provider, page-label,
+  and explicit-refetch ownership controls. The capped provider violates the
+  request protocol; its characterization is not a successful pagination oracle.
+- [x] Replace the misleading manual-append pagination example with an on-demand
+  fixed-server-page drain example; explain ordering/filter translation,
+  cancellation, exhaustion, unlimited loads, and opaque-cursor boundaries.
+- [x] Fix the React overview to stop recommending the ignored callback.
+- [x] Full React: 220 checks (runtime and type cases), Vue: 96, Svelte: 101.
+  Query DB full suite: 195 runtime cases plus its type pass. All GREEN.
+  Electric declarations built to satisfy existing cross-package Query DB types.
+- [x] Focused lint: no errors or warnings. No core/adapter runtime edits.
+- [x] Prepare minor framework changesets and focused PR publication.
+
+Verification logs: `/private/tmp/968-react-full.log`,
+`/private/tmp/968-vue-green.log`, `/private/tmp/968-svelte-green.log`,
+`/private/tmp/968-query-full.log`, `/private/tmp/968-lint.log`.
+
+Test gap: previous framework tests materialized all rows or supplied the callback
+without asserting invocation. The new tests cross the real QueryObserver and
+collection/window boundary. They model numeric ascending ID/rank queries only,
+not arbitrary endpoint ordering, cursor protocols, retries, or changing datasets.
+
+## Original investigation (historical evidence)
+
+## Work queue
+
+- [x] Read AGENTS and live ARCHITECTURE in full.
+- [x] Read report #968 and the current disposition of RFC #1657.
+- [x] Read proposed documentation in #1355 without merging it.
+- [x] Reproduce eager Query DB + real React useLiveInfiniteQuery behavior.
+- [x] Verify the documented on-demand prefix path through the real adapter.
+- [x] Cross fixed server page sizes against live-query page growth.
+- [x] Identify API decisions and minimal alternatives below.
+- [x] Run focused runtime gates and finalize findings (type limits below).
+- [x] Parent/user selects API migration vs additional server-page feature.
+
+## Evidence
+
+Seven React integration probes pass on main. They use a real QueryClient,
+QueryObserver, Query Collection, live-query compiler/window controller, and
+useLiveInfiniteQuery. A separate test fixture evaluates small numeric predicates
+with an independent test evaluator, not production expression evaluation.
+
+1. Report shape: eager source initially returns four of eight available rows.
+   A page size of two reveals two then four rows. Further fetches do nothing;
+   `hasNextPage` is false, QueryFn ran once, `pageParam` is undefined, and the
+   supplied `getNextPageParam` callback was never invoked.
+2. On-demand provider fulfilling prefix demand: pages grow 2, 4, 6, 8 correctly;
+   finite requests have limits 3, 5, 7, 9. Tie requests can also occur. Prior rows
+   remain visible across these distinct Query cache entries.
+3. A capped provider returning two rows for a limit-three request underfills
+   the local window and yields false `hasNextPage` despite eight remote rows.
+   This is a deliberately nonconforming adapter, not proof that core can know
+   unknown server extent. Main's exact request contract requires fulfilling
+   the request (or exhausting that source) before successful settlement.
+4. Adapter-local page draining with explicit endpoint `nextPage` works through
+   the same actual hook for server page sizes 1, 2, 3, 5. The hook pages remain
+   size two; its first request peeks a third row. Later requests use offsets,
+   and page-number conversion/draining stays in QueryFn. Core needs no new state.
+
+Why previous tests missed the report: the React hook tests use fully materialized
+mock collections. They exercise local peek-ahead, not QueryObserver's transport
+context or an endpoint whose page size differs from the requested live window.
+The existing test that passes `getNextPageParam` never asserts it runs.
+
+## Minimal coherent options
+
+### A. Clarify existing API and reject or warn on the no-op callback
+
+Recommended scope. Query DB uses QueryObserver, not InfiniteQueryObserver. Its
+queryFn receives `meta.loadSubsetOptions`, not a server pageParam. The live hook
+widens a local ordered query. `initialPageParam` labels result pageParams; it is
+not a server cursor or an initial remote offset.
+
+Document on-demand limit/offset/filter/order translation and show a fixed-page
+endpoint adapter that drains to fulfill the requested window, stopping only on
+authoritative endpoint exhaustion. Keep arbitrary opaque cursor caching and
+resume state inside that adapter. It may need to refetch earlier pages to honor
+random offsets or independent queries; that is the honest cost of that endpoint.
+
+Decision needed: remove `getNextPageParam` (pre-1.0 API cleanup plus clear runtime
+error for untyped callers) or retain it with a once-per-hook warning. A silent
+compatibility option promises more compatibility than exists. It is currently
+defined by React, Vue, and Svelte hooks; its comment and generated docs call it a no-op.
+No decision is applied in this spike.
+
+Runtime state cost: zero for docs/adapter sample, one warning guard if warning
+chosen. A runtime rejection needs no retained state. Test-only cross-package
+fixture avoids adding Query dependencies to the React runtime.
+
+### B. New hook/server-page bridge
+
+Not a bug fix to the existing QueryObserver contract. Requires defining which
+collection owns cursor history, how independent filters/windows share pages,
+restart/invalidation semantics, and how UI hasNextPage maps to remote extent.
+An arbitrary query may join/filter/group remote rows; a source's next page is
+not necessarily another public result page. This must not be smuggled in as a
+boolean or restored coverage registry. No runtime implementation proposed.
+
+## Review of #1355's docs proposal
+
+Useful: on-demand is the recommended alternative; direct writes need an explicit
+ownership/refetch policy; function Query keys must distinguish relevant demand.
+
+Do not copy unchanged:
+
+- `staleTime: Infinity` prevents staleness-driven refetch, not explicit refetch,
+  invalidation, or configured polling. Those can still replace appended rows.
+- `enabled: false` suppresses initial automatic acquisition too, not merely
+  later refresh. It needs a separately managed loading path.
+- Examples omit orderBy and imply one exact Query cache entry per UI page.
+  Real loading can issue prefixes, suffixes, and tie requests; include an
+  explicit total order and describe requests rather than promising UI-page keys.
+- The adapter must honor filters/order and drain server caps, not simply forward
+  limit/offset if the endpoint can silently truncate them.
+- Appending with writeInsert fails on duplicate row IDs; writeUpsert can express
+  incremental page merging, but a later full-state snapshot still owns removal.
+
+## Boundaries retained
+
+No coverage algebra, outcome registry, new public extent facts, or inferential
+claim that a short arbitrary response establishes source exhaustion. The
+fixture's nextPage is endpoint-authoritative test data used only inside QueryFn.
+The intentionally broken capped-provider probe characterizes missing information;
+it must not become a green oracle accepting this provider as correct.
+
+## Verification handoff
+
+From packages/react-db:
+`pnpm exec vitest run tests/server-pagination-probe.test.tsx --coverage.enabled=false --maxWorkers=2`
+passes all seven probes, no React type errors.
+
+From packages/query-db-collection:
+`pnpm exec vitest run tests/server-pagination-boundary.test.ts --coverage.enabled=false --typecheck.enabled=false --maxWorkers=2`
+checks that explicit refetch removes a manually appended eager row despite
+staleTime Infinity. Runtime passes. The package-wide type pass is blocked by
+unbuilt Electric declarations imported by existing cross-package E2E suites.
+A fixture inference error found by that pass was corrected with an explicit
+page-response type; no production code changed.
+
+Local builds of db-ivm and db completed. No runtime fix, public API migration,
+changeset, commit or PR was made. All probe files and this document are untracked
+for parent review; do not stage parent-owned rfc-next-work-plan.md.

--- a/todo.md
+++ b/todo.md
@@ -27,9 +27,12 @@ not a new InfiniteQueryObserver bridge or remote cursor registry.
       fixed-server-page drain example; explain ordering/filter translation,
       cancellation, exhaustion, unlimited loads, and opaque-cursor boundaries.
 - [x] Fix the React overview to stop recommending the ignored callback.
-- [x] Full React: 220 checks (runtime and type cases), Vue: 96, Svelte: 101.
-      Query DB full suite: 195 runtime cases plus its type pass. All GREEN.
-      Electric declarations built to satisfy existing cross-package Query DB types.
+- [x] Package Vitest gates (with each package's configured type checking):
+      React reports 220 passing checks; Vue 96; Svelte 101. Query DB's final
+      log reports 370 passes / 371 discovered checks, no failures or type errors.
+      These are Vitest runtime/type reports, not standalone `tsc` claims.
+      Electric declarations were built before the final Query DB gate, clearing
+      the earlier dependency blocker recorded in the historical handoff below.
 - [x] Focused lint: no errors or warnings. No core/adapter runtime edits.
 - [x] Prepare minor framework changesets and focused PR publication.
 
@@ -146,20 +149,24 @@ fixture's nextPage is endpoint-authoritative test data used only inside QueryFn.
 The intentionally broken capped-provider probe characterizes missing information;
 it must not become a green oracle accepting this provider as correct.
 
-## Verification handoff
+## Historical probe handoff — before the accepted migration (2026-09-10)
+
+The following records the initial investigation only. It was superseded by the
+accepted implementation and package gates above; it is not the PR's final state.
 
 From packages/react-db:
 `pnpm exec vitest run tests/server-pagination-probe.test.tsx --coverage.enabled=false --maxWorkers=2`
-passes all seven probes, no React type errors.
+passed all seven probes with no errors from Vitest's configured React type check.
 
 From packages/query-db-collection:
 `pnpm exec vitest run tests/server-pagination-boundary.test.ts --coverage.enabled=false --typecheck.enabled=false --maxWorkers=2`
-checks that explicit refetch removes a manually appended eager row despite
-staleTime Infinity. Runtime passes. The package-wide type pass is blocked by
+checked that explicit refetch removes a manually appended eager row despite
+staleTime Infinity. Runtime passed. At this early stage the Query DB type pass was blocked by
 unbuilt Electric declarations imported by existing cross-package E2E suites.
 A fixture inference error found by that pass was corrected with an explicit
 page-response type; no production code changed.
 
-Local builds of db-ivm and db completed. No runtime fix, public API migration,
-changeset, commit or PR was made. All probe files and this document are untracked
-for parent review; do not stage parent-owned rfc-next-work-plan.md.
+At that early handoff only db-ivm/db builds and local probes were complete.
+The accepted migration subsequently shipped in PR #1806 with tests, docs and
+minor framework changesets; these files and this document are now committed.
+The separate parent-owned rfc-next-work-plan.md remains untracked.


### PR DESCRIPTION
## Summary

Remove the silently ignored `getNextPageParam` option from React, Vue, and Svelte's `useLiveInfiniteQuery`. Untyped callers now get a clear error before query construction. Document how an on-demand Query Collection loads server pages through `meta.loadSubsetOptions`.

Addresses #968 and the server-pagination documentation gap in #1657. This is a migration to the existing loading protocol, not a new server-pagination engine.

## Why and approach

The live hook expands an ordered Collection window. Query DB uses `QueryObserver`, not `InfiniteQueryObserver`: it never supplies a transport `pageParam` or invokes `getNextPageParam`. An eager source therefore stopped when its cached rows ran out, despite a config that looked like TanStack Query's infinite-query API.

- Remove the callback from the public types and reject its presence at runtime in all three hooks. Keep generic config wrappers and existing window behavior intact.
- Replace the manual-append pagination example with an on-demand, fixed-server-page drain example. Explain full predicate/order translation, offsets, peek-ahead, unlimited requests, and authoritative endpoint exhaustion.
- Clarify that `initialPageParam` labels result pages; it neither sets a server cursor nor skips remote rows. Explain why explicit refetch can remove manually appended eager rows even with infinite stale time.

**Migration:** delete `getNextPageParam`. For remote loading, use an on-demand collection and make `queryFn` fulfill the exact requested subset. A capped endpoint response is not a fulfilled request merely because its promise resolved.

**Scope/trade-off:** minor bumps for the three pre-1.0 framework packages. No core or Query DB runtime changes, new cursor registry, coverage algebra, or `InfiniteQueryObserver` bridge. Opaque cursor handling remains adapter-local and may require fetching earlier pages again. Retaining a warning-only no-op option was rejected because it continues to suggest unsupported behavior.

## Verification

The callback rejection test was RED before the guard in each framework: query construction ran instead of the migration error. Each now passes, and type tests prove the option is no longer advertised.

The new Query DB/React matrix crosses 4 server page sizes × 3 UI page sizes × 3 row counts (including empty results). It uses the real QueryClient, QueryObserver, collection, compiler/window controller, and React hook. Every page compares full visible IDs and `hasNextPage` against an independent array slice. Additional controls cover eager transport, prefix retention, page labels, invalid capped responses, and explicit-refetch ownership.

The previous tests used fully materialized collections or supplied the callback without asserting its invocation. The new suite crosses that missing transport/framework boundary. It models static numeric ascending ID/rank queries, not every endpoint's ordering or concurrent-write protocol. The deliberately capped-provider control documents a protocol violation; it does not bless truncated responses as successful pagination.

Full runtime suites and their type gates pass:

- React: 201 runtime tests, 19 type cases.
- Vue: 89 runtime tests, 7 type cases.
- Svelte: 97 runtime tests, 4 type cases.
- Query DB: 195 runtime tests and package type checking.
- Focused ESLint and `git diff --check` pass.

```sh
pnpm --filter @tanstack/electric-db-collection build # declarations for Query DB's existing E2E types
pnpm --filter @tanstack/react-db exec vitest run --coverage.enabled=false --maxWorkers=2
pnpm --filter @tanstack/vue-db exec vitest run --coverage.enabled=false --maxWorkers=2
pnpm --filter @tanstack/svelte-db exec vitest run --coverage.enabled=false --maxWorkers=2
pnpm --filter @tanstack/query-db-collection exec vitest run --coverage.enabled=false --maxWorkers=2
```

Review the three hook entry guards/types first, then the server-pagination fixture and React matrix. The Query Collection guide and React overview carry migration guidance; `todo.md` preserves the investigation and design decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `useLiveInfiniteQuery` now clearly rejects the unsupported `getNextPageParam` option across React, Vue, and Svelte instead of silently ignoring it.
  - Server-pagination behavior now correctly handles on-demand loading, fixed-size server pages, cursors, ordering, and capped responses.

- **Documentation**
  - Updated pagination guidance, including the role of `initialPageParam` and requirements for on-demand query collections.
  - Added guidance for endpoints that return fixed-size pages.

- **Tests**
  - Added coverage for pagination boundaries, rejected options, server-page draining, ordering, and refetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->