### PR TITLE
fix(db-ivm): treat 0 and empty string as valid min/max extremes

### DIFF
--- a/.changeset/minmax-falsy-extremes.md
+++ b/.changeset/minmax-falsy-extremes.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/db-ivm': patch
+---
+
+Compare min and max aggregates against `undefined` instead of truthiness so `0`, `0n`, and `""` can be the extreme of a group.

--- a/packages/db-ivm/src/operators/groupBy.ts
+++ b/packages/db-ivm/src/operators/groupBy.ts
@@ -237,7 +237,7 @@ export function min<T, V extends CanMinMax>(
     reduce: (values) => {
       let minValue: V | undefined
       for (const [value, _multiplicity] of values) {
-        if (!minValue || (value && value < minValue)) {
+        if (minValue === undefined || value < minValue) {
           minValue = value
         }
       }
@@ -267,7 +267,7 @@ export function max<T, V extends CanMinMax>(
     reduce: (values) => {
       let maxValue: V | undefined
       for (const [value, _multiplicity] of values) {
-        if (!maxValue || (value && value > maxValue)) {
+        if (maxValue === undefined || value > maxValue) {
           maxValue = value
         }
       }

--- a/packages/db-ivm/tests/operators/groupBy.test.ts
+++ b/packages/db-ivm/tests/operators/groupBy.test.ts
@@ -624,6 +624,108 @@ describe(`Operators`, () => {
       expect(latestMessage.getInner()).toEqual(expectedResult)
     })
 
+    test(`min and max reduce keep 0, 0n, and empty string as extremes`, () => {
+      const minNum = min<number>()
+      const maxNum = max<number>()
+      const minStr = min<string>()
+      const minBig = min<bigint>()
+      const maxBig = max<bigint>()
+
+      expect(
+        minNum.reduce([
+          [5, 1],
+          [0, 1],
+        ]),
+      ).toBe(0)
+      expect(
+        minNum.reduce([
+          [0, 1],
+          [3, 1],
+        ]),
+      ).toBe(0)
+      expect(
+        maxNum.reduce([
+          [-2, 1],
+          [0, 1],
+          [-1, 1],
+        ]),
+      ).toBe(0)
+      expect(
+        maxNum.reduce([
+          [0, 1],
+          [-1, 1],
+        ]),
+      ).toBe(0)
+      expect(
+        minStr.reduce([
+          [`b`, 1],
+          [``, 1],
+        ]),
+      ).toBe(``)
+      expect(
+        minStr.reduce([
+          [``, 1],
+          [`a`, 1],
+        ]),
+      ).toBe(``)
+      expect(
+        minBig.reduce([
+          [5n, 1],
+          [0n, 1],
+        ]),
+      ).toBe(0n)
+      expect(
+        maxBig.reduce([
+          [-2n, 1],
+          [0n, 1],
+        ]),
+      ).toBe(0n)
+    })
+
+    test(`with min and max aggregates including a zero amount`, () => {
+      const graph = new D2()
+      const input = graph.newInput<{
+        category: string
+        amount: number
+      }>()
+      let latestMessage: any = null
+
+      input.pipe(
+        groupBy((data) => ({ category: data.category }), {
+          minimum: min((data) => data.amount),
+          maximum: max((data) => data.amount),
+        }),
+        output((message) => {
+          latestMessage = message
+        }),
+      )
+
+      graph.finalize()
+
+      input.sendData(
+        new MultiSet([
+          [{ category: `A`, amount: 10 }, 1],
+          [{ category: `A`, amount: 0 }, 1],
+          [{ category: `A`, amount: 7 }, 1],
+        ]),
+      )
+      graph.run()
+
+      expect(latestMessage.getInner()).toEqual([
+        [
+          [
+            serializeValue({ category: `A` }),
+            {
+              category: `A`,
+              minimum: 0,
+              maximum: 10,
+            },
+          ],
+          1,
+        ],
+      ])
+    })
+
     test(`with median and mode aggregates`, () => {
       const graph = new D2()
       const input = graph.newInput<{


### PR DESCRIPTION
## 🎯 Changes

`min()` and `max()` in `@tanstack/db-ivm` treated a missing accumulator as any falsy value. A group whose true extreme is `0`, `0n`, or `""` therefore returned the wrong aggregate.

The reducers now compare against `undefined` only.

Fixes #1775

## ✅ Checklist

- [x] I have tested this code locally with `pnpm test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `min` and `max` grouping results so valid falsy values—including `0`, `0n`, and empty strings—are correctly considered.
  - Grouped calculations now return accurate minimum and maximum values when data includes zero or other falsy values.

- **Tests**
  - Added coverage for falsy extremes and grouped results containing zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->